### PR TITLE
feat(endorsements): implement get_endorsements() and get_endorsement_count()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1662,6 +1662,16 @@ impl TrustLinkContract {
         Ok(())
     }
 
+    /// Returns all endorsements for the given attestation.
+    pub fn get_endorsements(env: Env, attestation_id: String) -> Vec<Endorsement> {
+        Storage::get_endorsements(&env, &attestation_id)
+    }
+
+    /// Returns the number of endorsements for the given attestation.
+    pub fn get_endorsement_count(env: Env, attestation_id: String) -> u32 {
+        Storage::get_endorsements(&env, &attestation_id).len()
+    }
+
     /// Configure storage exhaustion limits (admin only).
     ///
     /// Sets the maximum number of attestations allowed per issuer and per subject.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -571,6 +571,25 @@ impl Storage {
         env.storage().persistent().extend_ttl(&key, ttl, ttl);
     }
 
+    /// Return the ordered list of endorsements for `attestation_id`, or an empty [`Vec`] if none.
+    pub fn get_endorsements(env: &Env, attestation_id: &String) -> Vec<Endorsement> {
+        let key = StorageKey::Endorsements(attestation_id.clone());
+        env.storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(Vec::new(env))
+    }
+
+    /// Append `endorsement` to the endorsements list for its attestation and refresh TTL.
+    pub fn add_endorsement(env: &Env, endorsement: &Endorsement) {
+        let key = StorageKey::Endorsements(endorsement.attestation_id.clone());
+        let ttl = get_ttl_lifetime(env);
+        let mut endorsements = Self::get_endorsements(env, &endorsement.attestation_id);
+        endorsements.push_back(endorsement.clone());
+        env.storage().persistent().set(&key, &endorsements);
+        env.storage().persistent().extend_ttl(&key, ttl, ttl);
+    }
+
     /// Return `true` if the contract is currently paused.
     ///
     /// Defaults to `false` (not paused) when the key is absent.


### PR DESCRIPTION
## Summary

Completes the endorsement system for issue #300.

`endorse_attestation()` already existed but the query side was missing. This PR adds the storage helpers and contract methods needed to read endorsements back.

## Changes

### `src/storage.rs`
- `get_endorsements(env, attestation_id) -> Vec<Endorsement>` — reads from `Endorsements(String)` storage key
- `add_endorsement(env, endorsement)` — appends to the endorsements list and refreshes TTL

### `src/lib.rs`
- `get_endorsements(env, attestation_id) -> Vec<Endorsement>` — public contract method
- `get_endorsement_count(env, attestation_id) -> u32` — public contract method

## Existing behaviour (unchanged)

`endorse_attestation()` already handles all write-side logic:
- Only registered issuers may endorse
- Self-endorsement prevented (`CannotEndorseOwn`)
- Revoked attestations rejected (`AlreadyRevoked`)
- Duplicate endorsements prevented (`AlreadyEndorsed`)
- `attestation_endorsed` event emitted

Closes #300