### PR TITLE
fix: validate bridge source reference lengths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,8 @@ use crate::validation::Validation;
 
 // Seconds in one day.
 const SECS_PER_DAY: u64 = 86_400;
+const MAX_SOURCE_CHAIN_LEN: u32 = 32;
+const MAX_SOURCE_TX_LEN: u32 = 128;
 
 /// Minimal interface expected on a registered callback contract.
 /// The callback receives the subject, attestation ID, and expiration timestamp.
@@ -72,6 +74,13 @@ fn validate_reason(reason: &Option<String>) -> Result<(), Error> {
         if r.len() > 128 {
             return Err(Error::ReasonTooLong);
         }
+    }
+    Ok(())
+}
+
+fn validate_source_reference(source_chain: &String, source_tx: &String) -> Result<(), Error> {
+    if source_chain.len() > MAX_SOURCE_CHAIN_LEN || source_tx.len() > MAX_SOURCE_TX_LEN {
+        return Err(Error::MetadataTooLong);
     }
     Ok(())
 }
@@ -766,6 +775,7 @@ impl TrustLinkContract {
     ) -> Result<String, Error> {
         bridge.require_auth();
         Validation::require_bridge(&env, &bridge)?;
+        validate_source_reference(&source_chain, &source_tx)?;
 
         let timestamp = env.ledger().timestamp();
         let attestation_id = Attestation::generate_bridge_id(

--- a/src/test.rs
+++ b/src/test.rs
@@ -629,6 +629,45 @@ fn test_bridge_attestation_stores_source_reference_and_marks_bridged() {
 }
 
 #[test]
+fn test_bridge_attestation_rejects_source_chain_too_long() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, _, client) = setup(&env);
+    let bridge = Address::generate(&env);
+    let subject = Address::generate(&env);
+    let claim_type = String::from_str(&env, "KYC_PASSED");
+    let source_chain = String::from_str(&env, "123456789012345678901234567890123"); // 33 chars
+    let source_tx = String::from_str(&env, "0xabc123");
+
+    client.register_bridge(&admin, &bridge);
+    let result = client.try_bridge_attestation(&bridge, &subject, &claim_type, &source_chain, &source_tx);
+
+    assert_eq!(result, Err(Ok(types::Error::MetadataTooLong)));
+}
+
+#[test]
+fn test_bridge_attestation_rejects_source_tx_too_long() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, _, client) = setup(&env);
+    let bridge = Address::generate(&env);
+    let subject = Address::generate(&env);
+    let claim_type = String::from_str(&env, "KYC_PASSED");
+    let source_chain = String::from_str(&env, "ethereum");
+    let source_tx = String::from_str(
+        &env,
+        "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
+    ); // 129 chars
+
+    client.register_bridge(&admin, &bridge);
+    let result = client.try_bridge_attestation(&bridge, &subject, &claim_type, &source_chain, &source_tx);
+
+    assert_eq!(result, Err(Ok(types::Error::MetadataTooLong)));
+}
+
+#[test]
 fn test_bridge_attestation_emits_event() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
Add strict input validation for bridge source reference fields to prevent storage bloat:

source_chain max length: 32
source_tx max length: 128
Return MetadataTooLong when limits are exceeded.

Adds regression tests for both oversized inputs.

Closes #265