### PR TITLE
feat(sdk): add missing contract methods to TypeScript client

### DIFF
--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -13,6 +13,7 @@ import {
 
 import type {
   Attestation,
+  AttestationRequest,
   AttestationStatus,
   AuditEntry,
   ClaimTypeInfo,
@@ -333,6 +334,125 @@ export class TrustLinkClient {
 
   async getMultisigProposal(proposalId: string): Promise<MultiSigProposal> {
     return this.simulate("get_multisig_proposal", this.str(proposalId));
+  }
+
+  async proposeAttestation(
+    proposer: string,
+    subject: string,
+    claimType: string,
+    requiredSigners: string[],
+    threshold: number
+  ): Promise<SorobanRpc.Api.SimulateTransactionResponse> {
+    const account = new Account(proposer, "0");
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(
+        this.contract.call(
+          "propose_attestation",
+          this.addr(proposer),
+          this.addr(subject),
+          this.str(claimType),
+          nativeToScVal(requiredSigners.map((s) => Address.fromString(s).toScVal()), { type: "array" }),
+          this.u32(threshold)
+        )
+      )
+      .setTimeout(30)
+      .build();
+    return this.server.simulateTransaction(tx);
+  }
+
+  async cosignAttestation(
+    issuer: string,
+    proposalId: string
+  ): Promise<SorobanRpc.Api.SimulateTransactionResponse> {
+    const account = new Account(issuer, "0");
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(
+        this.contract.call("cosign_attestation", this.addr(issuer), this.str(proposalId))
+      )
+      .setTimeout(30)
+      .build();
+    return this.server.simulateTransaction(tx);
+  }
+
+  // ── Attestation Requests ───────────────────────────────────────────────────
+
+  async requestAttestation(
+    subject: string,
+    issuer: string,
+    claimType: string
+  ): Promise<SorobanRpc.Api.SimulateTransactionResponse> {
+    const account = new Account(subject, "0");
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(
+        this.contract.call(
+          "request_attestation",
+          this.addr(subject),
+          this.addr(issuer),
+          this.str(claimType)
+        )
+      )
+      .setTimeout(30)
+      .build();
+    return this.server.simulateTransaction(tx);
+  }
+
+  async fulfillRequest(
+    issuer: string,
+    requestId: string,
+    expiration?: bigint
+  ): Promise<SorobanRpc.Api.SimulateTransactionResponse> {
+    const account = new Account(issuer, "0");
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(
+        this.contract.call(
+          "fulfill_request",
+          this.addr(issuer),
+          this.str(requestId),
+          this.optU64(expiration ?? null)
+        )
+      )
+      .setTimeout(30)
+      .build();
+    return this.server.simulateTransaction(tx);
+  }
+
+  async rejectRequest(
+    issuer: string,
+    requestId: string,
+    reason?: string
+  ): Promise<SorobanRpc.Api.SimulateTransactionResponse> {
+    const account = new Account(issuer, "0");
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(
+        this.contract.call(
+          "reject_request",
+          this.addr(issuer),
+          this.str(requestId),
+          this.optStr(reason ?? null)
+        )
+      )
+      .setTimeout(30)
+      .build();
+    return this.server.simulateTransaction(tx);
+  }
+
+  async getAttestationRequest(requestId: string): Promise<AttestationRequest> {
+    return this.simulate("get_attestation_request", this.str(requestId));
   }
 
   // ── Endorsements ──────────────────────────────────────────────────────────

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -111,6 +111,19 @@ export interface ExpirationHook {
   notify_days_before: number;
 }
 
+export type RequestStatus = "Pending" | "Fulfilled" | "Rejected";
+
+export interface AttestationRequest {
+  id: string;
+  subject: string;
+  issuer: string;
+  claim_type: string;
+  timestamp: bigint;
+  expires_at: bigint;
+  status: RequestStatus;
+  rejection_reason: string | null;
+}
+
 /** Error codes returned by the TrustLink contract. */
 export enum TrustLinkError {
   AlreadyInitialized = 1,


### PR DESCRIPTION
- proposeAttestation / cosignAttestation (multi-sig workflow)
- requestAttestation / fulfillRequest / rejectRequest (pull-based request workflow)
- getAttestationRequest (read query)
- Add AttestationRequest and RequestStatus types to types.ts

closes #345 