### PR TITLE
Add comprehensive KYC-gated lending cross-contract integration tests

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -248,3 +248,428 @@ mod tests {
     }
 }
     
+
+// =============================================================================
+// Comprehensive KYC-gated lending scenario
+//
+// This module adds a richer mock lending contract and a full end-to-end
+// scenario that walks through every KYC state transition in sequence:
+//
+//   1. Borrower has no KYC              → loan denied  (KYCRequired)
+//   2. Borrower receives KYC            → loan approved
+//   3. KYC revoked mid-loan             → subsequent borrow denied (KYCRequired)
+//   4. New KYC issued but expires       → subsequent borrow denied (KYCRequired)
+//
+// The mock lending contract is intentionally minimal: it checks KYC on every
+// call so that state changes in TrustLink are immediately visible.
+// =============================================================================
+
+/// A second, independent lending contract used only by this module so that
+/// the existing `LendingContract` above is not disturbed.
+#[contract]
+pub struct KycLendingContract;
+
+#[contractimpl]
+impl KycLendingContract {
+    /// Attempt to open a loan position.
+    ///
+    /// Checks `KYC_PASSED` on every call — no cached state — so that any
+    /// change to the TrustLink attestation is reflected immediately.
+    ///
+    /// # Errors
+    /// - [`LendingError::KYCRequired`]           — borrower has no valid KYC.
+    /// - [`LendingError::InsufficientCollateral`] — collateral < amount / 2.
+    pub fn open_loan(
+        env: Env,
+        borrower: Address,
+        trustlink_id: Address,
+        amount: i128,
+        collateral: i128,
+    ) -> Result<(), LendingError> {
+        borrower.require_auth();
+
+        let trustlink = TrustLinkContractClient::new(&env, &trustlink_id);
+        let kyc_claim = String::from_str(&env, "KYC_PASSED");
+
+        if !trustlink.has_valid_claim(&borrower, &kyc_claim) {
+            return Err(LendingError::KYCRequired);
+        }
+
+        if collateral < amount / 2 {
+            return Err(LendingError::InsufficientCollateral);
+        }
+
+        // Record the open position keyed by borrower.
+        env.storage().instance().set(&borrower, &amount);
+        Ok(())
+    }
+
+    /// Return the outstanding loan amount for `borrower`, or 0 if none.
+    pub fn loan_balance(env: Env, borrower: Address) -> i128 {
+        env.storage()
+            .instance()
+            .get::<Address, i128>(&borrower)
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod kyc_lending_scenario {
+    use super::*;
+    use soroban_sdk::testutils::Ledger;
+
+    // -------------------------------------------------------------------------
+    // Shared setup
+    // -------------------------------------------------------------------------
+
+    /// Deploy TrustLink + KycLendingContract and return ready-to-use clients
+    /// together with the key actors.
+    ///
+    /// Returns `(trustlink, lending, trustlink_id, admin, issuer, borrower)`.
+    fn deploy(
+        env: &Env,
+    ) -> (
+        TrustLinkContractClient<'_>,
+        KycLendingContractClient<'_>,
+        Address, // trustlink contract address
+        Address, // admin
+        Address, // issuer
+        Address, // borrower
+    ) {
+        let trustlink_id = env.register_contract(None, TrustLinkContract);
+        let trustlink = TrustLinkContractClient::new(env, &trustlink_id);
+
+        let lending_id = env.register_contract(None, KycLendingContract);
+        let lending = KycLendingContractClient::new(env, &lending_id);
+
+        let admin = Address::generate(env);
+        let issuer = Address::generate(env);
+        let borrower = Address::generate(env);
+
+        // Initialise TrustLink at a non-zero timestamp so that native
+        // attestations (which use the current ledger timestamp as their own
+        // timestamp) are always in the past relative to any future expiration.
+        env.ledger().with_mut(|li| li.timestamp = 1_000);
+        trustlink.initialize(&admin, &None);
+        trustlink.register_issuer(&admin, &issuer);
+
+        (trustlink, lending, trustlink_id, admin, issuer, borrower)
+    }
+
+    /// Issue a native KYC attestation for `borrower` at the current ledger
+    /// timestamp, optionally with an expiration.
+    fn issue_kyc(
+        env: &Env,
+        trustlink: &TrustLinkContractClient<'_>,
+        issuer: &Address,
+        borrower: &Address,
+        expiration: Option<u64>,
+    ) -> String {
+        let kyc_claim = String::from_str(env, "KYC_PASSED");
+        trustlink.create_attestation(issuer, borrower, &kyc_claim, &expiration, &None, &None)
+    }
+
+    // -------------------------------------------------------------------------
+    // Comprehensive end-to-end scenario
+    // -------------------------------------------------------------------------
+
+    /// Walk through all four KYC state transitions in a single scenario so
+    /// that the causal chain is explicit and easy to follow in CI output.
+    #[test]
+    fn test_kyc_lending_full_lifecycle() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (trustlink, lending, trustlink_id, _admin, issuer, borrower) = deploy(&env);
+
+        // ------------------------------------------------------------------
+        // Phase 1: no KYC → loan denied
+        // ------------------------------------------------------------------
+        let result = lending.try_open_loan(&borrower, &trustlink_id, &1_000, &500);
+        assert_eq!(
+            result,
+            Err(Ok(LendingError::KYCRequired)),
+            "Phase 1: borrower without KYC must be denied"
+        );
+        assert_eq!(
+            lending.loan_balance(&borrower),
+            0,
+            "Phase 1: no loan position must be recorded"
+        );
+
+        // ------------------------------------------------------------------
+        // Phase 2: KYC issued → loan approved
+        // ------------------------------------------------------------------
+        // Advance time so the attestation timestamp is strictly in the past
+        // relative to any future expiration we set later.
+        env.ledger().with_mut(|li| li.timestamp = 5_000);
+        let attestation_id = issue_kyc(&env, &trustlink, &issuer, &borrower, None);
+
+        let result = lending.try_open_loan(&borrower, &trustlink_id, &1_000, &500);
+        assert_eq!(
+            result,
+            Ok(Ok(())),
+            "Phase 2: borrower with valid KYC must be approved"
+        );
+        assert_eq!(
+            lending.loan_balance(&borrower),
+            1_000,
+            "Phase 2: loan position must be recorded"
+        );
+
+        // Verify the attestation is genuinely valid in TrustLink.
+        let kyc_claim = String::from_str(&env, "KYC_PASSED");
+        assert!(
+            trustlink.has_valid_claim(&borrower, &kyc_claim),
+            "Phase 2: has_valid_claim must return true"
+        );
+
+        // ------------------------------------------------------------------
+        // Phase 3: KYC revoked mid-loan → subsequent borrow denied
+        // ------------------------------------------------------------------
+        trustlink.revoke_attestation(&issuer, &attestation_id, &Some(String::from_str(&env, "Compliance hold")));
+
+        // TrustLink must immediately reflect the revocation.
+        assert!(
+            !trustlink.has_valid_claim(&borrower, &kyc_claim),
+            "Phase 3: has_valid_claim must return false after revocation"
+        );
+
+        let result = lending.try_open_loan(&borrower, &trustlink_id, &2_000, &1_000);
+        assert_eq!(
+            result,
+            Err(Ok(LendingError::KYCRequired)),
+            "Phase 3: revoked KYC must cause loan denial"
+        );
+
+        // The existing loan position is unchanged — the contract only gates
+        // new borrows, it does not auto-liquidate on KYC loss.
+        assert_eq!(
+            lending.loan_balance(&borrower),
+            1_000,
+            "Phase 3: existing loan position must be unchanged after revocation"
+        );
+
+        // ------------------------------------------------------------------
+        // Phase 4: new KYC issued with expiration → expires → borrow denied
+        // ------------------------------------------------------------------
+        // Advance time and issue a fresh KYC that expires at 20_000.
+        env.ledger().with_mut(|li| li.timestamp = 10_000);
+        let _new_attestation_id =
+            issue_kyc(&env, &trustlink, &issuer, &borrower, Some(20_000));
+
+        // While KYC is valid a new borrow succeeds.
+        let result = lending.try_open_loan(&borrower, &trustlink_id, &500, &250);
+        assert_eq!(
+            result,
+            Ok(Ok(())),
+            "Phase 4: fresh KYC must allow a new borrow before expiration"
+        );
+
+        // Advance past the expiration timestamp.
+        env.ledger().with_mut(|li| li.timestamp = 20_001);
+
+        assert!(
+            !trustlink.has_valid_claim(&borrower, &kyc_claim),
+            "Phase 4: has_valid_claim must return false after expiration"
+        );
+
+        let result = lending.try_open_loan(&borrower, &trustlink_id, &500, &250);
+        assert_eq!(
+            result,
+            Err(Ok(LendingError::KYCRequired)),
+            "Phase 4: expired KYC must cause loan denial"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Focused individual tests (each isolated, no shared state)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_borrower_without_kyc_is_denied() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (_trustlink, lending, trustlink_id, _admin, _issuer, borrower) = deploy(&env);
+
+        let result = lending.try_open_loan(&borrower, &trustlink_id, &1_000, &500);
+        assert_eq!(
+            result,
+            Err(Ok(LendingError::KYCRequired)),
+            "A borrower with no attestation must receive KYCRequired"
+        );
+    }
+
+    #[test]
+    fn test_borrower_with_kyc_is_approved() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (trustlink, lending, trustlink_id, _admin, issuer, borrower) = deploy(&env);
+
+        env.ledger().with_mut(|li| li.timestamp = 5_000);
+        issue_kyc(&env, &trustlink, &issuer, &borrower, None);
+
+        let result = lending.try_open_loan(&borrower, &trustlink_id, &1_000, &500);
+        assert_eq!(
+            result,
+            Ok(Ok(())),
+            "A borrower with a valid KYC attestation must be approved"
+        );
+        assert_eq!(lending.loan_balance(&borrower), 1_000);
+    }
+
+    #[test]
+    fn test_kyc_revoked_mid_loan_denies_subsequent_borrow() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (trustlink, lending, trustlink_id, _admin, issuer, borrower) = deploy(&env);
+
+        // Issue KYC and open an initial loan.
+        env.ledger().with_mut(|li| li.timestamp = 5_000);
+        let attestation_id = issue_kyc(&env, &trustlink, &issuer, &borrower, None);
+
+        lending
+            .try_open_loan(&borrower, &trustlink_id, &1_000, &500)
+            .expect("initial loan must succeed");
+
+        // Revoke KYC with an explicit reason.
+        trustlink.revoke_attestation(
+            &issuer,
+            &attestation_id,
+            &Some(String::from_str(&env, "AML flag")),
+        );
+
+        // Verify the attestation record reflects the revocation.
+        let att = trustlink.get_attestation(&attestation_id);
+        assert!(att.revoked, "attestation must be marked revoked");
+        assert_eq!(
+            att.revocation_reason,
+            Some(String::from_str(&env, "AML flag")),
+            "revocation reason must be stored"
+        );
+
+        // Subsequent borrow attempt must be denied.
+        let result = lending.try_open_loan(&borrower, &trustlink_id, &500, &250);
+        assert_eq!(
+            result,
+            Err(Ok(LendingError::KYCRequired)),
+            "revoked KYC must deny subsequent borrows"
+        );
+    }
+
+    #[test]
+    fn test_kyc_expiration_denies_subsequent_borrow() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (trustlink, lending, trustlink_id, _admin, issuer, borrower) = deploy(&env);
+
+        // Issue KYC that expires at timestamp 15_000.
+        env.ledger().with_mut(|li| li.timestamp = 5_000);
+        let attestation_id = issue_kyc(&env, &trustlink, &issuer, &borrower, Some(15_000));
+
+        // Loan succeeds while KYC is valid.
+        lending
+            .try_open_loan(&borrower, &trustlink_id, &1_000, &500)
+            .expect("loan must succeed before KYC expiration");
+
+        // Confirm the attestation has the expected expiration.
+        let att = trustlink.get_attestation(&attestation_id);
+        assert_eq!(att.expiration, Some(15_000));
+
+        // Advance time to exactly the expiration boundary — still valid at
+        // timestamp == expiration - 1.
+        env.ledger().with_mut(|li| li.timestamp = 14_999);
+        let result = lending.try_open_loan(&borrower, &trustlink_id, &100, &50);
+        assert_eq!(
+            result,
+            Ok(Ok(())),
+            "loan must still be approved one ledger before expiration"
+        );
+
+        // Advance past expiration.
+        env.ledger().with_mut(|li| li.timestamp = 15_001);
+
+        let kyc_claim = String::from_str(&env, "KYC_PASSED");
+        assert!(
+            !trustlink.has_valid_claim(&borrower, &kyc_claim),
+            "has_valid_claim must return false after expiration"
+        );
+
+        let result = lending.try_open_loan(&borrower, &trustlink_id, &500, &250);
+        assert_eq!(
+            result,
+            Err(Ok(LendingError::KYCRequired)),
+            "expired KYC must deny subsequent borrows"
+        );
+    }
+
+    #[test]
+    fn test_insufficient_collateral_is_distinct_from_kyc_failure() {
+        // Ensures the two error paths are independent: a borrower with valid
+        // KYC but insufficient collateral gets InsufficientCollateral, not
+        // KYCRequired.
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (trustlink, lending, trustlink_id, _admin, issuer, borrower) = deploy(&env);
+
+        env.ledger().with_mut(|li| li.timestamp = 5_000);
+        issue_kyc(&env, &trustlink, &issuer, &borrower, None);
+
+        // collateral (100) < amount / 2 (500) → InsufficientCollateral
+        let result = lending.try_open_loan(&borrower, &trustlink_id, &1_000, &100);
+        assert_eq!(
+            result,
+            Err(Ok(LendingError::InsufficientCollateral)),
+            "under-collateralised loan must return InsufficientCollateral, not KYCRequired"
+        );
+    }
+
+    #[test]
+    fn test_second_borrower_unaffected_by_first_borrowers_kyc_revocation() {
+        // Revocation of one borrower's KYC must not affect another borrower
+        // who holds their own independent attestation.
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (trustlink, lending, trustlink_id, _admin, issuer, borrower_a) = deploy(&env);
+        let borrower_b = Address::generate(&env);
+
+        env.ledger().with_mut(|li| li.timestamp = 5_000);
+        let id_a = issue_kyc(&env, &trustlink, &issuer, &borrower_a, None);
+
+        env.ledger().with_mut(|li| li.timestamp = 6_000);
+        issue_kyc(&env, &trustlink, &issuer, &borrower_b, None);
+
+        // Both borrowers can open loans.
+        lending
+            .try_open_loan(&borrower_a, &trustlink_id, &1_000, &500)
+            .expect("borrower_a initial loan must succeed");
+        lending
+            .try_open_loan(&borrower_b, &trustlink_id, &1_000, &500)
+            .expect("borrower_b initial loan must succeed");
+
+        // Revoke only borrower_a's KYC.
+        trustlink.revoke_attestation(&issuer, &id_a, &None);
+
+        // borrower_a is now denied.
+        let result_a = lending.try_open_loan(&borrower_a, &trustlink_id, &500, &250);
+        assert_eq!(
+            result_a,
+            Err(Ok(LendingError::KYCRequired)),
+            "borrower_a must be denied after their KYC is revoked"
+        );
+
+        // borrower_b is still approved — their attestation is independent.
+        let result_b = lending.try_open_loan(&borrower_b, &trustlink_id, &500, &250);
+        assert_eq!(
+            result_b,
+            Ok(Ok(())),
+            "borrower_b must remain approved; their KYC was not revoked"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `KycLendingContract` mock and a `kyc_lending_scenario` test module to
`tests/integration_test.rs` covering the full attestation lifecycle as seen
from a consuming contract.

## What's Added

### `KycLendingContract`
A second independent mock lending contract (distinct from the existing
`LendingContract`) with an `open_loan` entry point that re-checks `KYC_PASSED`
on every call — no cached state — so any TrustLink state change is immediately
visible to the test.

this pr Closes #338 

### Tests

| Test | Scenario |
|------|----------|
| `test_kyc_lending_full_lifecycle` | End-to-end chain: no KYC → KYC issued → KYC revoked → new KYC expires, all four state transitions in one scenario |
| `test_borrower_without_kyc_is_denied` | Isolated: no attestation → `KYCRequired` |
| `test_borrower_with_kyc_is_approved` | Isolated: valid attestation → loan approved, balance recorded |
| `test_kyc_revoked_mid_loan_denies_subsequent_borrow` | Isolated: revocation with reason → `KYCRequired`, reason stored on attestation |
| `test_kyc_expiration_denies_subsequent_borrow` | Isolated: boundary check at `expiration - 1` (still valid) and `expiration + 1` (denied) |
| `test_insufficient_collateral_is_distinct_from_kyc_failure` | Ensures `InsufficientCollateral` and `KYCRequired` are independent error paths |
| `test_second_borrower_unaffected_by_first_borrowers_kyc_revocation` | Revocation of one borrower's KYC must not affect another borrower's independent attestation |

## Design Notes

- Uses `create_attestation` (native) rather than `import_attestation` so the
  tests exercise the primary issuance path.
- All timestamp manipulation uses `env.ledger().with_mut(|li| li.timestamp = ...)`
  matching the existing test conventions in this file.
- The new module is fully isolated — it does not share state with the existing
  `tests` module above it.

## Related

Closes #<issue-number>
