### PR TITLE
test: add tests for issues #340 #341 #342 #343

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,6 +278,24 @@ impl TrustLinkContract {
         Ok(())
     }
 
+    /// Cancel a pending two-step admin transfer.
+    ///
+    /// Only the current admin who proposed the transfer may cancel it.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] — caller is not the current admin.
+    /// - [`Error::NotFound`] — no pending transfer exists.
+    pub fn cancel_admin_transfer(env: Env, current_admin: Address) -> Result<(), Error> {
+        current_admin.require_auth();
+        Validation::require_admin(&env, &current_admin)?;
+        let pending = Storage::get_pending_admin_transfer(&env).ok_or(Error::NotFound)?;
+        if pending.proposed_by != current_admin {
+            return Err(Error::Unauthorized);
+        }
+        Storage::remove_pending_admin_transfer(&env);
+        Ok(())
+    }
+
     /// Step 2 of two-step admin transfer: new admin accepts the pending transfer.
     ///
     /// # Errors
@@ -2028,6 +2046,43 @@ impl TrustLinkContract {
     /// - [`Error::CannotEndorseOwn`] — endorser is the attestation's issuer.
     /// - [`Error::AlreadyRevoked`] — attestation has been revoked.
     /// - [`Error::AlreadyEndorsed`] — endorser has already endorsed this attestation.
+    pub fn endorse_attestation(env: Env, endorser: Address, attestation_id: String) -> Result<(), Error> {
+        endorser.require_auth();
+        Validation::require_issuer(&env, &endorser)?;
+        Validation::require_not_paused(&env)?;
+
+        let attestation = Storage::get_attestation(&env, &attestation_id)?;
+
+        if attestation.issuer == endorser {
+            return Err(Error::CannotEndorseOwn);
+        }
+        if attestation.revoked {
+            return Err(Error::AlreadyRevoked);
+        }
+
+        // Check for duplicate endorsement.
+        let existing = Storage::get_endorsements(&env, &attestation_id);
+        for e in existing.iter() {
+            if e.endorser == endorser {
+                return Err(Error::AlreadyEndorsed);
+            }
+        }
+
+        let endorsement = Endorsement {
+            attestation_id: attestation_id.clone(),
+            endorser: endorser.clone(),
+            timestamp: env.ledger().timestamp(),
+        };
+        Storage::add_endorsement(&env, &attestation_id, &endorsement);
+        Ok(())
+    }
+
+    /// Return the number of endorsements for `attestation_id`.
+    #[must_use]
+    pub fn get_endorsement_count(env: Env, attestation_id: String) -> u32 {
+        Storage::get_endorsements(&env, &attestation_id).len()
+    }
+
     /// Delegate authority to create attestations of `claim_type` to `delegate`.
     ///
     /// # Errors

--- a/src/test.rs
+++ b/src/test.rs
@@ -4475,3 +4475,496 @@ mod import_attestation_tests {
         );
     }
 }
+
+// =============================================================================
+// Issue #342 — Two-step admin transfer tests
+// =============================================================================
+#[cfg(test)]
+mod two_step_admin_transfer_tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env, String};
+
+    fn setup(env: &Env) -> (Address, TrustLinkContractClient<'_>) {
+        let contract_id = env.register_contract(None, TrustLinkContract);
+        let client = TrustLinkContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        client.initialize(&admin, &None);
+        (admin, client)
+    }
+
+    /// Propose transfer → pending admin stored (NotFound before, succeeds after).
+    #[test]
+    fn test_propose_transfer_stores_pending() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, client) = setup(&env);
+        let new_admin = Address::generate(&env);
+
+        // Before proposal, accept should fail with NotFound.
+        let before = client.try_accept_admin_transfer(&new_admin);
+        assert_eq!(before, Err(Ok(Error::NotFound)));
+
+        // Propose the transfer.
+        client.propose_admin_transfer(&admin, &new_admin);
+
+        // Now accept should succeed (pending is stored).
+        client.accept_admin_transfer(&new_admin);
+        assert_eq!(client.get_admin(), Ok(new_admin));
+    }
+
+    /// Wrong address tries to accept → Unauthorized.
+    #[test]
+    fn test_wrong_address_cannot_accept() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, client) = setup(&env);
+        let new_admin = Address::generate(&env);
+        let wrong = Address::generate(&env);
+
+        client.propose_admin_transfer(&admin, &new_admin);
+
+        let result = client.try_accept_admin_transfer(&wrong);
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
+
+        // Original admin still in place.
+        assert_eq!(client.get_admin(), Ok(admin));
+    }
+
+    /// Correct new admin accepts → admin updated.
+    #[test]
+    fn test_correct_new_admin_accepts_and_becomes_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, client) = setup(&env);
+        let new_admin = Address::generate(&env);
+
+        client.propose_admin_transfer(&admin, &new_admin);
+        client.accept_admin_transfer(&new_admin);
+
+        assert_eq!(client.get_admin(), Ok(new_admin.clone()));
+    }
+
+    /// Old admin loses privileges after transfer completes.
+    #[test]
+    fn test_old_admin_loses_privileges_after_transfer() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, client) = setup(&env);
+        let new_admin = Address::generate(&env);
+        let issuer = Address::generate(&env);
+
+        client.propose_admin_transfer(&admin, &new_admin);
+        client.accept_admin_transfer(&new_admin);
+
+        // Old admin can no longer register issuers.
+        let result = client.try_register_issuer(&admin, &issuer);
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
+
+        // New admin can.
+        client.register_issuer(&new_admin, &issuer);
+        assert!(client.is_issuer(&issuer));
+    }
+
+    /// Propose then cancel → pending cleared.
+    #[test]
+    fn test_propose_then_cancel_clears_pending() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, client) = setup(&env);
+        let new_admin = Address::generate(&env);
+
+        // Propose the transfer.
+        client.propose_admin_transfer(&admin, &new_admin);
+
+        // Cancel it.
+        client.cancel_admin_transfer(&admin);
+
+        // Accept should now fail with NotFound — pending is cleared.
+        let result = client.try_accept_admin_transfer(&new_admin);
+        assert_eq!(result, Err(Ok(Error::NotFound)));
+
+        // Original admin still in place.
+        assert_eq!(client.get_admin(), Ok(admin));
+    }
+
+    /// Non-admin cannot propose a transfer.
+    #[test]
+    fn test_non_admin_cannot_propose_transfer() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client) = setup(&env);
+        let non_admin = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+
+        let result = client.try_propose_admin_transfer(&non_admin, &new_admin);
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
+    }
+}
+
+// =============================================================================
+// Issue #340 — get_attestations_in_range boundary condition tests
+// =============================================================================
+#[cfg(test)]
+mod attestations_in_range_boundary_tests {
+    use super::*;
+    use soroban_sdk::{testutils::{Address as _, Ledger}, Env, String};
+
+    fn setup(env: &Env) -> (Address, Address, TrustLinkContractClient<'_>) {
+        let contract_id = env.register_contract(None, TrustLinkContract);
+        let client = TrustLinkContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        let issuer = Address::generate(env);
+        client.initialize(&admin, &None);
+        client.register_issuer(&admin, &issuer);
+        (admin, issuer, client)
+    }
+
+    /// from_ts == to_ts with no attestation at that timestamp → empty result.
+    #[test]
+    fn test_equal_timestamps_no_attestation_returns_empty() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, _, client) = setup(&env);
+        let subject = Address::generate(&env);
+
+        let result = client.get_attestations_in_range(&subject, &500, &500, &0, &10);
+        assert_eq!(result.len(), 0);
+    }
+
+    /// Attestation at exactly from_ts → included.
+    #[test]
+    fn test_attestation_at_exactly_from_ts_is_included() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, issuer, client) = setup(&env);
+        let subject = Address::generate(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+
+        env.ledger().set_timestamp(1000);
+        let id = client.create_attestation(&issuer, &subject, &claim, &None, &None, &None);
+
+        // Query with from_ts == attestation timestamp.
+        let result = client.get_attestations_in_range(&subject, &1000, &2000, &0, &10);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.get(0).unwrap().id, id);
+    }
+
+    /// Attestation at exactly to_ts → included (inclusive upper bound).
+    #[test]
+    fn test_attestation_at_exactly_to_ts_is_included() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, issuer, client) = setup(&env);
+        let subject = Address::generate(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+
+        env.ledger().set_timestamp(2000);
+        let id = client.create_attestation(&issuer, &subject, &claim, &None, &None, &None);
+
+        // Query with to_ts == attestation timestamp.
+        let result = client.get_attestations_in_range(&subject, &1000, &2000, &0, &10);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.get(0).unwrap().id, id);
+    }
+
+    /// from_ts == to_ts and attestation exists at that exact timestamp → included.
+    #[test]
+    fn test_equal_timestamps_with_attestation_returns_one() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, issuer, client) = setup(&env);
+        let subject = Address::generate(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+
+        env.ledger().set_timestamp(750);
+        let id = client.create_attestation(&issuer, &subject, &claim, &None, &None, &None);
+
+        let result = client.get_attestations_in_range(&subject, &750, &750, &0, &10);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.get(0).unwrap().id, id);
+    }
+
+    /// Range with no attestations → empty result.
+    #[test]
+    fn test_range_with_no_attestations_returns_empty() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, issuer, client) = setup(&env);
+        let subject = Address::generate(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+
+        // Attestation at ts=100, query range 200–300.
+        env.ledger().set_timestamp(100);
+        client.create_attestation(&issuer, &subject, &claim, &None, &None, &None);
+
+        let result = client.get_attestations_in_range(&subject, &200, &300, &0, &10);
+        assert_eq!(result.len(), 0);
+    }
+
+    /// Attestation just before from_ts → excluded.
+    #[test]
+    fn test_attestation_just_before_from_ts_excluded() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, issuer, client) = setup(&env);
+        let subject = Address::generate(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+
+        env.ledger().set_timestamp(999);
+        client.create_attestation(&issuer, &subject, &claim, &None, &None, &None);
+
+        let result = client.get_attestations_in_range(&subject, &1000, &2000, &0, &10);
+        assert_eq!(result.len(), 0);
+    }
+
+    /// Attestation just after to_ts → excluded.
+    #[test]
+    fn test_attestation_just_after_to_ts_excluded() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, issuer, client) = setup(&env);
+        let subject = Address::generate(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+
+        env.ledger().set_timestamp(2001);
+        client.create_attestation(&issuer, &subject, &claim, &None, &None, &None);
+
+        let result = client.get_attestations_in_range(&subject, &1000, &2000, &0, &10);
+        assert_eq!(result.len(), 0);
+    }
+}
+
+// =============================================================================
+// Issue #341 — Endorsement system tests
+// =============================================================================
+#[cfg(test)]
+mod endorsement_tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env, String};
+
+    /// Setup: contract + admin + two issuers + one subject.
+    fn setup(env: &Env) -> (Address, Address, Address, Address, TrustLinkContractClient<'_>) {
+        let contract_id = env.register_contract(None, TrustLinkContract);
+        let client = TrustLinkContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        let issuer = Address::generate(env);
+        let endorser = Address::generate(env);
+        let subject = Address::generate(env);
+        client.initialize(&admin, &None);
+        client.register_issuer(&admin, &issuer);
+        client.register_issuer(&admin, &endorser);
+        (admin, issuer, endorser, subject, client)
+    }
+
+    /// Endorse attestation → endorsement stored, count increases.
+    #[test]
+    fn test_endorse_attestation_stored() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, issuer, endorser, subject, client) = setup(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+
+        let id = client.create_attestation(&issuer, &subject, &claim, &None, &None, &None);
+        client.endorse_attestation(&endorser, &id);
+
+        let count = client.get_endorsement_count(&id);
+        assert_eq!(count, 1);
+    }
+
+    /// Cannot endorse own attestation → CannotEndorseOwn.
+    #[test]
+    fn test_cannot_endorse_own_attestation() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, issuer, _, subject, client) = setup(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+
+        let id = client.create_attestation(&issuer, &subject, &claim, &None, &None, &None);
+
+        let result = client.try_endorse_attestation(&issuer, &id);
+        assert_eq!(result, Err(Ok(Error::CannotEndorseOwn)));
+    }
+
+    /// Cannot endorse twice → AlreadyEndorsed.
+    #[test]
+    fn test_cannot_endorse_twice() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, issuer, endorser, subject, client) = setup(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+
+        let id = client.create_attestation(&issuer, &subject, &claim, &None, &None, &None);
+        client.endorse_attestation(&endorser, &id);
+
+        let result = client.try_endorse_attestation(&endorser, &id);
+        assert_eq!(result, Err(Ok(Error::AlreadyEndorsed)));
+    }
+
+    /// get_endorsement_count returns correct value after multiple endorsers.
+    #[test]
+    fn test_get_endorsement_count_correct_value() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, issuer, endorser1, subject, client) = setup(&env);
+        let endorser2 = Address::generate(&env);
+        client.register_issuer(&admin, &endorser2);
+        let claim = String::from_str(&env, "KYC_PASSED");
+
+        let id = client.create_attestation(&issuer, &subject, &claim, &None, &None, &None);
+
+        assert_eq!(client.get_endorsement_count(&id), 0);
+
+        client.endorse_attestation(&endorser1, &id);
+        assert_eq!(client.get_endorsement_count(&id), 1);
+
+        client.endorse_attestation(&endorser2, &id);
+        assert_eq!(client.get_endorsement_count(&id), 2);
+    }
+
+    /// Endorsement on revoked attestation → AlreadyRevoked.
+    #[test]
+    fn test_endorse_revoked_attestation_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, issuer, endorser, subject, client) = setup(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+
+        let id = client.create_attestation(&issuer, &subject, &claim, &None, &None, &None);
+        client.revoke_attestation(&issuer, &id, &None);
+
+        let result = client.try_endorse_attestation(&endorser, &id);
+        assert_eq!(result, Err(Ok(Error::AlreadyRevoked)));
+    }
+
+    /// Non-issuer cannot endorse → Unauthorized.
+    #[test]
+    fn test_non_issuer_cannot_endorse() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, issuer, _, subject, client) = setup(&env);
+        let non_issuer = Address::generate(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+
+        let id = client.create_attestation(&issuer, &subject, &claim, &None, &None, &None);
+
+        let result = client.try_endorse_attestation(&non_issuer, &id);
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
+    }
+}
+
+// =============================================================================
+// Issue #343 — IssuerTier assignment and enforcement tests
+// =============================================================================
+#[cfg(test)]
+mod issuer_tier_tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env, String};
+
+    fn setup(env: &Env) -> (Address, Address, TrustLinkContractClient<'_>) {
+        let contract_id = env.register_contract(None, TrustLinkContract);
+        let client = TrustLinkContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        let issuer = Address::generate(env);
+        client.initialize(&admin, &None);
+        client.register_issuer(&admin, &issuer);
+        (admin, issuer, client)
+    }
+
+    /// Default tier is Basic on registration (None or Basic).
+    #[test]
+    fn test_default_tier_is_basic_on_registration() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, issuer, client) = setup(&env);
+
+        let tier = client.get_issuer_tier(&issuer);
+        // Unset tier is treated as Basic (None maps to Basic in confidence score).
+        assert!(tier.is_none() || tier == Some(types::IssuerTier::Basic));
+    }
+
+    /// Admin can upgrade issuer to Verified.
+    #[test]
+    fn test_admin_can_set_verified_tier() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, issuer, client) = setup(&env);
+
+        client.set_issuer_tier(&admin, &issuer, &types::IssuerTier::Verified);
+        assert_eq!(client.get_issuer_tier(&issuer), Some(types::IssuerTier::Verified));
+    }
+
+    /// Admin can upgrade issuer to Premium.
+    #[test]
+    fn test_admin_can_set_premium_tier() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, issuer, client) = setup(&env);
+
+        client.set_issuer_tier(&admin, &issuer, &types::IssuerTier::Premium);
+        assert_eq!(client.get_issuer_tier(&issuer), Some(types::IssuerTier::Premium));
+    }
+
+    /// Non-admin cannot change tier → Unauthorized.
+    #[test]
+    fn test_non_admin_cannot_change_tier() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, issuer, client) = setup(&env);
+        let non_admin = Address::generate(&env);
+
+        let result = client.try_set_issuer_tier(&non_admin, &issuer, &types::IssuerTier::Premium);
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
+    }
+
+    /// Tier affects confidence score: Basic→30, Verified→60, Premium→90.
+    #[test]
+    fn test_tier_affects_confidence_score() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, issuer, client) = setup(&env);
+        let subject = Address::generate(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+
+        let id = client.create_attestation(&issuer, &subject, &claim, &None, &None, &None);
+
+        // Basic (default) → 30.
+        let score_basic = client.get_confidence_score(&id);
+        assert_eq!(score_basic, Some(30));
+
+        // Verified → 60.
+        client.set_issuer_tier(&admin, &issuer, &types::IssuerTier::Verified);
+        let score_verified = client.get_confidence_score(&id);
+        assert_eq!(score_verified, Some(60));
+
+        // Premium → 90.
+        client.set_issuer_tier(&admin, &issuer, &types::IssuerTier::Premium);
+        let score_premium = client.get_confidence_score(&id);
+        assert_eq!(score_premium, Some(90));
+    }
+
+    /// Cannot set tier for unregistered issuer → Unauthorized.
+    #[test]
+    fn test_cannot_set_tier_for_unregistered_issuer() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, _, client) = setup(&env);
+        let unregistered = Address::generate(&env);
+
+        let result = client.try_set_issuer_tier(&admin, &unregistered, &types::IssuerTier::Verified);
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
+    }
+
+    /// Admin can downgrade tier (Premium → Basic).
+    #[test]
+    fn test_admin_can_downgrade_tier() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, issuer, client) = setup(&env);
+
+        client.set_issuer_tier(&admin, &issuer, &types::IssuerTier::Premium);
+        assert_eq!(client.get_issuer_tier(&issuer), Some(types::IssuerTier::Premium));
+
+        client.set_issuer_tier(&admin, &issuer, &types::IssuerTier::Basic);
+        assert_eq!(client.get_issuer_tier(&issuer), Some(types::IssuerTier::Basic));
+    }
+}


### PR DESCRIPTION

```
## Summary

pr Closes #340  
closes #341  
closes #342  
closes #343  

Adds comprehensive test coverage for four features: two-step admin transfer,
`get_attestations_in_range` boundary conditions, the endorsement system, and
`IssuerTier` assignment/enforcement. Also implements the missing
`endorse_attestation`, `get_endorsement_count`, and `cancel_admin_transfer`
contract entry points required by the tests.

---

## Changes

### `src/lib.rs`

New contract functions:
- `endorse_attestation` — registered issuers endorse an attestation with guards for own/revoked/duplicate
- `get_endorsement_count` — returns endorsement count for an attestation
- `cancel_admin_transfer` — proposing admin can cancel a pending two-step transfer

### `src/test.rs`

Four new test modules:

**`two_step_admin_transfer_tests`** (#342)
- propose → pending stored, accept succeeds
- wrong address → `Unauthorized`
- correct new admin accepts → admin updated
- old admin loses privileges after transfer
- propose then cancel → `NotFound` on accept
- non-admin cannot propose → `Unauthorized`

**`attestations_in_range_boundary_tests`** (#340)
- `from_ts == to_ts` with no attestation → empty
- attestation at exactly `from_ts` → included
- attestation at exactly `to_ts` → included
- `from_ts == to_ts` with attestation → one result
- range with no attestations → empty
- just before `from_ts` → excluded
- just after `to_ts` → excluded

**`endorsement_tests`** (#341)
- endorse → stored, count = 1
- cannot endorse own → `CannotEndorseOwn`
- cannot endorse twice → `AlreadyEndorsed`
- count increments correctly with multiple endorsers
- endorse revoked attestation → `AlreadyRevoked`
- non-issuer cannot endorse → `Unauthorized`

**`issuer_tier_tests`** (#343)
- default tier is Basic on registration
- admin upgrades to Verified / Premium
- non-admin blocked → `Unauthorized`
- tier affects confidence score (Basic=30, Verified=60, Premium=90)
- unregistered issuer blocked → `Unauthorized`
- admin can downgrade tier
```

---

