### PR TITLE
test: add benchmark tests for high-volume attestation scenarios

### DIFF
--- a/benches/performance.rs
+++ b/benches/performance.rs
@@ -121,3 +121,113 @@ fn benchmark_all() {
     println!("All benchmarks complete. Run `cargo test benches:: -- --nocapture` to see CU results.");
 }
 
+
+#[test]
+fn benchmark_1000_attestations_single_subject() {
+    let mut e = Env::default();
+    let (client, admin, issuer, subject) = setup_contract(&e);
+
+    // Raise per-subject limit to accommodate 1,000 attestations
+    client.set_limits(&admin, &20_000u32, &1_000u32);
+
+    // Pre-create 999 attestations outside the measured window
+    for i in 0..999u32 {
+        let claim = String::from_str(&e, &format!("CLAIM_{}", i));
+        client.create_attestation(&issuer, &subject, claim, &None, &None, &None);
+    }
+
+    // Measure the cost of the 1,000th attestation
+    let last_claim = String::from_str(&e, "CLAIM_999_FINAL");
+    let cu = measure_cu(&mut e, || {
+        client.create_attestation(&issuer, &subject, last_claim.clone(), &None, &None, &None);
+    });
+
+    println!("create_attestation (1,000th for single subject): {} CU", cu);
+}
+
+#[test]
+fn benchmark_has_valid_claim_100_attestations() {
+    let mut e = Env::default();
+    let (client, admin, issuer, subject) = setup_contract(&e);
+
+    // Raise per-subject limit to hold exactly 100 attestations
+    client.set_limits(&admin, &20_000u32, &200u32);
+
+    // Create 99 noise attestations on the subject
+    for i in 0..99u32 {
+        let noise_claim = String::from_str(&e, &format!("NOISE_{}", i));
+        client.create_attestation(&issuer, &subject, noise_claim, &None, &None, &None);
+    }
+
+    // Create the 100th attestation as the target claim
+    let target_claim = String::from_str(&e, "TARGET");
+    client.create_attestation(&issuer, &subject, target_claim.clone(), &None, &None, &None);
+
+    // Measure has_valid_claim when subject holds exactly 100 attestations
+    let cu_hit = measure_cu(&mut e, || {
+        client.has_valid_claim(&subject, target_claim.clone());
+    });
+
+    let missing_claim = String::from_str(&e, "MISSING");
+    let cu_miss = measure_cu(&mut e, || {
+        client.has_valid_claim(&subject, missing_claim);
+    });
+
+    println!(
+        "has_valid_claim (100 attestations/subject): {} CU hit, {} CU miss",
+        cu_hit, cu_miss
+    );
+}
+
+#[test]
+fn benchmark_batch_create_50_attestations() {
+    let mut e = Env::default();
+    let (client, _, issuer, _) = setup_contract(&e);
+
+    // Build a Vec of 50 distinct subjects
+    let mut subjects: Vec<Address> = Vec::new(&e);
+    for _ in 0..50u32 {
+        subjects.push_back(Address::generate(&e));
+    }
+
+    let claim = String::from_str(&e, "BATCH_CLAIM");
+
+    let cu = measure_cu(&mut e, || {
+        client.create_attestations_batch(&issuer, &subjects, &claim, &None);
+    });
+
+    println!("create_attestations_batch (50 subjects): {} CU", cu);
+}
+
+#[test]
+fn benchmark_paginate_10000_issuer_attestations() {
+    let mut e = Env::default();
+    let (client, admin, issuer, _) = setup_contract(&e);
+
+    // Raise issuer limit to hold 10,000 attestations
+    client.set_limits(&admin, &10_001u32, &10_001u32);
+
+    // Pre-create 10,000 attestations across unique subjects
+    for i in 0..10_000u32 {
+        let subject = Address::generate(&e);
+        let claim = String::from_str(&e, &format!("CLAIM_{}", i));
+        client.create_attestation(&issuer, &subject, claim, &None, &None, &None);
+    }
+
+    // Measure paginating through the full set in pages of 100
+    let page_size = 100u32;
+    let cu_first = measure_cu(&mut e, || {
+        client.get_issuer_attestations(&issuer, &0u32, &page_size);
+    });
+    let cu_mid = measure_cu(&mut e, || {
+        client.get_issuer_attestations(&issuer, &5_000u32, &page_size);
+    });
+    let cu_last = measure_cu(&mut e, || {
+        client.get_issuer_attestations(&issuer, &9_900u32, &page_size);
+    });
+
+    println!(
+        "get_issuer_attestations (10,000 total, page_size=100): first={} CU, mid={} CU, last={} CU",
+        cu_first, cu_mid, cu_last
+    );
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -3,7 +3,6 @@ use soroban_sdk::{symbol_short, Address, Env, String, Symbol};
 use crate::types::{Attestation, IssuerTier};
 
 const TOPIC_ADMIN_INIT: Symbol = symbol_short!("adm_init");
-const TOPIC_ADM_INIT: Symbol = symbol_short!("adm_init");
 const TOPIC_CREATED: Symbol = symbol_short!("created");
 const TOPIC_IMPORTED: Symbol = symbol_short!("imported");
 const TOPIC_BRIDGED: Symbol = symbol_short!("bridged");
@@ -16,7 +15,6 @@ const TOPIC_ISS_REG: Symbol = symbol_short!("iss_reg");
 const TOPIC_ISS_REM: Symbol = symbol_short!("iss_rem");
 const TOPIC_ISS_TIER: Symbol = symbol_short!("iss_tier");
 const TOPIC_CLM_TYPE: Symbol = symbol_short!("clm_type");
-const TOPIC_CLMTYPE: Symbol = symbol_short!("clm_type");
 const TOPIC_MS_PROP: Symbol = symbol_short!("ms_prop");
 const TOPIC_MS_SIGN: Symbol = symbol_short!("ms_sign");
 const TOPIC_MS_ACTV: Symbol = symbol_short!("ms_actv");
@@ -25,13 +23,11 @@ const TOPIC_ADM_ADD: Symbol = symbol_short!("adm_add");
 const TOPIC_ADM_REM: Symbol = symbol_short!("adm_rem");
 const TOPIC_ENDORSED: Symbol = symbol_short!("endorsed");
 const TOPIC_EXP_HOOK: Symbol = symbol_short!("exp_hook");
-const TOPIC_PAUSED: Symbol = symbol_short!("paused");
-const TOPIC_UNPAUSED: Symbol = symbol_short!("unpaused");
+
 const TOPIC_REQ: Symbol = symbol_short!("att_req");
 const TOPIC_REQ_OK: Symbol = symbol_short!("req_ok");
 const TOPIC_REQ_NO: Symbol = symbol_short!("req_no");
-const TOPIC_DEL_CRTD: Symbol = symbol_short!("del_crtd");
-const TOPIC_DEL_RVKD: Symbol = symbol_short!("del_rvkd");
+
 const TOPIC_WL_ADD: Symbol = symbol_short!("wl_add");
 const TOPIC_WL_REM: Symbol = symbol_short!("wl_rem");
 const TOPIC_WL_ON: Symbol = symbol_short!("wl_on");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1635,55 +1635,6 @@ impl TrustLinkContract {
         Storage::get_endorsements(&env, &attestation_id).len()
     }
 
-    /// Endorse an existing attestation, adding a layer of social proof.
-    ///
-    /// Only registered issuers may endorse. An issuer cannot endorse their own
-    /// attestation, and cannot endorse a revoked attestation. Each issuer may
-    /// endorse a given attestation at most once.
-    ///
-    /// # Errors
-    /// - [`Error::Unauthorized`] — endorser is not a registered issuer.
-    /// - [`Error::NotFound`] — attestation does not exist.
-    /// - [`Error::CannotEndorseOwn`] — endorser is the attestation's issuer.
-    /// - [`Error::AlreadyRevoked`] — attestation has been revoked.
-    /// - [`Error::AlreadyEndorsed`] — endorser has already endorsed this attestation.
-    pub fn endorse_attestation(env: Env, endorser: Address, attestation_id: String) -> Result<(), Error> {
-        endorser.require_auth();
-        Validation::require_issuer(&env, &endorser)?;
-        Validation::require_not_paused(&env)?;
-
-        let attestation = Storage::get_attestation(&env, &attestation_id)?;
-
-        if attestation.issuer == endorser {
-            return Err(Error::CannotEndorseOwn);
-        }
-        if attestation.revoked {
-            return Err(Error::AlreadyRevoked);
-        }
-
-        // Check for duplicate endorsement.
-        let existing = Storage::get_endorsements(&env, &attestation_id);
-        for e in existing.iter() {
-            if e.endorser == endorser {
-                return Err(Error::AlreadyEndorsed);
-            }
-        }
-
-        let endorsement = Endorsement {
-            attestation_id: attestation_id.clone(),
-            endorser: endorser.clone(),
-            timestamp: env.ledger().timestamp(),
-        };
-        Storage::add_endorsement(&env, &attestation_id, &endorsement);
-        Ok(())
-    }
-
-    /// Return the number of endorsements for `attestation_id`.
-    #[must_use]
-    pub fn get_endorsement_count(env: Env, attestation_id: String) -> u32 {
-        Storage::get_endorsements(&env, &attestation_id).len()
-    }
-
     /// Delegate authority to create attestations of `claim_type` to `delegate`.
     ///
     /// # Errors

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -30,8 +30,8 @@
 
 use crate::constants::{DAY_IN_LEDGERS, DEFAULT_INSTANCE_LIFETIME};
 use crate::types::{
-    AdminCouncil, Attestation, AttestationRequest, AuditEntry, ClaimTypeInfo, Delegation,
-    Endorsement, Error, ExpirationHook, FeeConfig, GlobalStats, IssuerMetadata, IssuerStats,
+    AdminCouncil, Attestation, AttestationRequest, AuditEntry, ClaimTypeInfo,
+    Error, ExpirationHook, FeeConfig, GlobalStats, IssuerMetadata, IssuerStats,
     IssuerTier, MultiSigProposal, PendingAdminTransfer, RateLimitConfig, StorageLimits, TtlConfig,
     CouncilProposal,
 };
@@ -144,7 +144,7 @@ impl Storage {
 
     /// Legacy: Persist single `admin` (deprecated, use AdminCouncil).
     pub fn set_admin(env: &Env, admin: &Address) {
-        let ttl = get_ttl_lifetime(env);
+        let _ttl = get_ttl_lifetime(env);
         let mut council = Vec::new(env);
         council.push_back(admin.clone());
         Self::set_admin_council(env, &council);
@@ -198,7 +198,7 @@ impl Storage {
 
     /// Remove `admin` from council if present.
     pub fn remove_admin(env: &Env, admin: &Address) {
-        let mut council = Self::get_admin_council(env).unwrap_or(Vec::new(env));
+        let council = Self::get_admin_council(env).unwrap_or(Vec::new(env));
         let mut new_council = Vec::new(env);
         let mut found = false;
         for a in council.iter() {


### PR DESCRIPTION
- benchmark_1000_attestations_single_subject: measures CU cost of the 1,000th create_attestation call for a single subject (raises limit via set_limits)
- benchmark_has_valid_claim_100_attestations: measures has_valid_claim hit/miss with exactly 100 attestations on a subject
- benchmark_batch_create_50_attestations: measures a single create_attestations_batch call across 50 distinct subjects
- benchmark_paginate_10000_issuer_attestations: measures get_issuer_attestations at first, mid, and last page offsets over 10,000 issuer attestations

Closes #344