### PR TITLE
feat(query): add get_attestation_by_type() returning Option<Attestation>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1376,7 +1376,7 @@ impl TrustLinkContract {
         env: Env,
         subject: Address,
         claim_type: String,
-    ) -> Result<Attestation, Error> {
+    ) -> Option<Attestation> {
         let attestation_ids = Storage::get_subject_attestations(&env, &subject);
         let current_time = env.ledger().timestamp();
         let mut index = attestation_ids.len();
@@ -1384,17 +1384,18 @@ impl TrustLinkContract {
         while index > 0 {
             index -= 1;
             if let Some(attestation_id) = attestation_ids.get(index) {
-                let attestation = Storage::get_attestation(&env, &attestation_id)?;
-                if !attestation.deleted
-                    && attestation.claim_type == claim_type
-                    && attestation.get_status(current_time) == AttestationStatus::Valid
-                {
-                    return Ok(attestation);
+                if let Ok(attestation) = Storage::get_attestation(&env, &attestation_id) {
+                    if !attestation.deleted
+                        && attestation.claim_type == claim_type
+                        && attestation.get_status(current_time) == AttestationStatus::Valid
+                    {
+                        return Some(attestation);
+                    }
                 }
             }
         }
 
-        Err(Error::NotFound)
+        None
     }
 
     pub fn is_issuer(env: Env, address: Address) -> bool {


### PR DESCRIPTION
## Summary

Fixes #296

Implements `get_attestation_by_type(env, subject, claim_type) -> Option<Attestation>` so callers can find the most recent valid attestation for a subject+claim_type pair without manually iterating all attestations.

## Behavior

- Iterates the subject's attestation index in **reverse order** (newest first)
- Returns the first attestation that is:
  - Not deleted (GDPR)
  - Matching `claim_type`
  - Status `Valid` (not revoked, not expired, not pending)
- Returns `None` if no matching attestation exists

## Changes

- `src/lib.rs`: Updated return type from `Result<Attestation, Error>` to `Option<Attestation>` per spec; changed error propagation to graceful `if let Ok(...)` pattern

Closes #296