### PR TITLE
refactor: move StorageLimits defaults to types.rs

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -29,11 +29,11 @@
 //! - `GlobalStats` — running counters for total attestations, revocations, and issuers.
 
 use crate::types::{
-    AdminCouncil, Attestation, AttestationRequest, AuditEntry, ClaimTypeInfo, Endorsement, Error, ExpirationHook,
-    FeeConfig, GlobalStats, IssuerMetadata, IssuerStats, IssuerTier, MultiSigProposal, TtlConfig, Delegation, RateLimitConfig,
+    AdminCouncil, Attestation, AttestationRequest, AuditEntry, ClaimTypeInfo, Delegation,
+    Endorsement, Error, ExpirationHook, FeeConfig, GlobalStats, IssuerMetadata, IssuerStats,
+    IssuerTier, MultiSigProposal, RateLimitConfig, StorageLimits, TtlConfig,
 };
 use soroban_sdk::{contracttype, Address, Env, String, Vec};
-use crate::types::{Attestation, ClaimTypeInfo, Error, IssuerMetadata, StorageLimits, Delegation};
 
 /// Keys used to address data in contract storage.
 #[contracttype]
@@ -68,6 +68,8 @@ pub enum StorageKey {
     IssuerWhitelistMode(Address),
     /// Whether a subject is whitelisted for a specific issuer.
     IssuerWhitelist(Address, Address),
+    /// Configurable storage exhaustion limits.
+    Limits,
 }
 
 const DAY_IN_LEDGERS: u32 = 17280;
@@ -465,5 +467,18 @@ impl Storage {
         env.storage()
             .persistent()
             .has(&StorageKey::IssuerWhitelist(issuer.clone(), subject.clone()))
+    }
+
+    /// Persist storage exhaustion limits.
+    pub fn set_limits(env: &Env, limits: &StorageLimits) {
+        env.storage().instance().set(&StorageKey::Limits, limits);
+    }
+
+    /// Return the current storage limits, falling back to [`StorageLimits::default`] if not set.
+    pub fn get_limits(env: &Env) -> StorageLimits {
+        env.storage()
+            .instance()
+            .get(&StorageKey::Limits)
+            .unwrap_or_default()
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -239,19 +239,6 @@ pub struct Delegation {
     pub claim_type: String,
     /// Optional expiration timestamp for this delegation.
     pub expiration: Option<u64>,
-#[contracterror]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum Error {
-    AlreadyInitialized = 1,
-    NotInitialized = 2,
-    Unauthorized = 3,
-    NotFound = 4,
-    DuplicateAttestation = 5,
-    AlreadyRevoked = 6,
-    Expired = 7,
-    InvalidValidFrom = 8,
-    InvalidExpiration = 9,
-    SubjectNotWhitelisted = 25,
 }
 
 #[contracttype]


### PR DESCRIPTION
## Summary

Closes #281

### Changes

- `impl Default for StorageLimits` is already co-located with the type definition in `types.rs` — defaults (`10_000` per issuer, `100` per subject) live alongside the struct
- Fixed `Delegation` struct missing closing brace in `types.rs`
- Removed duplicate `Error` enum fragment from `types.rs`
- Removed duplicate import in `storage.rs`
- Added `Limits` key to `StorageKey` enum
- Added `Storage::get_limits()` — returns stored limits or `StorageLimits::default()` as fallback
- Added `Storage::set_limits()` — persists admin-configured limits

### Why

Previously `Storage::get_limits` and `Storage::set_limits` were called in `lib.rs` but not defined in `storage.rs`. The defaults are now driven by `StorageLimits::default()` in `types.rs`, keeping them co-located with the type.