### PR TITLE
audit: verify has_all_claims() AND-logic matches spec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1149,6 +1149,13 @@ impl TrustLinkContract {
         false
     }
 
+    /// Returns `true` only if the subject holds a valid attestation for **every**
+    /// claim type in `claim_types`.
+    ///
+    /// # Behaviour (verified against spec in issue #309)
+    /// - AND-logic: short-circuits and returns `false` on the first unsatisfied claim.
+    /// - Empty `claim_types` list returns `true` (vacuous truth).
+    /// - Revoked, expired, pending, and deleted attestations are excluded.
     pub fn has_all_claims(env: Env, subject: Address, claim_types: Vec<String>) -> bool {
         if claim_types.is_empty() {
             return true;


### PR DESCRIPTION
## Audit Summary — Issue #309

Audited `has_all_claims()` against the documented spec.

### Findings

| Spec requirement | Status |
|---|---|
| Returns `true` only if ALL claim types have a valid attestation | ✅ Correct — AND-logic via labeled `continue` |
| Empty list returns `true` (vacuous truth) | ✅ Correct — early return on `is_empty()` |
| Short-circuits on first missing claim | ✅ Correct — `return false` on first unsatisfied claim |
| Revoked/expired/pending attestations excluded | ✅ Correct — `get_status() == Valid` check |
| Deleted attestations excluded | ✅ Correct — `!attestation.deleted` guard |

**Result: Implementation is correct and matches the spec.**

Added a doc comment to `has_all_claims()` to make the verified behaviour explicit for future reviewers.

Closes #309