### PR TITLE
Fix release-please workflow: remove invalid action inputs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,15 +22,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: rust
-          package-name: trustlink
           path: .
-          changelog-types: |
-            [
-              {"type": "feat", "section": "Features", "hidden": false},
-              {"type": "fix", "section": "Bug Fixes", "hidden": false},
-              {"type": "docs", "section": "Documentation", "hidden": false},
-              {"type": "test", "section": "Tests", "hidden": true},
-              {"type": "refactor", "section": "Refactoring", "hidden": false},
-              {"type": "perf", "section": "Performance", "hidden": false},
-              {"type": "chore", "section": "Miscellaneous", "hidden": true}
-            ]


### PR DESCRIPTION
closes #316 

- Remove invalid 'package-name' input from release-please action
- Remove invalid 'changelog-types' input from release-please action
- Keep valid inputs: token, release-type, and path
- Resolves GitHub workflow validation errors