### PR TITLE
Refactor: Implement fixes for issues #258, #254, #251, #256

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,13 +157,20 @@ fn validate_import_timestamps(
     Ok(())
 }
 
-fn validate_fee_config(fee: i128, fee_token: &Option<Address>) -> Result<(), Error> {
+fn validate_fee_config(env: &Env, fee: i128, fee_token: &Option<Address>) -> Result<(), Error> {
     if fee < 0 {
         return Err(Error::InvalidFee);
     }
 
     if fee > 0 && fee_token.is_none() {
         return Err(Error::FeeTokenRequired);
+    }
+
+    // Validate that fee_token is a real token contract by attempting a balance call
+    if let Some(token_addr) = fee_token {
+        let token = TokenClient::new(&env, token_addr);
+        // Dry-run balance call to verify it's a token contract
+        let _ = token.balance(&env.current_contract_address());
     }
 
     Ok(())
@@ -475,7 +482,7 @@ impl TrustLinkContract {
     ) -> Result<(), Error> {
         admin.require_auth();
         Validation::require_admin(&env, &admin)?;
-        validate_fee_config(fee, &fee_token)?;
+        validate_fee_config(&env, fee, &fee_token)?;
 
         Storage::set_fee_config(
             &env,
@@ -1215,7 +1222,7 @@ impl TrustLinkContract {
     ) -> Vec<String> {
         crate::storage::paginate(
             &env,
-            Storage::get_subject_attestations(&env, &subject),
+            &Storage::get_subject_attestations(&env, &subject),
             start,
             limit,
         )
@@ -1310,7 +1317,7 @@ impl TrustLinkContract {
     ) -> Vec<String> {
         crate::storage::paginate(
             &env,
-            Storage::get_issuer_attestations(&env, &issuer),
+            &Storage::get_issuer_attestations(&env, &issuer),
             start,
             limit,
         )
@@ -1427,7 +1434,7 @@ impl TrustLinkContract {
     }
 
     pub fn list_claim_types(env: Env, start: u32, limit: u32) -> Vec<String> {
-        crate::storage::paginate(&env, Storage::get_claim_type_list(&env), start, limit)
+        crate::storage::paginate(&env, &Storage::get_claim_type_list(&env), start, limit)
     }
 
     /// Create a multi-sig attestation proposal.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -462,10 +462,7 @@ impl Storage {
         env.storage()
             .instance()
             .get(&StorageKey::Limits)
-            .unwrap_or(StorageLimits {
-                max_attestations_per_issuer: 10_000,
-                max_attestations_per_subject: 100,
-            })
+            .unwrap_or_default()
     }
 
     /// Persist updated global stats to instance storage and refresh TTL.
@@ -666,7 +663,7 @@ impl Storage {
 
 /// Return a paginated window of `values` starting at index `start` for up to
 /// `limit` items. Returns an empty vec if `start >= values.len()`.
-pub(crate) fn paginate(env: &Env, values: Vec<String>, start: u32, limit: u32) -> Vec<String> {
+pub(crate) fn paginate<T: Clone>(env: &Env, values: &Vec<T>, start: u32, limit: u32) -> Vec<T> {
     let total = values.len();
     if start >= total {
         return Vec::new(env);
@@ -675,7 +672,7 @@ pub(crate) fn paginate(env: &Env, values: Vec<String>, start: u32, limit: u32) -
     let mut result = Vec::new(env);
     for index in start..end {
         if let Some(value) = values.get(index) {
-            result.push_back(value);
+            result.push_back(value.clone());
         }
     }
     result
@@ -698,7 +695,7 @@ mod tests {
     fn paginate_normal_slice() {
         let env = Env::default();
         let input = make_vec(&env, &["a", "b", "c", "d", "e"]);
-        let result = paginate(&env, input, 1, 3);
+        let result = paginate(&env, &input, 1, 3);
         assert_eq!(result.len(), 3);
         assert_eq!(result.get(0).unwrap(), String::from_str(&env, "b"));
         assert_eq!(result.get(1).unwrap(), String::from_str(&env, "c"));
@@ -709,7 +706,7 @@ mod tests {
     fn paginate_empty_input() {
         let env = Env::default();
         let input: Vec<String> = Vec::new(&env);
-        let result = paginate(&env, input, 0, 5);
+        let result = paginate(&env, &input, 0, 5);
         assert_eq!(result.len(), 0);
     }
 
@@ -717,7 +714,7 @@ mod tests {
     fn paginate_start_beyond_length() {
         let env = Env::default();
         let input = make_vec(&env, &["a", "b"]);
-        let result = paginate(&env, input, 10, 5);
+        let result = paginate(&env, &input, 10, 5);
         assert_eq!(result.len(), 0);
     }
 
@@ -725,7 +722,7 @@ mod tests {
     fn paginate_limit_overflow() {
         let env = Env::default();
         let input = make_vec(&env, &["a", "b", "c"]);
-        let result = paginate(&env, input, 1, 100);
+        let result = paginate(&env, &input, 1, 100);
         assert_eq!(result.len(), 2);
         assert_eq!(result.get(0).unwrap(), String::from_str(&env, "b"));
         assert_eq!(result.get(1).unwrap(), String::from_str(&env, "c"));
@@ -735,7 +732,7 @@ mod tests {
     fn paginate_start_zero_full_limit() {
         let env = Env::default();
         let input = make_vec(&env, &["x", "y", "z"]);
-        let result = paginate(&env, input, 0, 3);
+        let result = paginate(&env, &input, 0, 3);
         assert_eq!(result.len(), 3);
     }
 
@@ -743,7 +740,7 @@ mod tests {
     fn paginate_start_equals_length() {
         let env = Env::default();
         let input = make_vec(&env, &["a", "b", "c"]);
-        let result = paginate(&env, input, 3, 5);
+        let result = paginate(&env, &input, 3, 5);
         assert_eq!(result.len(), 0);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -218,6 +218,15 @@ pub struct StorageLimits {
     pub max_attestations_per_subject: u32,
 }
 
+impl Default for StorageLimits {
+    fn default() -> Self {
+        Self {
+            max_attestations_per_issuer: 10_000,
+            max_attestations_per_subject: 100,
+        }
+    }
+}
+
 /// Delegation from an issuer to a sub-issuer for specific claim types.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION

- Issue Closes #256: Moved StorageLimits default values from hardcoded in storage.rs to a Default implementation in types.rs. This co-locates the defaults with the type definition as requested.

- Issue Closes #254: Consolidated duplicate pagination logic by making the paginate function generic. Changed fn paginate<T: Clone>(env: &Env, values: &Vec<T>, start: u32, limit: u32) -> Vec<T> to accept any Vec<T> where T: Clone. Updated get_subject_attestations, get_issuer_attestations, and list_claim_types to use the generic helper, ensuring identical behavior.

- Issue Closes #251: Added validation in set_fee to verify fee_token is a real token contract. Modified validate_fee_config to perform a dry-run balance call on the provided fee_token address using the contract's own address. This prevents create_attestation from panicking at runtime if an invalid token address is set.

- Issue Closes #258: No changes were needed as audit of lib.rs and storage.rs revealed no panic! calls using raw string error messages. All error handling already uses typed Error variants.

