### PR TITLE
feat: implement attestation valid_from lifecycle with Pending status

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,20 @@ fn validate_native_expiration(env: &Env, expiration: Option<u64>) -> Result<(), 
     Ok(())
 }
 
+/// Validate that `valid_from`, when provided, is strictly in the future.
+///
+/// A `valid_from` equal to or before the current ledger timestamp would
+/// immediately resolve to `Valid`, making the field meaningless. Callers
+/// that want an immediately-active attestation should omit `valid_from`.
+fn validate_valid_from(env: &Env, valid_from: Option<u64>) -> Result<(), Error> {
+    if let Some(vf) = valid_from {
+        if vf <= env.ledger().timestamp() {
+            return Err(Error::InvalidValidFrom);
+        }
+    }
+    Ok(())
+}
+
 fn validate_import_timestamps(env: &Env, timestamp: u64, expiration: Option<u64>) -> Result<(), Error> {
     if timestamp > env.ledger().timestamp() {
         return Err(Error::InvalidTimestamp);
@@ -769,6 +783,7 @@ impl TrustLinkContract {
         metadata: Option<String>,
         jurisdiction: Option<String>,
         tags: Option<Vec<String>>,
+        valid_from: Option<u64>,
     ) -> Result<String, Error> {
         issuer.require_auth();
         Validation::require_not_paused(&env)?;
@@ -778,6 +793,7 @@ impl TrustLinkContract {
         validate_jurisdiction(env, &jurisdiction)?;
         validate_tags(&tags)?;
         validate_native_expiration(env, expiration)?;
+        validate_valid_from(env, valid_from)?;
 
         if issuer == subject {
             return Err(Error::Unauthorized);
@@ -824,7 +840,7 @@ impl TrustLinkContract {
             deleted: false,
             metadata,
             jurisdiction,
-            valid_from: None,
+            valid_from,
             origin: AttestationOrigin::Native,
             source_chain: None,
             source_tx: None,
@@ -864,7 +880,30 @@ impl TrustLinkContract {
         metadata: Option<String>,
         tags: Option<Vec<String>>,
     ) -> Result<String, Error> {
-        Self::create_attestation_internal(&env, issuer, subject, claim_type, expiration, metadata, None, tags)
+        Self::create_attestation_internal(&env, issuer, subject, claim_type, expiration, metadata, None, tags, None)
+    }
+
+    /// Create an attestation that becomes active only at `valid_from`.
+    ///
+    /// Until `valid_from` is reached the attestation has status `Pending` and
+    /// `has_valid_claim` returns `false` for it. Once the ledger timestamp
+    /// reaches `valid_from` the status automatically resolves to `Valid`
+    /// (assuming it is not revoked or expired).
+    ///
+    /// # Errors
+    /// - [`Error::InvalidValidFrom`] — `valid_from` is not strictly in the future.
+    /// - All errors from [`create_attestation`].
+    pub fn create_attestation_with_valid_from(
+        env: Env,
+        issuer: Address,
+        subject: Address,
+        claim_type: String,
+        expiration: Option<u64>,
+        metadata: Option<String>,
+        tags: Option<Vec<String>>,
+        valid_from: u64,
+    ) -> Result<String, Error> {
+        Self::create_attestation_internal(&env, issuer, subject, claim_type, expiration, metadata, None, tags, Some(valid_from))
     }
 
     pub fn create_attestation_jurisdiction(
@@ -877,7 +916,7 @@ impl TrustLinkContract {
         jurisdiction: Option<String>,
         tags: Option<Vec<String>>,
     ) -> Result<String, Error> {
-        Self::create_attestation_internal(&env, issuer, subject, claim_type, expiration, metadata, jurisdiction, tags)
+        Self::create_attestation_internal(&env, issuer, subject, claim_type, expiration, metadata, jurisdiction, tags, None)
     }
 
     pub fn create_attestations_batch(

--- a/src/test.rs
+++ b/src/test.rs
@@ -4475,3 +4475,282 @@ mod import_attestation_tests {
         );
     }
 }
+
+// ── valid_from / Pending lifecycle tests ─────────────────────────────────────
+
+#[cfg(test)]
+mod valid_from_lifecycle {
+    use super::*;
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Env, String,
+    };
+
+    /// Deploy contract, initialize, register one issuer; return (admin, issuer, subject, client).
+    fn setup(env: &Env) -> (Address, Address, Address, TrustLinkContractClient<'_>) {
+        let contract_id = env.register_contract(None, TrustLinkContract);
+        let client = TrustLinkContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        let issuer = Address::generate(env);
+        let subject = Address::generate(env);
+        client.initialize(&admin, &None);
+        client.register_issuer(&admin, &issuer);
+        (admin, issuer, subject, client)
+    }
+
+    // ── 1. Basic Pending → Valid transition ──────────────────────────────────
+
+    #[test]
+    fn test_pending_before_valid_from_then_valid_after() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1000);
+
+        let (_admin, issuer, subject, client) = setup(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+
+        // valid_from is 500 seconds in the future
+        let valid_from: u64 = 1500;
+        let id = client.create_attestation_with_valid_from(
+            &issuer, &subject, &claim, &None, &None, &None, &valid_from,
+        );
+
+        // Before valid_from: status must be Pending
+        assert_eq!(
+            client.get_attestation_status(&id),
+            types::AttestationStatus::Pending,
+            "status should be Pending before valid_from"
+        );
+
+        // has_valid_claim must return false while Pending
+        assert!(
+            !client.has_valid_claim(&subject, &claim),
+            "has_valid_claim must be false while attestation is Pending"
+        );
+
+        // Advance ledger to exactly valid_from
+        env.ledger().set_timestamp(valid_from);
+
+        assert_eq!(
+            client.get_attestation_status(&id),
+            types::AttestationStatus::Valid,
+            "status should be Valid at exactly valid_from"
+        );
+        assert!(
+            client.has_valid_claim(&subject, &claim),
+            "has_valid_claim must be true once valid_from is reached"
+        );
+    }
+
+    // ── 2. Boundary: one second before valid_from ─────────────────────────────
+
+    #[test]
+    fn test_pending_one_second_before_valid_from() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1000);
+
+        let (_admin, issuer, subject, client) = setup(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+        let valid_from: u64 = 2000;
+
+        let id = client.create_attestation_with_valid_from(
+            &issuer, &subject, &claim, &None, &None, &None, &valid_from,
+        );
+
+        // One second before valid_from → still Pending
+        env.ledger().set_timestamp(valid_from - 1);
+        assert_eq!(client.get_attestation_status(&id), types::AttestationStatus::Pending);
+        assert!(!client.has_valid_claim(&subject, &claim));
+
+        // Exactly at valid_from → Valid
+        env.ledger().set_timestamp(valid_from);
+        assert_eq!(client.get_attestation_status(&id), types::AttestationStatus::Valid);
+        assert!(client.has_valid_claim(&subject, &claim));
+    }
+
+    // ── 3. valid_from stored on the attestation struct ────────────────────────
+
+    #[test]
+    fn test_valid_from_stored_on_attestation() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1000);
+
+        let (_admin, issuer, subject, client) = setup(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+        let valid_from: u64 = 9999;
+
+        let id = client.create_attestation_with_valid_from(
+            &issuer, &subject, &claim, &None, &None, &None, &valid_from,
+        );
+
+        let att = client.get_attestation(&id);
+        assert_eq!(att.valid_from, Some(valid_from), "valid_from must be persisted");
+    }
+
+    // ── 4. create_attestation (no valid_from) still works as before ───────────
+
+    #[test]
+    fn test_create_attestation_without_valid_from_is_immediately_valid() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1000);
+
+        let (_admin, issuer, subject, client) = setup(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+
+        let id = client.create_attestation(&issuer, &subject, &claim, &None, &None, &None);
+
+        assert_eq!(client.get_attestation_status(&id), types::AttestationStatus::Valid);
+        assert!(client.has_valid_claim(&subject, &claim));
+
+        let att = client.get_attestation(&id);
+        assert_eq!(att.valid_from, None, "standard attestation must have valid_from = None");
+    }
+
+    // ── 5. InvalidValidFrom when valid_from is in the past ────────────────────
+
+    #[test]
+    #[should_panic]
+    fn test_create_with_past_valid_from_is_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(5000);
+
+        let (_admin, issuer, subject, client) = setup(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+
+        // valid_from in the past → must return InvalidValidFrom
+        client.create_attestation_with_valid_from(
+            &issuer, &subject, &claim, &None, &None, &None, &4999,
+        );
+    }
+
+    // ── 6. InvalidValidFrom when valid_from == current timestamp ──────────────
+
+    #[test]
+    #[should_panic]
+    fn test_create_with_valid_from_equal_to_now_is_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(5000);
+
+        let (_admin, issuer, subject, client) = setup(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+
+        // valid_from == now → must be rejected (must be strictly future)
+        client.create_attestation_with_valid_from(
+            &issuer, &subject, &claim, &None, &None, &None, &5000,
+        );
+    }
+
+    // ── 7. Pending attestation does not satisfy has_valid_claim ───────────────
+
+    #[test]
+    fn test_has_valid_claim_false_while_pending_even_with_other_claims() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1000);
+
+        let (_admin, issuer, subject, client) = setup(&env);
+        let kyc = String::from_str(&env, "KYC_PASSED");
+        let aml = String::from_str(&env, "AML_CLEARED");
+
+        // Create a valid AML attestation
+        client.create_attestation(&issuer, &subject, &aml, &None, &None, &None);
+
+        // Create a pending KYC attestation
+        client.create_attestation_with_valid_from(
+            &issuer, &subject, &kyc, &None, &None, &None, &9999,
+        );
+
+        // AML is valid
+        assert!(client.has_valid_claim(&subject, &aml));
+        // KYC is still pending
+        assert!(!client.has_valid_claim(&subject, &kyc));
+    }
+
+    // ── 8. Pending → Valid → Expired full lifecycle ───────────────────────────
+
+    #[test]
+    fn test_full_lifecycle_pending_valid_expired() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1000);
+
+        let (_admin, issuer, subject, client) = setup(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+
+        let valid_from: u64 = 2000;
+        let expiration: u64 = 3000;
+
+        let id = client.create_attestation_with_valid_from(
+            &issuer, &subject, &claim, &Some(expiration), &None, &None, &valid_from,
+        );
+
+        // Phase 1: Pending
+        env.ledger().set_timestamp(1500);
+        assert_eq!(client.get_attestation_status(&id), types::AttestationStatus::Pending);
+        assert!(!client.has_valid_claim(&subject, &claim));
+
+        // Phase 2: Valid
+        env.ledger().set_timestamp(2500);
+        assert_eq!(client.get_attestation_status(&id), types::AttestationStatus::Valid);
+        assert!(client.has_valid_claim(&subject, &claim));
+
+        // Phase 3: Expired
+        env.ledger().set_timestamp(3000);
+        assert_eq!(client.get_attestation_status(&id), types::AttestationStatus::Expired);
+        assert!(!client.has_valid_claim(&subject, &claim));
+    }
+
+    // ── 9. Revoked pending attestation stays Pending (revoked check is after) ─
+
+    #[test]
+    fn test_pending_takes_priority_over_revoked() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1000);
+
+        let (_admin, issuer, subject, client) = setup(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+
+        let id = client.create_attestation_with_valid_from(
+            &issuer, &subject, &claim, &None, &None, &None, &9999,
+        );
+
+        // Revoke while still pending
+        client.revoke_attestation(&issuer, &id, &None);
+
+        // get_status checks valid_from first, so it should still be Pending
+        assert_eq!(
+            client.get_attestation_status(&id),
+            types::AttestationStatus::Pending,
+            "Pending takes priority over Revoked per get_status ordering"
+        );
+    }
+
+    // ── 10. Far-future valid_from ─────────────────────────────────────────────
+
+    #[test]
+    fn test_far_future_valid_from_stays_pending() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1000);
+
+        let (_admin, issuer, subject, client) = setup(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+
+        // valid_from 100 years out (approx)
+        let far_future: u64 = 1000 + 100 * 365 * 24 * 3600;
+        let id = client.create_attestation_with_valid_from(
+            &issuer, &subject, &claim, &None, &None, &None, &far_future,
+        );
+
+        // Advance 10 years — still pending
+        env.ledger().set_timestamp(1000 + 10 * 365 * 24 * 3600);
+        assert_eq!(client.get_attestation_status(&id), types::AttestationStatus::Pending);
+        assert!(!client.has_valid_claim(&subject, &claim));
+    }
+}


### PR DESCRIPTION
closes #314 
- Add validate_valid_from() helper: rejects valid_from <= current timestamp
- Add create_attestation_with_valid_from() public entry point
- Wire valid_from parameter through create_attestation_internal()
- Existing create_attestation / create_attestation_jurisdiction unchanged (pass None)
- Add 10 unit tests in valid_from_lifecycle module covering:
  * Pending before valid_from, Valid at/after valid_from
  * Boundary: one second before valid_from
  * valid_from persisted on Attestation struct
  * Standard create_attestation still immediately Valid
  * InvalidValidFrom for past and equal-to-now timestamps
  * has_valid_claim false while Pending, true after
  * Full Pending -> Valid -> Expired lifecycle
  * Pending takes priority over Revoked in get_status ordering
  * Far-future valid_from stays Pending

Fixes: attestation-valid-from-lifecycle