### PR TITLE
feat(attestation): implement get_confidence_score(attestation_id) -> u32

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1844,5 +1844,69 @@ impl TrustLinkContract {
 
         Ok(())
     }
+
+    /// Compute a confidence score (0–100) for an attestation.
+    ///
+    /// The score is derived from four factors:
+    ///
+    /// | Factor | Points |
+    /// |--------|--------|
+    /// | Issuer tier: Basic | 20 |
+    /// | Issuer tier: Verified | 35 |
+    /// | Issuer tier: Premium | 50 |
+    /// | Each endorsement (up to 3) | +10 each (max 30) |
+    /// | Multi-sig approved | +15 |
+    /// | Age bonus: ≥ 30 days old | +5 |
+    ///
+    /// Maximum possible score: 100 (50 + 30 + 15 + 5).
+    ///
+    /// Returns `0` if the attestation does not exist.
+    pub fn get_confidence_score(env: Env, attestation_id: String) -> u32 {
+        let attestation = match Storage::get_attestation(&env, &attestation_id) {
+            Ok(a) => a,
+            Err(_) => return 0,
+        };
+
+        let mut score: u32 = 0;
+
+        // Factor 1: Issuer tier
+        let tier_points = match Storage::get_issuer_tier(&env, &attestation.issuer) {
+            Some(IssuerTier::Premium) => 50,
+            Some(IssuerTier::Verified) => 35,
+            Some(IssuerTier::Basic) | None => 20,
+        };
+        score += tier_points;
+
+        // Factor 2: Endorsements (up to 3, +10 each)
+        let endorsement_count = Storage::get_endorsements(&env, &attestation_id).len();
+        let endorsement_points = (endorsement_count.min(3)) * 10;
+        score += endorsement_points;
+
+        // Factor 3: Multi-sig approved (+15)
+        // A multi-sig approved attestation is one whose ID matches a finalized proposal.
+        // We detect this by checking if a proposal with the same proposer/subject/claim_type
+        // was finalized at the attestation's timestamp.
+        let proposal_id = MultiSigProposal::generate_id(
+            &env,
+            &attestation.issuer,
+            &attestation.subject,
+            &attestation.claim_type,
+            attestation.timestamp,
+        );
+        if let Ok(proposal) = Storage::get_multisig_proposal(&env, &proposal_id) {
+            if proposal.finalized {
+                score += 15;
+            }
+        }
+
+        // Factor 4: Age bonus — attestation is at least 30 days old (+5)
+        let current_time = env.ledger().timestamp();
+        let age_secs = current_time.saturating_sub(attestation.timestamp);
+        if age_secs >= 30 * SECS_PER_DAY {
+            score += 5;
+        }
+
+        score.min(100)
+    }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -690,6 +690,40 @@ impl Storage {
             .persistent()
             .get(&StorageKey::LastIssuanceTime(issuer.clone()))
     }
+
+    /// Return all endorsements for `attestation_id`, or an empty Vec if none.
+    pub fn get_endorsements(env: &Env, attestation_id: &String) -> Vec<Endorsement> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::Endorsements(attestation_id.clone()))
+            .unwrap_or(Vec::new(env))
+    }
+
+    /// Append `endorsement` to the endorsements list for its attestation.
+    pub fn add_endorsement(env: &Env, endorsement: &Endorsement) {
+        let key = StorageKey::Endorsements(endorsement.attestation_id.clone());
+        let ttl = get_ttl_lifetime(env);
+        let mut endorsements = Self::get_endorsements(env, &endorsement.attestation_id);
+        endorsements.push_back(endorsement.clone());
+        env.storage().persistent().set(&key, &endorsements);
+        env.storage().persistent().extend_ttl(&key, ttl, ttl);
+    }
+
+    /// Retrieve a multi-sig proposal by ID.
+    pub fn get_multisig_proposal(env: &Env, proposal_id: &String) -> Result<MultiSigProposal, Error> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::MultiSigProposal(proposal_id.clone()))
+            .ok_or(Error::NotFound)
+    }
+
+    /// Persist a multi-sig proposal.
+    pub fn set_multisig_proposal(env: &Env, proposal: &MultiSigProposal) {
+        let key = StorageKey::MultiSigProposal(proposal.id.clone());
+        let ttl = get_ttl_lifetime(env);
+        env.storage().persistent().set(&key, proposal);
+        env.storage().persistent().extend_ttl(&key, ttl, ttl);
+    }
 }
 
 /// Return a paginated window of `values` starting at index `start` for up to


### PR DESCRIPTION
## Summary

Fixes #297

Implements `get_confidence_score(attestation_id) -> u32` as specified in `.kiro/specs/attestation-confidence-score/design.md`.

## Score Calculation

The score is computed from four factors (max 100):

| Factor | Points |
|--------|--------|
| Issuer tier: Basic (or unset) | 20 |
| Issuer tier: Verified | 35 |
| Issuer tier: Premium | 50 |
| Each endorsement (up to 3) | +10 each (max +30) |
| Multi-sig approved | +15 |
| Age ≥ 30 days | +5 |

Returns `0` if the attestation does not exist.

## Additional Fixes

Adds missing `Storage` functions that were called in `lib.rs` but not defined in `storage.rs`:
- `Storage::get_endorsements()` — retrieve endorsements list for an attestation
- `Storage::add_endorsement()` — append an endorsement to the list  
- `Storage::get_multisig_proposal()` — retrieve a multi-sig proposal by ID
- `Storage::set_multisig_proposal()` — persist a multi-sig proposal

## Changes

- `src/lib.rs`: Added `get_confidence_score()` public function
- `src/storage.rs`: Added 4 missing storage functions

Closes #297