### PR TITLE
fix(limits): enforce storage limits in create_attestation and import_…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,6 +607,15 @@ impl TrustLinkContract {
             return Err(Error::DuplicateAttestation);
         }
 
+        // Enforce storage limits
+        let limits = Storage::get_limits(env);
+        if Storage::get_issuer_attestations(env, &issuer).len() >= limits.max_attestations_per_issuer {
+            return Err(Error::LimitExceeded);
+        }
+        if Storage::get_subject_attestations(env, &subject).len() >= limits.max_attestations_per_subject {
+            return Err(Error::LimitExceeded);
+        }
+
         // Validate claim_type length (enforce max 64 characters)
         let claim_type_len = claim_type.len();
         if claim_type_len > 64 {
@@ -719,6 +728,15 @@ impl TrustLinkContract {
 
         if Storage::has_attestation(&env, &attestation_id) {
             return Err(Error::DuplicateAttestation);
+        }
+
+        // Enforce storage limits
+        let limits = Storage::get_limits(&env);
+        if Storage::get_issuer_attestations(&env, &issuer).len() >= limits.max_attestations_per_issuer {
+            return Err(Error::LimitExceeded);
+        }
+        if Storage::get_subject_attestations(&env, &subject).len() >= limits.max_attestations_per_subject {
+            return Err(Error::LimitExceeded);
         }
 
         let attestation = Attestation {

--- a/src/test.rs
+++ b/src/test.rs
@@ -3373,3 +3373,51 @@ fn test_whitelist_check_before_storage_write() {
     // This must panic — no attestation should be stored
     client.create_attestation(&issuer, &subject, &claim_type, &None, &None, &None);
 }
+
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_import_attestation_issuer_limit_exceeded() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let issuer = Address::generate(&env);
+    let (_, client) = create_test_contract(&env);
+    client.initialize(&admin);
+    client.register_issuer(&admin, &issuer);
+
+    // Set issuer limit to 1
+    client.set_limits(&admin, &1, &1000);
+
+    let claim = String::from_str(&env, "KYC_PASSED");
+    let ts: u64 = 1_700_000_000;
+
+    // First import succeeds
+    client.import_attestation(&admin, &issuer, &Address::generate(&env), &claim, &ts, &None);
+
+    // Second import should hit LimitExceeded (#10)
+    client.import_attestation(&admin, &issuer, &Address::generate(&env), &claim, &(ts + 1), &None);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_import_attestation_subject_limit_exceeded() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let issuer = Address::generate(&env);
+    let subject = Address::generate(&env);
+    let (_, client) = create_test_contract(&env);
+    client.initialize(&admin);
+    client.register_issuer(&admin, &issuer);
+
+    // Set subject limit to 1
+    client.set_limits(&admin, &10_000, &1);
+
+    let ts: u64 = 1_700_000_000;
+
+    // First import succeeds
+    client.import_attestation(&admin, &issuer, &subject, &String::from_str(&env, "KYC_PASSED"), &ts, &None);
+
+    // Second import on same subject should hit LimitExceeded (#10)
+    client.import_attestation(&admin, &issuer, &subject, &String::from_str(&env, "AML_CLEARED"), &(ts + 1), &None);
+}


### PR DESCRIPTION
…attestation

Prior to this change, LimitExceeded was only checked in create_attestations_batch. Single-attestation paths (create_attestation_internal and import_attestation) had no limit enforcement, allowing any issuer or subject to exceed the configured max_attestations_per_issuer / max_attestations_per_subject caps.

Changes:
- Add issuer and subject limit checks to create_attestation_internal (covers create_attestation and create_attestation_jurisdiction)
- Add issuer and subject limit checks to import_attestation
- Add tests: test_import_attestation_issuer_limit_exceeded, test_import_attestation_subject_limit_exceeded

Closes #318