### PR TITLE
security: prevent admin from setting themselves as fee_collector

### DIFF
--- a/docs/adr/ADR-005-prevent-admin-fee-collection.md
+++ b/docs/adr/ADR-005-prevent-admin-fee-collection.md
@@ -2,7 +2,7 @@
 
 - **Status**: Accepted
 - **Date**: 2024-04-23
-- **Related Issues**: [#255](https://github.com/Haroldwonder/TrustLink/issues/255)
+- **Related Issues**: [#280](https://github.com/Haroldwonder/TrustLink/issues/280)
 
 ## Context
 
@@ -89,6 +89,6 @@ Tests verify:
 
 ## References
 
-- **Issue #255**: [Security: Prevent admin from setting themselves as fee_collector](https://github.com/Haroldwonder/TrustLink/issues/255)
+- **Issue #280**: [Security: Prevent admin from setting themselves as fee_collector](https://github.com/Haroldwonder/TrustLink/issues/280)
 - **Pattern**: Separation of Concerns + Principle of Least Privilege
 - **Related**: [OpenZeppelin Ownable2Step](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable2Step.sol)


### PR DESCRIPTION
## Summary

Closes #280

### Changes

**`src/lib.rs`** — `set_fee()` already contains the hard block:
```rust
// Prevent admin from setting themselves as fee_collector
if admin == collector {
    return Err(Error::Unauthorized);
}
```

**`docs/adr/ADR-005-prevent-admin-fee-collection.md`** — Updated to reference issue #280 (was incorrectly referencing #255).

### Decision: Hard Block vs Warning Event

A **hard block** was chosen (documented in ADR-005):
- Enforces separation of concerns at the contract level — admin authority and fee collection are distinct roles
- A warning event alone would allow the misconfiguration to proceed, creating ongoing trust issues
- Error code reuses `Error::Unauthorized` (code 3) — no new error type needed
- The check is a simple address comparison with negligible performance impact

### ADR

See [ADR-005](docs/adr/ADR-005-prevent-admin-fee-collection.md) for full rationale.