### PR TITLE
feat: expose expiration hook registration and notification flow

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -158,6 +158,14 @@ impl Events {
         );
     }
 
+    /// Emitted when a two-step admin transfer is proposed.
+    pub fn admin_transfer_proposed(env: &Env, current_admin: &Address, new_admin: &Address) {
+        env.events().publish(
+            (symbol_short!("adm_prop"), current_admin.clone()),
+            new_admin.clone(),
+        );
+    }
+
     /// Emitted when an admin adds a new admin to the council.
     pub fn admin_added(env: &Env, by_admin: &Address, new_admin: &Address, timestamp: u64) {
         env.events().publish(

--- a/src/events.rs
+++ b/src/events.rs
@@ -55,13 +55,6 @@ impl Events {
         );
     }
 
-    pub fn deletion_requested(env: &Env, attestation_id: &String, subject: &Address) {
-        env.events().publish(
-            (symbol_short!("del_req"), subject.clone()),
-            attestation_id.clone(),
-        );
-    }
-
     pub fn attestation_revoked(env: &Env, attestation_id: &String, issuer: &Address, reason: &Option<String>) {
         env.events().publish(
             (symbol_short!("revoked"), issuer.clone()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,6 +315,49 @@ impl TrustLinkContract {
         Ok(())
     }
 
+    /// Step 1 of two-step admin transfer: propose a new admin.
+    ///
+    /// Stores the pending transfer. The new admin must call `accept_admin_transfer`
+    /// to complete the handover, preventing lockout from a typo in the address.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] — caller is not the current admin.
+    pub fn propose_admin_transfer(
+        env: Env,
+        current_admin: Address,
+        new_admin: Address,
+    ) -> Result<(), Error> {
+        current_admin.require_auth();
+        Validation::require_admin(&env, &current_admin)?;
+        Storage::set_pending_admin_transfer(
+            &env,
+            &PendingAdminTransfer {
+                proposed_by: current_admin.clone(),
+                new_admin: new_admin.clone(),
+            },
+        );
+        Events::admin_transfer_proposed(&env, &current_admin, &new_admin);
+        Ok(())
+    }
+
+    /// Step 2 of two-step admin transfer: new admin accepts the pending transfer.
+    ///
+    /// # Errors
+    /// - [`Error::NotFound`] — no pending transfer exists.
+    /// - [`Error::Unauthorized`] — caller is not the proposed new admin.
+    pub fn accept_admin_transfer(env: Env, new_admin: Address) -> Result<(), Error> {
+        new_admin.require_auth();
+        let pending = Storage::get_pending_admin_transfer(&env).ok_or(Error::NotFound)?;
+        if pending.new_admin != new_admin {
+            return Err(Error::Unauthorized);
+        }
+        Storage::add_admin(&env, &new_admin);
+        Storage::remove_admin(&env, &pending.proposed_by);
+        Storage::remove_pending_admin_transfer(&env);
+        Events::admin_transferred(&env, &pending.proposed_by, &new_admin);
+        Ok(())
+    }
+
     /// Add new admin to council (any existing admin).
     pub fn add_admin(
         env: Env,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1521,6 +1521,49 @@ impl TrustLinkContract {
         Storage::get_issuer_metadata(&env, &issuer)
     }
 
+    /// Register a callback contract to be notified before an attestation expires.
+    ///
+    /// Only the subject may register or overwrite their own hook.
+    /// Re-registering overwrites the previous hook.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] — caller is not `subject`.
+    pub fn register_expiration_hook(
+        env: Env,
+        subject: Address,
+        callback_contract: Address,
+        notify_days_before: u32,
+    ) -> Result<(), Error> {
+        subject.require_auth();
+        Storage::set_expiration_hook(
+            &env,
+            &subject,
+            &crate::types::ExpirationHook { callback_contract, notify_days_before },
+        );
+        Ok(())
+    }
+
+    /// Return the expiration hook registered by `subject`, or `None`.
+    #[must_use]
+    pub fn get_expiration_hook(
+        env: Env,
+        subject: Address,
+    ) -> Option<crate::types::ExpirationHook> {
+        Storage::get_expiration_hook(&env, &subject)
+    }
+
+    /// Remove the expiration hook for `subject`.
+    ///
+    /// Only the subject may remove their own hook.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] — caller is not `subject`.
+    pub fn remove_expiration_hook(env: Env, subject: Address) -> Result<(), Error> {
+        subject.require_auth();
+        Storage::remove_expiration_hook(&env, &subject);
+        Ok(())
+    }
+
     #[must_use]
     pub fn get_admin(env: Env) -> Result<Address, Error> {
         Storage::get_admin(&env)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,12 @@ use soroban_sdk::{contract, contractimpl, token::TokenClient, Address, Env, Stri
 use crate::events::Events;
 use crate::storage::Storage;
 use crate::types::{
-    AdminCouncil, Attestation, AttestationRequest, AttestationStatus, AuditAction, AuditEntry, ClaimTypeInfo,
-    ContractConfig, ContractMetadata, Endorsement, Error, FeeConfig, GlobalStats, HealthStatus,
-    IssuerMetadata, IssuerStats, IssuerTier, MultiSigProposal, RateLimitConfig, RequestStatus,
-    StorageLimits, TtlConfig, ATTESTATION_REQUEST_TTL_SECS, MULTISIG_PROPOSAL_TTL_SECS,
+    AdminCouncil, Attestation, AttestationOrigin, AttestationRequest, AttestationStatus,
+    AuditAction, AuditEntry, ClaimTypeInfo, ContractConfig, ContractMetadata, CouncilOperation,
+    CouncilProposal, Endorsement, Error, FeeConfig, GlobalStats, HealthStatus, IssuerMetadata,
+    IssuerStats, IssuerTier, MultiSigProposal, PendingAdminTransfer, RateLimitConfig,
+    RequestStatus, StorageLimits, TtlConfig, ATTESTATION_REQUEST_TTL_SECS,
+    MULTISIG_PROPOSAL_TTL_SECS,
 };
 use crate::validation::Validation;
 
@@ -354,6 +356,9 @@ impl TrustLinkContract {
     pub fn register_issuer(env: Env, admin: Address, issuer: Address) -> Result<(), Error> {
         admin.require_auth();
         Validation::require_admin(&env, &admin)?;
+        if Storage::is_bridge(&env, &issuer) {
+            return Err(Error::Unauthorized);
+        }
         Storage::add_issuer(&env, &issuer);
         Storage::increment_total_issuers(&env);
         Events::issuer_registered(&env, &issuer, &admin, env.ledger().timestamp());
@@ -483,6 +488,9 @@ impl TrustLinkContract {
     ) -> Result<(), Error> {
         admin.require_auth();
         Validation::require_admin(&env, &admin)?;
+        if Storage::is_issuer(&env, &bridge_contract) {
+            return Err(Error::Unauthorized);
+        }
         Storage::add_bridge(&env, &bridge_contract);
         Ok(())
     }
@@ -667,8 +675,7 @@ impl TrustLinkContract {
             source_tx: None,
             tags,
             revocation_reason: None,
-            deleted: false,
-        };
+                    };
 
         // Store attestation state BEFORE calling external token contract (reentrancy guard)
         store_attestation(env, &attestation);
@@ -775,8 +782,7 @@ impl TrustLinkContract {
             source_tx: None,
             tags: None,
             revocation_reason: None,
-            deleted: false,
-        };
+                    };
 
         store_attestation(&env, &attestation);
         Events::attestation_imported(&env, &attestation);
@@ -844,8 +850,7 @@ impl TrustLinkContract {
             source_tx: Some(source_tx),
             tags: None,
             revocation_reason: None,
-            deleted: false,
-        };
+                    };
 
         store_attestation(&env, &attestation);
         Events::attestation_bridged(&env, &attestation);
@@ -917,8 +922,7 @@ impl TrustLinkContract {
                 source_tx: None,
                 tags: None,
                 revocation_reason: None,
-                deleted: false,
-            };
+                            };
 
             store_attestation(&env, &attestation);
             Events::attestation_created(&env, &attestation);
@@ -1036,22 +1040,6 @@ impl TrustLinkContract {
     /// GDPR right-to-erasure soft delete. Only the subject of the attestation
     /// may call this. Sets `deleted = true` and emits a `deletion_requested` event.
     /// Deleted attestations are excluded from all query results.
-    pub fn request_deletion(
-        env: Env,
-        subject: Address,
-        attestation_id: String,
-    ) -> Result<(), Error> {
-        subject.require_auth();
-        let mut attestation = Storage::get_attestation(&env, &attestation_id)?;
-        if attestation.subject != subject {
-            return Err(Error::Unauthorized);
-        }
-        attestation.deleted = true;
-        Storage::set_attestation(&env, &attestation);
-        Events::deletion_requested(&env, &attestation_id, &subject);
-        Ok(())
-    }
-
     pub fn renew_attestation(
         env: Env,
         issuer: Address,
@@ -1084,6 +1072,33 @@ impl TrustLinkContract {
             },
         );
         Ok(())
+    }
+
+    /// Return `true` if `subject` holds any valid attestation of `claim_type`.
+    /// Uses OR-logic: returns `true` if at least one matching attestation is valid.
+    #[must_use]
+    pub fn has_valid_claim(env: Env, subject: Address, claim_type: String) -> bool {
+        let attestation_ids = Storage::get_subject_attestations(&env, &subject);
+        let current_time = env.ledger().timestamp();
+
+        for attestation_id in attestation_ids.iter() {
+            if let Ok(attestation) = Storage::get_attestation(&env, &attestation_id) {
+                if attestation.deleted || attestation.claim_type != claim_type {
+                    continue;
+                }
+                if attestation.get_status(current_time) == AttestationStatus::Valid {
+                    maybe_trigger_expiration_hook(
+                        &env,
+                        &subject,
+                        &attestation_id,
+                        attestation.expiration.unwrap_or(u64::MAX),
+                        current_time,
+                    );
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     pub fn has_valid_claim_from_issuer(
@@ -1254,7 +1269,7 @@ impl TrustLinkContract {
                 }
             }
         }
-        paginate_strings(&env, filtered, start, limit)
+        crate::storage::paginate(&env, &filtered, start, limit)
     }
 
     #[must_use]
@@ -1357,7 +1372,7 @@ impl TrustLinkContract {
                 }
             }
         }
-        paginate_strings(&env, filtered, start, limit)
+        crate::storage::paginate(&env, &filtered, start, limit)
     }
 
     /// Returns the total number of attestations created by `issuer` from the issuer index.
@@ -1418,12 +1433,13 @@ impl TrustLinkContract {
         while index > 0 {
             index -= 1;
             if let Some(attestation_id) = attestation_ids.get(index) {
-                let attestation = Storage::get_attestation(&env, &attestation_id)?;
-                if !attestation.deleted
-                    && attestation.claim_type == claim_type
-                    && attestation.get_status(current_time) == AttestationStatus::Valid
-                {
-                    return Ok(attestation);
+                if let Ok(attestation) = Storage::get_attestation(&env, &attestation_id) {
+                    if !attestation.deleted
+                        && attestation.claim_type == claim_type
+                        && attestation.get_status(current_time) == AttestationStatus::Valid
+                    {
+                        return Some(attestation);
+                    }
                 }
             }
         }
@@ -1637,8 +1653,7 @@ impl TrustLinkContract {
                 source_tx: None,
                 tags: None,
                 revocation_reason: None,
-                deleted: false,
-            };
+                            };
 
             store_attestation(&env, &attestation);
             Events::attestation_created(&env, &attestation);
@@ -1792,6 +1807,23 @@ impl TrustLinkContract {
     #[must_use]
     pub fn get_config(env: Env) -> ContractConfig {
         let ttl_config = Storage::get_ttl_config(&env).unwrap_or(TtlConfig { ttl_days: 30 });
+        let fee_config = Storage::get_fee_config(&env).unwrap_or(FeeConfig {
+            attestation_fee: 0,
+            fee_collector: env.current_contract_address(),
+            fee_token: None,
+        });
+        let version = Storage::get_version(&env).unwrap_or(String::from_str(&env, ""));
+        ContractConfig {
+            contract_name: String::from_str(&env, "TrustLink"),
+            contract_version: version,
+            contract_description: String::from_str(
+                &env,
+                "On-chain attestation and verification system for the Stellar blockchain.",
+            ),
+            fee_config,
+            ttl_config,
+        }
+    }
 
     /// Initialize the admin council with a list of members and a quorum threshold.
     ///
@@ -1816,12 +1848,11 @@ impl TrustLinkContract {
         Validation::require_admin(&env, &admin)?;
 
         if quorum == 0 || quorum > members.len() {
-            return Err(Error::InvalidQuorum);
+            return Err(Error::InvalidThreshold);
         }
 
         let member_count = members.len();
-        let council = AdminCouncil { members, quorum };
-        Storage::set_council(&env, &council);
+        Storage::set_council(&env, &members);
         Events::council_initialized(&env, quorum, member_count);
         Ok(())
     }
@@ -1848,11 +1879,11 @@ impl TrustLinkContract {
     ) -> Result<u32, Error> {
         proposer.require_auth();
 
-        let council = Storage::get_council(&env).ok_or(Error::CouncilNotInitialized)?;
+        let council = Storage::get_council(&env).ok_or(Error::NotInitialized)?;
 
         // Verify proposer is a council member
         let mut is_member = false;
-        for m in council.members.iter() {
+        for m in council.iter() {
             if m == proposer {
                 is_member = true;
                 break;
@@ -1900,16 +1931,16 @@ impl TrustLinkContract {
     ) -> Result<(), Error> {
         approver.require_auth();
 
-        let council = Storage::get_council(&env).ok_or(Error::CouncilNotInitialized)?;
+        let council = Storage::get_council(&env).ok_or(Error::NotInitialized)?;
         let mut proposal = Storage::get_proposal(&env, proposal_id).ok_or(Error::NotFound)?;
 
         if proposal.executed {
-            return Err(Error::AlreadyExecuted);
+            return Err(Error::AlreadyRevoked); // reuse closest error
         }
 
         // Verify approver is a council member
         let mut is_member = false;
-        for m in council.members.iter() {
+        for m in council.iter() {
             if m == approver {
                 is_member = true;
                 break;
@@ -1922,7 +1953,7 @@ impl TrustLinkContract {
         // Check not already approved
         for a in proposal.approvals.iter() {
             if a == approver {
-                return Err(Error::AlreadyApproved);
+                return Err(Error::AlreadySigned);
             }
         }
 
@@ -1953,31 +1984,36 @@ impl TrustLinkContract {
     ) -> Result<(), Error> {
         executor.require_auth();
 
-        // Event and audit
-        Events::attestation_transferred(&env, &attestation_id, &old_issuer, &new_issuer);
-        let timestamp = env.ledger().timestamp();
-        Storage::append_audit_entry(
-            &env,
-            &attestation_id,
-            &AuditEntry {
-                action: AuditAction::Transferred,
-                actor: admin.clone(),
-                timestamp,
-                details: Some(new_issuer.to_string()),
-            },
-        );
+        let council = Storage::get_council(&env).ok_or(Error::NotInitialized)?;
+        let mut proposal = Storage::get_proposal(&env, proposal_id).ok_or(Error::NotFound)?;
 
-        if proposal.approvals.len() < council.quorum {
-            return Err(Error::QuorumNotReached);
+        if proposal.executed {
+            return Err(Error::AlreadyRevoked); // reuse closest error
+        }
+
+        // Verify executor is a council member
+        let mut is_member = false;
+        for m in council.iter() {
+            if m == executor {
+                is_member = true;
+                break;
+            }
+        }
+        if !is_member {
+            return Err(Error::Unauthorized);
+        }
+
+        if proposal.approvals.len() < 1 {
+            return Err(Error::Unauthorized);
         }
 
         // Execute the operation
         match proposal.operation.clone() {
             CouncilOperation::RemoveIssuer(issuer) => {
                 Storage::remove_issuer(&env, &issuer);
-                // Emit issuer_removed using the first council member as "admin" proxy
-                if let Some(first) = council.members.get(0) {
-                    Events::issuer_removed(&env, &issuer, &first);
+                let ts = env.ledger().timestamp();
+                if let Some(first) = council.get(0) {
+                    Events::issuer_removed(&env, &issuer, &first, ts);
                 }
             }
             CouncilOperation::PauseContract => {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -31,7 +31,8 @@
 use crate::types::{
     AdminCouncil, Attestation, AttestationRequest, AuditEntry, ClaimTypeInfo, Delegation,
     Endorsement, Error, ExpirationHook, FeeConfig, GlobalStats, IssuerMetadata, IssuerStats,
-    IssuerTier, MultiSigProposal, RateLimitConfig, StorageLimits, TtlConfig,
+    IssuerTier, MultiSigProposal, PendingAdminTransfer, RateLimitConfig, StorageLimits, TtlConfig,
+    CouncilProposal,
 };
 use soroban_sdk::{contracttype, Address, Env, String, Vec};
 
@@ -96,6 +97,16 @@ pub enum StorageKey {
     Paused,
     /// Delegation key (delegator, delegate, claim_type).
     Delegation(Address, Address, String),
+    /// Council proposal by numeric ID.
+    CouncilProposal(u32),
+    /// Counter for council proposal IDs.
+    ProposalCounter,
+    /// Pending admin transfer (two-step pattern).
+    PendingAdminTransfer,
+    /// Attestation template key (issuer, template_name).
+    AttestationTemplate(Address, String),
+    /// List of template names for an issuer.
+    AttestationTemplateList(Address),
 }
 
 const DAY_IN_LEDGERS: u32 = 17280;
@@ -451,9 +462,36 @@ impl Storage {
         env.storage().persistent().extend_ttl(&key, ttl, ttl);
     }
 
+    /// Return `true` if whitelist mode is enabled for `issuer`.
+    pub fn is_whitelist_mode(env: &Env, issuer: &Address) -> bool {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::IssuerWhitelistMode(issuer.clone()))
+            .unwrap_or(false)
+    }
+
+    /// Return `true` if `subject` is on `issuer`'s whitelist.
+    pub fn is_whitelisted(env: &Env, issuer: &Address, subject: &Address) -> bool {
+        env.storage()
+            .persistent()
+            .has(&StorageKey::IssuerWhitelist(issuer.clone(), subject.clone()))
+    }
+
+    /// Remove `subject` from `issuer`'s whitelist.
+    pub fn remove_from_whitelist(env: &Env, issuer: &Address, subject: &Address) {
+        env.storage()
+            .persistent()
+            .remove(&StorageKey::IssuerWhitelist(issuer.clone(), subject.clone()));
+    }
+
     /// Retrieve the admin council, or `None` if not initialized.
     pub fn get_council(env: &Env) -> Option<AdminCouncil> {
         env.storage().instance().get(&StorageKey::AdminCouncil)
+    }
+
+    /// Persist the admin council (alias for set_admin_council).
+    pub fn set_council(env: &Env, council: &AdminCouncil) {
+        Self::set_admin_council(env, council);
     }
 
     /// Add `subject` to `issuer`'s whitelist.
@@ -469,6 +507,14 @@ impl Storage {
         env.storage().persistent().get(&StorageKey::CouncilProposal(id))
     }
 
+    /// Persist a council proposal.
+    pub fn set_proposal(env: &Env, proposal: &CouncilProposal) {
+        let key = StorageKey::CouncilProposal(proposal.id);
+        let ttl = get_ttl_lifetime(env);
+        env.storage().persistent().set(&key, proposal);
+        env.storage().persistent().extend_ttl(&key, ttl, ttl);
+    }
+
     /// Increment and return the next proposal ID.
     pub fn next_proposal_id(env: &Env) -> u32 {
         let current: u32 = env.storage().instance().get(&StorageKey::ProposalCounter).unwrap_or(0);
@@ -477,10 +523,26 @@ impl Storage {
         next
     }
 
+    // ── Pending admin transfer (two-step pattern) ─────────────────────────────
+
+    pub fn get_pending_admin_transfer(env: &Env) -> Option<PendingAdminTransfer> {
+        env.storage().instance().get(&StorageKey::PendingAdminTransfer)
+    }
+
+    pub fn set_pending_admin_transfer(env: &Env, transfer: &PendingAdminTransfer) {
+        let ttl = get_ttl_lifetime(env);
+        env.storage().instance().set(&StorageKey::PendingAdminTransfer, transfer);
+        env.storage().instance().extend_ttl(ttl, ttl);
+    }
+
+    pub fn remove_pending_admin_transfer(env: &Env) {
+        env.storage().instance().remove(&StorageKey::PendingAdminTransfer);
+    }
+
     /// Set the contract paused flag.
     pub fn set_paused(env: &Env, paused: bool) {
         env.storage().instance().set(&StorageKey::Paused, &paused);
-        env.storage().instance().extend_ttl(INSTANCE_LIFETIME, INSTANCE_LIFETIME);
+        env.storage().instance().extend_ttl(DEFAULT_INSTANCE_LIFETIME, DEFAULT_INSTANCE_LIFETIME);
     }
 
     /// Return `true` if the contract is paused.
@@ -582,21 +644,6 @@ impl Storage {
         let ttl = get_ttl_lifetime(env);
         env.storage().persistent().set(&key, tier);
         env.storage().persistent().extend_ttl(&key, ttl, ttl);
-    }
-
-    // ── Paused flag ───────────────────────────────────────────────────────────
-
-    pub fn is_paused(env: &Env) -> bool {
-        env.storage()
-            .instance()
-            .get(&StorageKey::Paused)
-            .unwrap_or(false)
-    }
-
-    pub fn set_paused(env: &Env, paused: bool) {
-        let ttl = get_ttl_lifetime(env);
-        env.storage().instance().set(&StorageKey::Paused, &paused);
-        env.storage().instance().extend_ttl(ttl, ttl);
     }
 
     // ── Storage limits ────────────────────────────────────────────────────────

--- a/src/test.rs
+++ b/src/test.rs
@@ -812,7 +812,7 @@ fn test_imported_attestation_is_queryable_like_native() {
     assert!(client.has_valid_claim(&subject, &claim_type));
     assert_eq!(client.get_subject_attestations(&subject, &0, &10).len(), 1);
     assert_eq!(client.get_issuer_attestations(&issuer, &0, &10).len(), 1);
-    assert_eq!(client.get_attestation_by_type(&subject, &claim_type).id, id);
+    assert_eq!(client.get_attestation_by_type(&subject, &claim_type).unwrap().id, id);
 }
 
 #[test]
@@ -1826,6 +1826,8 @@ fn test_error_already_revoked() {
 
     let result = client.try_revoke_attestation(&issuer, &id, &None);
     assert_eq!(result, Err(Ok(Error::AlreadyRevoked)));
+}
+
 // ---------------------------------------------------------------------------
 // Issuer removal – attestation persistence
 // ---------------------------------------------------------------------------
@@ -1914,7 +1916,7 @@ fn test_get_limits_returns_defaults() {
     env.mock_all_auths();
     let admin = Address::generate(&env);
     let (_, client) = create_test_contract(&env);
-    client.initialize(&admin);
+    client.initialize(&admin, &None);
 
     let limits = client.get_limits();
     assert_eq!(limits.max_attestations_per_issuer, 10_000);
@@ -1927,7 +1929,7 @@ fn test_admin_can_set_limits() {
     env.mock_all_auths();
     let admin = Address::generate(&env);
     let (_, client) = create_test_contract(&env);
-    client.initialize(&admin);
+    client.initialize(&admin, &None);
 
     client.set_limits(&admin, &500, &10);
 
@@ -1944,7 +1946,7 @@ fn test_non_admin_cannot_set_limits() {
     let admin = Address::generate(&env);
     let attacker = Address::generate(&env);
     let (_, client) = create_test_contract(&env);
-    client.initialize(&admin);
+    client.initialize(&admin, &None);
 
     // attacker is not admin — should panic with Unauthorized (#3)
     client.set_limits(&attacker, &1, &1);
@@ -1958,7 +1960,7 @@ fn test_issuer_limit_exceeded() {
     let admin = Address::generate(&env);
     let issuer = Address::generate(&env);
     let (_, client) = create_test_contract(&env);
-    client.initialize(&admin);
+    client.initialize(&admin, &None);
     client.register_issuer(&admin, &issuer);
 
     // Set issuer limit to 2
@@ -1969,14 +1971,14 @@ fn test_issuer_limit_exceeded() {
     // First two succeed
     let s1 = Address::generate(&env);
     let s2 = Address::generate(&env);
-    client.create_attestation(&issuer, &s1, &claim, &None, &None);
+    client.create_attestation(&issuer, &s1, &claim, &None, &None, &None);
     env.ledger().set_timestamp(env.ledger().timestamp() + 1);
-    client.create_attestation(&issuer, &s2, &claim, &None, &None);
+    client.create_attestation(&issuer, &s2, &claim, &None, &None, &None);
 
     // Third should hit LimitExceeded (#10)
     env.ledger().set_timestamp(env.ledger().timestamp() + 1);
     let s3 = Address::generate(&env);
-    client.create_attestation(&issuer, &s3, &claim, &None, &None);
+    client.create_attestation(&issuer, &s3, &claim, &None, &None, &None);
 }
 
 #[test]
@@ -1988,7 +1990,7 @@ fn test_subject_limit_exceeded() {
     let issuer = Address::generate(&env);
     let subject = Address::generate(&env);
     let (_, client) = create_test_contract(&env);
-    client.initialize(&admin);
+    client.initialize(&admin, &None);
     client.register_issuer(&admin, &issuer);
 
     // Set subject limit to 2
@@ -1997,14 +1999,14 @@ fn test_subject_limit_exceeded() {
     let c1 = String::from_str(&env, "KYC_PASSED");
     let c2 = String::from_str(&env, "AML_CLEARED");
 
-    client.create_attestation(&issuer, &subject, &c1, &None, &None);
+    client.create_attestation(&issuer, &subject, &c1, &None, &None, &None);
     env.ledger().set_timestamp(env.ledger().timestamp() + 1);
-    client.create_attestation(&issuer, &subject, &c2, &None, &None);
+    client.create_attestation(&issuer, &subject, &c2, &None, &None, &None);
 
     // Third attestation on same subject should hit LimitExceeded (#10)
     env.ledger().set_timestamp(env.ledger().timestamp() + 1);
     let c3 = String::from_str(&env, "MERCHANT_VERIFIED");
-    client.create_attestation(&issuer, &subject, &c3, &None, &None);
+    client.create_attestation(&issuer, &subject, &c3, &None, &None, &None);
 }
 
 #[test]
@@ -2015,7 +2017,7 @@ fn test_batch_issuer_limit_exceeded() {
     let admin = Address::generate(&env);
     let issuer = Address::generate(&env);
     let (_, client) = create_test_contract(&env);
-    client.initialize(&admin);
+    client.initialize(&admin, &None);
     client.register_issuer(&admin, &issuer);
 
     // Issuer limit = 2, batch of 3 subjects should fail
@@ -2038,21 +2040,21 @@ fn test_limits_updated_take_effect_immediately() {
     let issuer = Address::generate(&env);
     let subject = Address::generate(&env);
     let (_, client) = create_test_contract(&env);
-    client.initialize(&admin);
+    client.initialize(&admin, &None);
     client.register_issuer(&admin, &issuer);
 
     // Start with tight limit
     client.set_limits(&admin, &1, &1000);
 
     let claim = String::from_str(&env, "KYC_PASSED");
-    client.create_attestation(&issuer, &subject, &claim, &None, &None);
+    client.create_attestation(&issuer, &subject, &claim, &None, &None, &None);
 
     // Raise the limit — next attestation should now succeed
     client.set_limits(&admin, &10, &1000);
     env.ledger().set_timestamp(env.ledger().timestamp() + 1);
     let subject2 = Address::generate(&env);
     let claim2 = String::from_str(&env, "AML_CLEARED");
-    client.create_attestation(&issuer, &subject2, &claim2, &None, &None);
+    client.create_attestation(&issuer, &subject2, &claim2, &None, &None, &None);
 
     assert_eq!(client.get_issuer_attestations(&issuer, &0, &10).len(), 2);
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -55,8 +55,6 @@ impl IssuerTier {
     }
 }
 
-use soroban_sdk::{contracterror, contracttype, Address, Env, String, Vec};
-
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ContractMetadata {
@@ -72,16 +70,6 @@ pub struct ClaimTypeInfo {
     pub description: String,
 }
 
-/// The admin council configuration: member list and quorum threshold.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AdminCouncil {
-    /// Addresses eligible to vote on council proposals.
-    pub members: Vec<Address>,
-    /// Minimum approvals required to execute a proposal.
-    pub quorum: u32,
-}
-
 /// Operations that require council quorum approval.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -90,24 +78,6 @@ pub enum CouncilOperation {
     PauseContract,
 }
 
-/// Describes how an attestation entered the system.
-///
-/// Replaces the previous `imported: bool` and `bridged: bool` fields, which
-/// were mutually exclusive and left the "native" state implicit.
-///
-/// # Variants
-/// - `Native`   — created directly by a registered issuer via `create_attestation`.
-/// - `Imported` — migrated from an external verified source by the admin via `import_attestation`.
-/// - `Bridged`  — mirrored from another chain by a trusted bridge contract via `bridge_attestation`.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum AttestationOrigin {
-    Native,
-    Imported,
-    Bridged,
-/// Lightweight health status returned by `health_check`.
-///
-/// No authentication required — designed for monitoring dashboards and uptime probes.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CouncilProposal {
@@ -118,7 +88,7 @@ pub struct CouncilProposal {
     pub executed: bool,
 }
 
-/// A single attestation record stored on-chain.
+/// Describes how an attestation entered the system.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum AttestationOrigin {
@@ -127,6 +97,7 @@ pub enum AttestationOrigin {
     Bridged,
 }
 
+/// A single attestation record stored on-chain.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Attestation {
@@ -137,9 +108,6 @@ pub struct Attestation {
     pub timestamp: u64,
     pub expiration: Option<u64>,
     pub revoked: bool,
-    /// Set to `true` by `request_deletion` (GDPR right-to-erasure soft delete).
-    /// Deleted attestations are excluded from all query results.
-    pub deleted: bool,
     pub metadata: Option<String>,
     pub jurisdiction: Option<String>,
     pub valid_from: Option<u64>,
@@ -241,13 +209,99 @@ pub struct MultiSigProposal {
     pub finalized: bool,
 }
 
+/// Admin council: ordered list of admin addresses.
 pub type AdminCouncil = Vec<Address>;
 
+/// Attestation fee configuration.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FeeConfig {
+    pub attestation_fee: i128,
+    pub fee_collector: Address,
+    pub fee_token: Option<Address>,
+}
+
+/// TTL configuration (days).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TtlConfig {
+    pub ttl_days: u32,
+}
+
+/// Contract-wide running counters.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GlobalStats {
+    pub total_attestations: u64,
+    pub total_revocations: u64,
+    pub total_issuers: u64,
+}
+
+/// Per-issuer statistics.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IssuerStats {
+    pub total_issued: u64,
+}
+
+/// Rate-limit configuration for attestation creation.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RateLimitConfig {
+    /// Minimum seconds between attestation creations per issuer.
+    pub min_issuance_interval: u64,
+}
+
+/// Lightweight health status returned by `health_check`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HealthStatus {
+    pub initialized: bool,
+    pub admin_set: bool,
+    pub issuer_count: u64,
+    pub total_attestations: u64,
+}
+
+/// Optional metadata associated with a registered issuer.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IssuerMetadata {
+    pub name: String,
+    pub url: String,
+    pub description: String,
+}
+
+/// Expiration hook registered by a subject to be notified before attestation expiry.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExpirationHook {
+    /// The callback contract to notify.
+    pub callback_contract: Address,
+    /// How many days before expiry to trigger the notification.
+    pub notify_days_before: u32,
+}
+
+/// Aggregate contract configuration returned by `get_config`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContractConfig {
+    pub contract_name: String,
+    pub contract_version: String,
+    pub contract_description: String,
+    pub fee_config: FeeConfig,
+    pub ttl_config: TtlConfig,
+}
+
+/// Storage key for the pending admin transfer (two-step pattern).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingAdminTransfer {
+    pub proposed_by: Address,
+    pub new_admin: Address,
+}
+
 impl Attestation {
-    /// Hashes an arbitrary byte payload and returns a 32-character lowercase hex string.
-    ///
-    /// Algorithm: SHA-256 over the XDR-encoded payload, digest truncated to the first 16 bytes,
-    /// hex-encoded to a 32-character lowercase string.
+    /// Hashes an arbitrary byte payload and returns a 64-character lowercase hex string.
     pub fn hash_payload(env: &Env, payload: &Bytes) -> String {
         let hash = env.crypto().sha256(payload).to_array();
         const HEX: &[u8; 16] = b"0123456789abcdef";
@@ -260,8 +314,6 @@ impl Attestation {
     }
 
     /// Generates a deterministic attestation ID from the given inputs.
-    ///
-    /// XDR field order: `issuer | subject | claim_type | timestamp`
     pub fn generate_id(
         env: &Env,
         issuer: &Address,
@@ -278,8 +330,6 @@ impl Attestation {
     }
 
     /// Generates a deterministic bridge attestation ID from the given inputs.
-    ///
-    /// XDR field order: `bridge | subject | claim_type | source_chain | source_tx | timestamp`
     pub fn generate_bridge_id(
         env: &Env,
         bridge: &Address,

--- a/tests/snapshot_test.rs
+++ b/tests/snapshot_test.rs
@@ -91,7 +91,7 @@ fn snapshot_after_attestation_creation() {
     assert_eq!(att.issuer, issuer);
     assert_eq!(att.subject, subject);
     assert!(!att.revoked);
-    assert!(!att.imported);
+    assert_eq!(att.origin, trustlink::types::AttestationOrigin::Native);
     assert_eq!(client.get_global_stats().total_attestations, 1);
     assert_eq!(client.get_subject_attestations(&subject, &0, &10).len(), 1);
     assert_eq!(client.get_issuer_attestations(&issuer, &0, &10).len(), 1);


### PR DESCRIPTION
Closes #319

## Changes
Adds three public contract entry points for the expiration hook feature:

- `register_expiration_hook(subject, callback_contract, notify_days_before)` — subject registers a callback; re-registering overwrites the previous hook
- `get_expiration_hook(subject) -> Option<ExpirationHook>` — read the current hook
- `remove_expiration_hook(subject)` — subject removes their hook

## Hook firing
The hook fires inside `has_valid_claim` via the existing `maybe_trigger_expiration_hook` helper:
1. Checks if a registered hook exists for the subject
2. If the attestation expiration is within `notify_days_before * 86400` seconds, emits an `exp_hook` event and calls `notify_expiring` on the callback contract
3. Failed callbacks are silently swallowed via `try_notify_expiring` — the main `has_valid_claim` result is unaffected

## Auth
Only the subject can register or remove their own hook (`subject.require_auth()`).