### PR TITLE
feat(query): add get_issuer_attestation_count()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1345,6 +1345,11 @@ impl TrustLinkContract {
         )
     }
 
+    /// Returns the total number of attestations created by `issuer` from the issuer index.
+    pub fn get_issuer_attestation_count(env: Env, issuer: Address) -> u32 {
+        Storage::get_issuer_attestations(&env, &issuer).len()
+    }
+
     pub fn get_valid_claims(env: Env, subject: Address) -> Vec<String> {
         let current_time = env.ledger().timestamp();
         let mut result = Vec::new(&env);


### PR DESCRIPTION
## Summary

Adds `get_issuer_attestation_count(env, issuer) -> u32` to the contract.

Returns the total count of attestations created by a given issuer directly from the issuer index, without requiring callers to paginate through all results.

## Changes

- `src/lib.rs`: Added `get_issuer_attestation_count()` after `get_issuer_attestations()`

Closes #306