### PR TITLE
refactor: unify issuer and bridge auth into require_authorized_creator

### DIFF
--- a/src/validation.rs
+++ b/src/validation.rs
@@ -56,6 +56,20 @@ impl Validation {
         Ok(())
     }
 
+    /// Assert that `caller` is either a registered issuer or a registered bridge contract.
+    ///
+    /// Used by attestation creation paths that accept both issuers and bridges,
+    /// eliminating the duplicated `require_issuer` / `require_bridge` pattern.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] — `caller` is neither a registered issuer nor a registered bridge.
+    pub fn require_authorized_creator(env: &Env, caller: &Address) -> Result<(), Error> {
+        if Storage::is_issuer(env, caller) || Storage::is_bridge(env, caller) {
+            return Ok(());
+        }
+        Err(Error::Unauthorized)
+    }
+
     /// Assert that the contract is not currently paused.
     ///
     /// # Errors


### PR DESCRIPTION
## Summary

Closes #285

### Changes

- Added `pub fn require_authorized_creator(env: &Env, caller: &Address) -> Result<(), Error>` to `validation.rs`
- Returns `Ok(())` if `caller` is a registered issuer **or** a registered bridge contract
- Returns `Err(Error::Unauthorized)` if neither
- Existing `require_issuer` and `require_bridge` are preserved for callers that need role-specific enforcement

### Why

`create_attestation` calls `require_issuer` and `bridge_attestation` calls `require_bridge`. The authorization logic is nearly identical — both just check whether the caller is in a trusted registry. `require_authorized_creator` unifies this into a single reusable guard that can be used wherever either role is acceptable, reducing duplication.