### PR TITLE
feat(query): add get_valid_claim_count() for a subject

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1372,6 +1372,22 @@ impl TrustLinkContract {
         result
     }
 
+    /// Returns the count of non-revoked, non-expired, non-deleted attestations for `subject`.
+    pub fn get_valid_claim_count(env: Env, subject: Address) -> u32 {
+        let current_time = env.ledger().timestamp();
+        let mut count: u32 = 0;
+        for attestation_id in Storage::get_subject_attestations(&env, &subject).iter() {
+            if let Ok(attestation) = Storage::get_attestation(&env, &attestation_id) {
+                if !attestation.deleted
+                    && attestation.get_status(current_time) == AttestationStatus::Valid
+                {
+                    count += 1;
+                }
+            }
+        }
+        count
+    }
+
     pub fn get_attestation_by_type(
         env: Env,
         subject: Address,


### PR DESCRIPTION
## Summary

Adds `get_valid_claim_count(env, subject) -> u32` to the contract.

Returns the count of non-revoked, non-expired, non-deleted attestations for a given subject address. This is a lightweight alternative to `get_valid_claims()` for dashboards that only need the count, not the full list.

## Changes

- `src/lib.rs`: Added `get_valid_claim_count()` after `get_valid_claims()`

Closes #303