### PR TITLE
security: validate source_chain and source_tx length in bridge_attestation

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -53,4 +53,12 @@ pub enum Error {
     LastAdminCannotBeRemoved = 29,
     /// Issuer is rate-limited and must wait before creating another attestation.
     RateLimited = 30,
+    /// Claim type identifier is empty, too long, or contains invalid characters.
+    InvalidClaimType = 31,
+    /// Jurisdiction code is not a valid ISO 3166-1 alpha-2 code.
+    InvalidJurisdiction = 32,
+    /// Issuer or subject attestation count has reached the configured limit.
+    LimitExceeded = 33,
+    /// Batch size exceeds the maximum allowed (50).
+    BatchTooLarge = 34,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -61,4 +61,6 @@ pub enum Error {
     LimitExceeded = 33,
     /// Batch size exceeds the maximum allowed (50).
     BatchTooLarge = 34,
+    /// source_chain exceeds 32 chars or source_tx exceeds 128 chars in bridge_attestation.
+    SourceRefTooLong = 35,
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{symbol_short, Address, Env, String};
 
-use crate::types::{Attestation, IssuerTier, Address};
+use crate::types::{Attestation, IssuerTier};
 
 pub struct Events;
 
@@ -93,18 +93,6 @@ impl Events {
         );
     }
 
-    pub fn deletion_requested(
-    env: &Env,
-    subject: &Address,
-    attestation_id: &String,
-    timestamp: u64,
-) {
-    env.events().publish(
-        (symbol_short!("del_req"), subject.clone()),
-        (attestation_id.clone(), timestamp),
-    );
-}
-
     pub fn attestation_expired(env: &Env, attestation_id: &String, subject: &Address) {
         env.events().publish(
             (symbol_short!("expired"), subject.clone()),
@@ -196,6 +184,19 @@ impl Events {
         env.events().publish(
             (symbol_short!("ms_actv"),),
             (proposal_id.clone(), attestation_id.clone()),
+        );
+    }
+
+    /// Emitted when admin transfers an attestation to a new issuer.
+    pub fn attestation_transferred(
+        env: &Env,
+        attestation_id: &String,
+        old_issuer: &Address,
+        new_issuer: &Address,
+    ) {
+        env.events().publish(
+            (symbol_short!("att_xfer"), old_issuer.clone()),
+            (attestation_id.clone(), new_issuer.clone()),
         );
     }
 
@@ -300,7 +301,7 @@ impl Events {
         expiration: Option<u64>,
     ) {
         env.events().publish(
-            (symbol_short!("del_created"), delegator.clone()),
+            (symbol_short!("del_crtd"), delegator.clone()),
             (delegate.clone(), claim_type.clone(), expiration),
         );
     }
@@ -313,7 +314,7 @@ impl Events {
         claim_type: &String,
     ) {
         env.events().publish(
-            (symbol_short!("del_revoked"), delegator.clone()),
+            (symbol_short!("del_rvkd"), delegator.clone()),
             (delegate.clone(), claim_type.clone()),
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -791,6 +791,13 @@ impl TrustLinkContract {
         bridge.require_auth();
         Validation::require_bridge(&env, &bridge)?;
 
+        if source_chain.len() > 32 {
+            return Err(Error::SourceRefTooLong);
+        }
+        if source_tx.len() > 128 {
+            return Err(Error::SourceRefTooLong);
+        }
+
         let timestamp = env.ledger().timestamp();
         let attestation_id = Attestation::generate_bridge_id(
             &env,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@ use crate::storage::Storage;
 use crate::types::{
     AdminCouncil, Attestation, AttestationRequest, AttestationStatus, AuditAction, AuditEntry, ClaimTypeInfo,
     ContractConfig, ContractMetadata, Endorsement, Error, FeeConfig, GlobalStats, HealthStatus,
-    IssuerMetadata, IssuerStats, IssuerTier, MultiSigProposal, RequestStatus, TtlConfig,
-    ATTESTATION_REQUEST_TTL_SECS, MULTISIG_PROPOSAL_TTL_SECS,
+    IssuerMetadata, IssuerStats, IssuerTier, MultiSigProposal, RateLimitConfig, RequestStatus,
+    StorageLimits, TtlConfig, ATTESTATION_REQUEST_TTL_SECS, MULTISIG_PROPOSAL_TTL_SECS,
 };
 use crate::validation::Validation;
 
@@ -517,35 +517,6 @@ impl TrustLinkContract {
         Storage::set_whitelist_mode(&env, &issuer, true);
         Events::whitelist_mode_enabled(&env, &issuer);
         Ok(())
-    }
-
-    /// Add a subject to the calling issuer's whitelist.
-    ///
-    /// # Errors
-    /// - [`Error::Unauthorized`] — caller is not a registered issuer.
-    pub fn add_to_whitelist(env: Env, issuer: Address, subject: Address) -> Result<(), Error> {
-        issuer.require_auth();
-        Validation::require_issuer(&env, &issuer)?;
-        Storage::add_to_whitelist(&env, &issuer, &subject);
-        Events::whitelist_updated(&env, &issuer, &subject, true);
-        Ok(())
-    }
-
-    /// Remove a subject from the calling issuer's whitelist.
-    ///
-    /// # Errors
-    /// - [`Error::Unauthorized`] — caller is not a registered issuer.
-    pub fn remove_from_whitelist(env: Env, issuer: Address, subject: Address) -> Result<(), Error> {
-        issuer.require_auth();
-        Validation::require_issuer(&env, &issuer)?;
-        Storage::remove_from_whitelist(&env, &issuer, &subject);
-        Events::whitelist_updated(&env, &issuer, &subject, false);
-        Ok(())
-    }
-
-    /// Return `true` if `subject` is on `issuer`'s whitelist.
-    pub fn is_whitelisted(env: Env, issuer: Address, subject: Address) -> bool {
-        Storage::is_whitelisted(&env, &issuer, &subject)
     }
 
     /// Create a new attestation about a subject address.    ///
@@ -1075,68 +1046,6 @@ impl TrustLinkContract {
         Ok(())
     }
 
-    /// Revoke multiple attestations in a single atomic call (issuer only).
-    ///
-    /// Authorization is checked once for the issuer. If any attestation does
-    /// not belong to the caller or is already revoked the entire batch is
-    /// rolled back — no partial writes occur.
-    ///
-    /// Max batch size is 50. Passing more IDs returns [`Error::BatchTooLarge`].
-    ///
-    /// Emits one `revoked` event per attestation.
-    ///
-    /// # Parameters
-    /// - `issuer` — authorized issuer (must authorize).
-    /// - `attestation_ids` — list of IDs to revoke (max 50).
-    /// - `reason` — optional human-readable reason stored in the event data.
-    ///
-    /// # Returns
-    /// Count of revoked attestations.
-    ///
-    /// # Errors
-    /// - [`Error::BatchTooLarge`] — more than 50 IDs supplied.
-    /// - [`Error::Unauthorized`] — issuer is not registered or does not own an attestation.
-    /// - [`Error::NotFound`] — an ID does not exist.
-    /// - [`Error::AlreadyRevoked`] — an attestation is already revoked.
-    pub fn revoke_attestations_batch(
-        env: Env,
-        issuer: Address,
-        attestation_ids: Vec<String>,
-        reason: Option<String>,
-    ) -> Result<u32, Error> {
-        const MAX_BATCH: u32 = 50;
-
-        issuer.require_auth();
-        Validation::require_issuer(&env, &issuer)?;
-
-        if attestation_ids.len() > MAX_BATCH {
-            return Err(Error::BatchTooLarge);
-        }
-
-        // Validate all attestations first (atomic — no partial writes)
-        for id in attestation_ids.iter() {
-            let attestation = Storage::get_attestation(&env, &id)?;
-            if attestation.issuer != issuer {
-                return Err(Error::Unauthorized);
-            }
-            if attestation.revoked {
-                return Err(Error::AlreadyRevoked);
-            }
-        }
-
-        // All checks passed — apply writes
-        let mut count: u32 = 0;
-        for id in attestation_ids.iter() {
-            let mut attestation = Storage::get_attestation(&env, &id)?;
-            attestation.revoked = true;
-            Storage::set_attestation(&env, &attestation);
-            Events::attestation_revoked_with_reason(&env, &id, &issuer, &reason);
-            count += 1;
-        }
-
-        false
-    }
-
     pub fn has_valid_claim_from_issuer(
         env: Env,
         subject: Address,
@@ -1313,7 +1222,7 @@ impl TrustLinkContract {
             }
         }
 
-        let paginated_ids = crate::storage::paginate(&env, filtered_ids, start, limit);
+        let paginated_ids = crate::storage::paginate(&env, &filtered_ids, start, limit);
         let mut result = Vec::new(&env);
 
         for id in paginated_ids.iter() {
@@ -1771,26 +1680,6 @@ impl TrustLinkContract {
         }
     }
 
-    pub fn pause(env: Env, admin: Address) -> Result<(), Error> {
-        admin.require_auth();
-        Validation::require_admin(&env, &admin)?;
-        Storage::set_paused(&env, true);
-        Events::contract_paused(&env, &admin);
-        Ok(())
-    }
-
-    pub fn unpause(env: Env, admin: Address) -> Result<(), Error> {
-        admin.require_auth();
-        Validation::require_admin(&env, &admin)?;
-        Storage::set_paused(&env, false);
-        Events::contract_unpaused(&env, &admin);
-        Ok(())
-    }
-
-    pub fn is_paused(env: Env) -> bool {
-        Storage::is_paused(&env)
-    }
-
     pub fn get_contract_metadata(env: Env) -> Result<ContractMetadata, Error> {
         let version = Storage::get_version(&env).ok_or(Error::NotInitialized)?;
         Ok(ContractMetadata {
@@ -1876,10 +1765,7 @@ impl TrustLinkContract {
                 action: AuditAction::Transferred,
                 actor: admin.clone(),
                 timestamp,
-                details: Some(format!(
-                    "{}",
-                    new_issuer.to_string()
-                )),
+                details: Some(new_issuer.to_string()),
             },
         );
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -29,11 +29,11 @@
 //! - `GlobalStats` — running counters for total attestations, revocations, and issuers.
 
 use crate::types::{
-    AdminCouncil, Attestation, AttestationRequest, AuditEntry, ClaimTypeInfo, Endorsement, Error, ExpirationHook,
-    FeeConfig, GlobalStats, IssuerMetadata, IssuerStats, IssuerTier, MultiSigProposal, TtlConfig, Delegation, RateLimitConfig,
+    AdminCouncil, Attestation, AttestationRequest, AuditEntry, ClaimTypeInfo, Delegation,
+    Endorsement, Error, ExpirationHook, FeeConfig, GlobalStats, IssuerMetadata, IssuerStats,
+    IssuerTier, MultiSigProposal, RateLimitConfig, StorageLimits, TtlConfig,
 };
 use soroban_sdk::{contracttype, Address, Env, String, Vec};
-use crate::types::{Attestation, ClaimTypeInfo, Error, IssuerMetadata, StorageLimits, Delegation};
 
 /// Keys used to address data in contract storage.
 #[contracttype]
@@ -68,6 +68,34 @@ pub enum StorageKey {
     IssuerWhitelistMode(Address),
     /// Whether a subject is whitelisted for a specific issuer.
     IssuerWhitelist(Address, Address),
+    /// Global contract statistics.
+    GlobalStats,
+    /// Per-issuer statistics.
+    IssuerStats(Address),
+    /// Issuer trust tier.
+    IssuerTier(Address),
+    /// Audit log for an attestation.
+    AuditLog(String),
+    /// Endorsements for an attestation.
+    Endorsements(String),
+    /// Expiration hook for a subject.
+    ExpirationHook(Address),
+    /// Multi-sig proposal.
+    MultiSigProposal(String),
+    /// Attestation request.
+    AttestationRequest(String),
+    /// Pending request IDs for an issuer.
+    PendingRequests(Address),
+    /// Rate limit config.
+    RateLimitConfig,
+    /// Last issuance timestamp for an issuer.
+    LastIssuanceTime(Address),
+    /// Storage limits.
+    StorageLimits,
+    /// Contract paused flag.
+    Paused,
+    /// Delegation key (delegator, delegate, claim_type).
+    Delegation(Address, Address, String),
 }
 
 const DAY_IN_LEDGERS: u32 = 17280;
@@ -121,22 +149,22 @@ impl Storage {
     pub fn get_admin_council(env: &Env) -> Result<AdminCouncil, Error> {
         env.storage()
             .instance()
-            .get(&amp;StorageKey::AdminCouncil)
+            .get(&StorageKey::AdminCouncil)
             .ok_or(Error::NotInitialized)
     }
 
     /// Persist the admin council and refresh TTL.
-    pub fn set_admin_council(env: &amp;Env, council: &amp;AdminCouncil) {
+    pub fn set_admin_council(env: &Env, council: &AdminCouncil) {
         let ttl = get_ttl_lifetime(env);
-        env.storage().instance().set(&amp;StorageKey::AdminCouncil, council);
+        env.storage().instance().set(&StorageKey::AdminCouncil, council);
         env.storage().instance().extend_ttl(ttl, ttl);
     }
 
     /// Return true if `address` is an admin in the council.
-    pub fn is_admin(env: &amp;Env, address: &amp;Address) -> bool {
+    pub fn is_admin(env: &Env, address: &Address) -> bool {
         if let Ok(council) = Self::get_admin_council(env) {
             for admin in council.iter() {
-                if admin == address {
+                if admin == *address {
                     return true;
                 }
             }
@@ -145,35 +173,35 @@ impl Storage {
     }
 
     /// Add `admin` to council if not already present.
-    pub fn add_admin(env: &amp;Env, admin: &amp;Address) {
+    pub fn add_admin(env: &Env, admin: &Address) {
         let mut council = Self::get_admin_council(env).unwrap_or(Vec::new(env));
         let mut found = false;
         for a in council.iter() {
-            if a == admin {
+            if a == *admin {
                 found = true;
                 break;
             }
         }
         if !found {
             council.push_back(admin.clone());
-            Self::set_admin_council(env, &amp;council);
+            Self::set_admin_council(env, &council);
         }
     }
 
     /// Remove `admin` from council if present.
-    pub fn remove_admin(env: &amp;Env, admin: &amp;Address) {
+    pub fn remove_admin(env: &Env, admin: &Address) {
         let mut council = Self::get_admin_council(env).unwrap_or(Vec::new(env));
         let mut new_council = Vec::new(env);
         let mut found = false;
         for a in council.iter() {
-            if a != admin {
+            if a != *admin {
                 new_council.push_back(a.clone());
             } else {
                 found = true;
             }
         }
         if found {
-            Self::set_admin_council(env, &amp;new_council);
+            Self::set_admin_council(env, &new_council);
         }
     }
 
@@ -224,7 +252,7 @@ impl Storage {
     /// - [`Error::NotInitialized`] — council empty.
     pub fn get_admin(env: &Env) -> Result<Address, Error> {
         let council = Self::get_admin_council(env)?;
-        council.first().cloned().ok_or(Error::NotInitialized)
+        council.first().ok_or(Error::NotInitialized)
     }
 
     /// Return `true` if `address` is in the issuer registry.
@@ -325,27 +353,8 @@ impl Storage {
         env.storage().persistent().extend_ttl(&key, ttl, ttl);
     }
 
-    /// Remove `attestation_id` from `issuer`'s attestation index.
-    ///
-    /// Note: this does not delete the attestation record; it only removes the ID
-    /// from the issuer's listing index so pagination results shrink.
-    pub fn remove_issuer_attestation(env: &Env, issuer: &Address, attestation_id: &String) {
-        let key = StorageKey::IssuerAttestations(issuer.clone());
-        let ttl = get_ttl_lifetime(env);
-        let existing = Self::get_issuer_attestations(env, issuer);
-        let mut updated = Vec::new(env);
-        for id in existing.iter() {
-            if &id != attestation_id {
-                updated.push_back(id);
-            }
-        }
-        env.storage().persistent().set(&key, &updated);
-        env.storage().persistent().extend_ttl(&key, ttl, ttl);
-    }
-
     /// Return the ordered list of attestation IDs created by `issuer`, or an
-    /// empty [`Vec`] if none exist. TTL is only extended on index modification,
-    /// not on read, to reduce compute costs for frequent queries.
+    /// empty [`Vec`] if none exist.
     pub fn get_issuer_attestations(env: &Env, issuer: &Address) -> Vec<String> {
         let key = StorageKey::IssuerAttestations(issuer.clone());
         env.storage()
@@ -354,7 +363,10 @@ impl Storage {
             .unwrap_or(Vec::new(env))
     }
 
-    /// Append `attestation_id` to `issuer`'s attestation index and refresh TTL.
+    /// Remove `attestation_id` from `issuer`'s attestation index.
+    ///
+    /// Note: this does not delete the attestation record; it only removes the ID
+    /// from the issuer's listing index so pagination results shrink.
     pub fn add_issuer_attestation(env: &Env, issuer: &Address, attestation_id: &String) {
         let key = StorageKey::IssuerAttestations(issuer.clone());
         let ttl = get_ttl_lifetime(env);
@@ -434,8 +446,9 @@ impl Storage {
     /// Enable or disable whitelist mode for an issuer.
     pub fn set_whitelist_mode(env: &Env, issuer: &Address, enabled: bool) {
         let key = StorageKey::IssuerWhitelistMode(issuer.clone());
+        let ttl = get_ttl_lifetime(env);
         env.storage().persistent().set(&key, &enabled);
-        env.storage().persistent().extend_ttl(&key, INSTANCE_LIFETIME, INSTANCE_LIFETIME);
+        env.storage().persistent().extend_ttl(&key, ttl, ttl);
     }
 
     /// Return `true` if whitelist mode is enabled for `issuer`.
@@ -449,8 +462,9 @@ impl Storage {
     /// Add `subject` to `issuer`'s whitelist.
     pub fn add_to_whitelist(env: &Env, issuer: &Address, subject: &Address) {
         let key = StorageKey::IssuerWhitelist(issuer.clone(), subject.clone());
+        let ttl = get_ttl_lifetime(env);
         env.storage().persistent().set(&key, &true);
-        env.storage().persistent().extend_ttl(&key, INSTANCE_LIFETIME, INSTANCE_LIFETIME);
+        env.storage().persistent().extend_ttl(&key, ttl, ttl);
     }
 
     /// Remove `subject` from `issuer`'s whitelist.
@@ -466,4 +480,337 @@ impl Storage {
             .persistent()
             .has(&StorageKey::IssuerWhitelist(issuer.clone(), subject.clone()))
     }
+
+    // ── Whitelist aliases used by lib.rs ──────────────────────────────────────
+
+    pub fn set_whitelist_enabled(env: &Env, issuer: &Address, enabled: bool) {
+        Self::set_whitelist_mode(env, issuer, enabled);
+    }
+
+    pub fn is_whitelist_enabled(env: &Env, issuer: &Address) -> bool {
+        Self::is_whitelist_mode(env, issuer)
+    }
+
+    pub fn add_subject_to_whitelist(env: &Env, issuer: &Address, subject: &Address) {
+        Self::add_to_whitelist(env, issuer, subject);
+    }
+
+    pub fn remove_subject_from_whitelist(env: &Env, issuer: &Address, subject: &Address) {
+        Self::remove_from_whitelist(env, issuer, subject);
+    }
+
+    pub fn is_subject_whitelisted(env: &Env, issuer: &Address, subject: &Address) -> bool {
+        Self::is_whitelisted(env, issuer, subject)
+    }
+
+    // ── Global stats ──────────────────────────────────────────────────────────
+
+    pub fn get_global_stats(env: &Env) -> GlobalStats {
+        env.storage()
+            .instance()
+            .get(&StorageKey::GlobalStats)
+            .unwrap_or(GlobalStats {
+                total_attestations: 0,
+                total_revocations: 0,
+                total_issuers: 0,
+            })
+    }
+
+    fn set_global_stats(env: &Env, stats: &GlobalStats) {
+        let ttl = get_ttl_lifetime(env);
+        env.storage().instance().set(&StorageKey::GlobalStats, stats);
+        env.storage().instance().extend_ttl(ttl, ttl);
+    }
+
+    pub fn increment_total_attestations(env: &Env, count: u64) {
+        let mut stats = Self::get_global_stats(env);
+        stats.total_attestations = stats.total_attestations.saturating_add(count);
+        Self::set_global_stats(env, &stats);
+    }
+
+    pub fn increment_total_revocations(env: &Env, count: u64) {
+        let mut stats = Self::get_global_stats(env);
+        stats.total_revocations = stats.total_revocations.saturating_add(count);
+        Self::set_global_stats(env, &stats);
+    }
+
+    pub fn increment_total_issuers(env: &Env) {
+        let mut stats = Self::get_global_stats(env);
+        stats.total_issuers = stats.total_issuers.saturating_add(1);
+        Self::set_global_stats(env, &stats);
+    }
+
+    pub fn decrement_total_issuers(env: &Env) {
+        let mut stats = Self::get_global_stats(env);
+        stats.total_issuers = stats.total_issuers.saturating_sub(1);
+        Self::set_global_stats(env, &stats);
+    }
+
+    // ── Per-issuer stats ──────────────────────────────────────────────────────
+
+    pub fn get_issuer_stats(env: &Env, issuer: &Address) -> IssuerStats {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::IssuerStats(issuer.clone()))
+            .unwrap_or(IssuerStats { total_issued: 0 })
+    }
+
+    pub fn set_issuer_stats(env: &Env, issuer: &Address, stats: &IssuerStats) {
+        let key = StorageKey::IssuerStats(issuer.clone());
+        let ttl = get_ttl_lifetime(env);
+        env.storage().persistent().set(&key, stats);
+        env.storage().persistent().extend_ttl(&key, ttl, ttl);
+    }
+
+    // ── Issuer tier ───────────────────────────────────────────────────────────
+
+    pub fn get_issuer_tier(env: &Env, issuer: &Address) -> Option<IssuerTier> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::IssuerTier(issuer.clone()))
+    }
+
+    pub fn set_issuer_tier(env: &Env, issuer: &Address, tier: &IssuerTier) {
+        let key = StorageKey::IssuerTier(issuer.clone());
+        let ttl = get_ttl_lifetime(env);
+        env.storage().persistent().set(&key, tier);
+        env.storage().persistent().extend_ttl(&key, ttl, ttl);
+    }
+
+    // ── Paused flag ───────────────────────────────────────────────────────────
+
+    pub fn is_paused(env: &Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&StorageKey::Paused)
+            .unwrap_or(false)
+    }
+
+    pub fn set_paused(env: &Env, paused: bool) {
+        let ttl = get_ttl_lifetime(env);
+        env.storage().instance().set(&StorageKey::Paused, &paused);
+        env.storage().instance().extend_ttl(ttl, ttl);
+    }
+
+    // ── Storage limits ────────────────────────────────────────────────────────
+
+    pub fn get_limits(env: &Env) -> StorageLimits {
+        env.storage()
+            .instance()
+            .get(&StorageKey::StorageLimits)
+            .unwrap_or_default()
+    }
+
+    pub fn set_limits(env: &Env, limits: &StorageLimits) {
+        let ttl = get_ttl_lifetime(env);
+        env.storage().instance().set(&StorageKey::StorageLimits, limits);
+        env.storage().instance().extend_ttl(ttl, ttl);
+    }
+
+    // ── Audit log ─────────────────────────────────────────────────────────────
+
+    pub fn get_audit_log(env: &Env, attestation_id: &String) -> Vec<AuditEntry> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::AuditLog(attestation_id.clone()))
+            .unwrap_or(Vec::new(env))
+    }
+
+    pub fn append_audit_entry(env: &Env, attestation_id: &String, entry: &AuditEntry) {
+        let key = StorageKey::AuditLog(attestation_id.clone());
+        let ttl = get_ttl_lifetime(env);
+        let mut log = Self::get_audit_log(env, attestation_id);
+        log.push_back(entry.clone());
+        env.storage().persistent().set(&key, &log);
+        env.storage().persistent().extend_ttl(&key, ttl, ttl);
+    }
+
+    // ── Endorsements ──────────────────────────────────────────────────────────
+
+    pub fn get_endorsements(env: &Env, attestation_id: &String) -> Vec<Endorsement> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::Endorsements(attestation_id.clone()))
+            .unwrap_or(Vec::new(env))
+    }
+
+    pub fn add_endorsement(env: &Env, endorsement: &Endorsement) {
+        let key = StorageKey::Endorsements(endorsement.attestation_id.clone());
+        let ttl = get_ttl_lifetime(env);
+        let mut list = Self::get_endorsements(env, &endorsement.attestation_id);
+        list.push_back(endorsement.clone());
+        env.storage().persistent().set(&key, &list);
+        env.storage().persistent().extend_ttl(&key, ttl, ttl);
+    }
+
+    // ── Expiration hooks ──────────────────────────────────────────────────────
+
+    pub fn get_expiration_hook(env: &Env, subject: &Address) -> Option<ExpirationHook> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::ExpirationHook(subject.clone()))
+    }
+
+    pub fn set_expiration_hook(env: &Env, subject: &Address, hook: &ExpirationHook) {
+        let key = StorageKey::ExpirationHook(subject.clone());
+        let ttl = get_ttl_lifetime(env);
+        env.storage().persistent().set(&key, hook);
+        env.storage().persistent().extend_ttl(&key, ttl, ttl);
+    }
+
+    pub fn remove_expiration_hook(env: &Env, subject: &Address) {
+        env.storage()
+            .persistent()
+            .remove(&StorageKey::ExpirationHook(subject.clone()));
+    }
+
+    // ── Multi-sig proposals ───────────────────────────────────────────────────
+
+    pub fn get_multisig_proposal(env: &Env, proposal_id: &String) -> Result<MultiSigProposal, Error> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::MultiSigProposal(proposal_id.clone()))
+            .ok_or(Error::NotFound)
+    }
+
+    pub fn set_multisig_proposal(env: &Env, proposal: &MultiSigProposal) {
+        let key = StorageKey::MultiSigProposal(proposal.id.clone());
+        let ttl = get_ttl_lifetime(env);
+        env.storage().persistent().set(&key, proposal);
+        env.storage().persistent().extend_ttl(&key, ttl, ttl);
+    }
+
+    // ── Attestation requests ──────────────────────────────────────────────────
+
+    pub fn get_attestation_request(env: &Env, request_id: &String) -> Result<AttestationRequest, Error> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::AttestationRequest(request_id.clone()))
+            .ok_or(Error::NotFound)
+    }
+
+    pub fn set_attestation_request(env: &Env, request: &AttestationRequest) {
+        let key = StorageKey::AttestationRequest(request.id.clone());
+        let ttl = get_ttl_lifetime(env);
+        env.storage().persistent().set(&key, request);
+        env.storage().persistent().extend_ttl(&key, ttl, ttl);
+    }
+
+    pub fn get_pending_requests(env: &Env, issuer: &Address) -> Vec<String> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::PendingRequests(issuer.clone()))
+            .unwrap_or(Vec::new(env))
+    }
+
+    pub fn add_pending_request(env: &Env, issuer: &Address, request_id: &String) {
+        let key = StorageKey::PendingRequests(issuer.clone());
+        let ttl = get_ttl_lifetime(env);
+        let mut list = Self::get_pending_requests(env, issuer);
+        list.push_back(request_id.clone());
+        env.storage().persistent().set(&key, &list);
+        env.storage().persistent().extend_ttl(&key, ttl, ttl);
+    }
+
+    pub fn remove_pending_request(env: &Env, issuer: &Address, request_id: &String) {
+        let key = StorageKey::PendingRequests(issuer.clone());
+        let ttl = get_ttl_lifetime(env);
+        let existing = Self::get_pending_requests(env, issuer);
+        let mut updated = Vec::new(env);
+        for id in existing.iter() {
+            if &id != request_id {
+                updated.push_back(id);
+            }
+        }
+        env.storage().persistent().set(&key, &updated);
+        env.storage().persistent().extend_ttl(&key, ttl, ttl);
+    }
+
+    // ── Rate limiting ─────────────────────────────────────────────────────────
+
+    pub fn get_rate_limit_config(env: &Env) -> Option<RateLimitConfig> {
+        env.storage()
+            .instance()
+            .get(&StorageKey::RateLimitConfig)
+    }
+
+    pub fn set_rate_limit_config(env: &Env, config: &RateLimitConfig) {
+        let ttl = get_ttl_lifetime(env);
+        env.storage().instance().set(&StorageKey::RateLimitConfig, config);
+        env.storage().instance().extend_ttl(ttl, ttl);
+    }
+
+    pub fn get_last_issuance_time(env: &Env, issuer: &Address) -> Option<u64> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::LastIssuanceTime(issuer.clone()))
+    }
+
+    pub fn set_last_issuance_time(env: &Env, issuer: &Address, timestamp: u64) {
+        let key = StorageKey::LastIssuanceTime(issuer.clone());
+        let ttl = get_ttl_lifetime(env);
+        env.storage().persistent().set(&key, &timestamp);
+        env.storage().persistent().extend_ttl(&key, ttl, ttl);
+    }
+
+    // ── Delegation ────────────────────────────────────────────────────────────
+
+    pub fn get_delegation(
+        env: &Env,
+        delegator: &Address,
+        delegate: &Address,
+        claim_type: &String,
+    ) -> Option<Delegation> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::Delegation(delegator.clone(), delegate.clone(), claim_type.clone()))
+    }
+
+    pub fn set_delegation(env: &Env, delegation: &Delegation) {
+        let key = StorageKey::Delegation(
+            delegation.delegator.clone(),
+            delegation.delegate.clone(),
+            delegation.claim_type.clone(),
+        );
+        let ttl = get_ttl_lifetime(env);
+        env.storage().persistent().set(&key, delegation);
+        env.storage().persistent().extend_ttl(&key, ttl, ttl);
+    }
+
+    pub fn remove_delegation(
+        env: &Env,
+        delegator: &Address,
+        delegate: &Address,
+        claim_type: &String,
+    ) {
+        env.storage()
+            .persistent()
+            .remove(&StorageKey::Delegation(delegator.clone(), delegate.clone(), claim_type.clone()));
+    }
+}
+
+/// Generic pagination helper: returns a slice of `items` starting at `start`
+/// with at most `limit` elements. Returns an empty Vec when `start >= items.len()`
+/// or `limit == 0`.
+pub fn paginate<T>(env: &Env, items: &Vec<T>, start: u32, limit: u32) -> Vec<T>
+where
+    T: soroban_sdk::TryFromVal<Env, soroban_sdk::Val>
+        + soroban_sdk::IntoVal<Env, soroban_sdk::Val>
+        + Clone,
+{
+    let mut result = Vec::new(env);
+    if limit == 0 {
+        return result;
+    }
+    let len = items.len();
+    if start >= len {
+        return result;
+    }
+    let end = len.min(start.saturating_add(limit));
+    for i in start..end {
+        if let Some(item) = items.get(i) {
+            result.push_back(item);
+        }
+    }
+    result
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -239,22 +239,24 @@ pub struct Delegation {
     pub claim_type: String,
     /// Optional expiration timestamp for this delegation.
     pub expiration: Option<u64>,
-#[contracterror]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum Error {
-    AlreadyInitialized = 1,
-    NotInitialized = 2,
-    Unauthorized = 3,
-    NotFound = 4,
-    DuplicateAttestation = 5,
-    AlreadyRevoked = 6,
-    Expired = 7,
-    InvalidValidFrom = 8,
-    InvalidExpiration = 9,
-    SubjectNotWhitelisted = 25,
 }
 
+/// A multi-sig attestation proposal requiring M-of-N issuer signatures.
 #[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MultiSigProposal {
+    pub id: String,
+    pub proposer: Address,
+    pub subject: Address,
+    pub claim_type: String,
+    pub required_signers: Vec<Address>,
+    pub threshold: u32,
+    pub signers: Vec<Address>,
+    pub created_at: u64,
+    pub expires_at: u64,
+    pub finalized: bool,
+}
+
 pub type AdminCouncil = Vec<Address>;
 
 impl Attestation {


### PR DESCRIPTION
## Summary

Closes #290

`bridge_attestation` previously accepted unbounded `source_chain` and `source_tx` strings, allowing storage bloat.

## Changes

- `src/errors.rs`: add `SourceRefTooLong = 35`
- `src/lib.rs`: validate lengths at the top of `bridge_attestation`
  - `source_chain` max **32** chars
  - `source_tx` max **128** chars
  - Returns `Error::SourceRefTooLong` on violation