### PR TITLE
 Refactor: Split lib.rs into focused sub-modules

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,0 +1,410 @@
+use soroban_sdk::{token::TokenClient, Address, Env, String, Vec};
+
+use crate::events::Events;
+use crate::storage::Storage;
+use crate::types::{
+    AdminCouncil, ClaimTypeInfo, Delegation, Error, ExpirationHook, FeeConfig, IssuerMetadata,
+    IssuerStats, IssuerTier, PendingAdminTransfer, RateLimitConfig, StorageLimits, TtlConfig,
+};
+use crate::validation::Validation;
+
+// -----------------------------------------------------------------------
+// Initialization & Admin
+// -----------------------------------------------------------------------
+
+pub fn initialize(env: &Env, admin: Address, ttl_days: Option<u32>) -> Result<(), Error> {
+    admin.require_auth();
+    if Storage::has_admin(env) {
+        return Err(Error::AlreadyInitialized);
+    }
+    let mut council: AdminCouncil = Vec::new(env);
+    council.push_back(admin.clone());
+    Storage::set_admin_council(env, &council);
+    Storage::set_version(env, &String::from_str(env, "1.0.0"));
+    Storage::set_fee_config(env, &FeeConfig { attestation_fee: 0, fee_collector: admin.clone(), fee_token: None });
+    let days = ttl_days.unwrap_or(30);
+    Storage::set_ttl_config(env, &TtlConfig { ttl_days: days });
+    Events::admin_initialized(env, &admin, env.ledger().timestamp());
+    Ok(())
+}
+
+pub fn transfer_admin(env: &Env, current_admin: Address, new_admin: Address) -> Result<(), Error> {
+    current_admin.require_auth();
+    Validation::require_admin(env, &current_admin)?;
+    Storage::add_admin(env, &new_admin);
+    Storage::remove_admin(env, &current_admin);
+    Events::admin_transferred(env, &current_admin, &new_admin);
+    Ok(())
+}
+
+pub fn propose_admin_transfer(env: &Env, current_admin: Address, new_admin: Address) -> Result<(), Error> {
+    current_admin.require_auth();
+    Validation::require_admin(env, &current_admin)?;
+    Storage::set_pending_admin_transfer(
+        env,
+        &PendingAdminTransfer { proposed_by: current_admin.clone(), new_admin: new_admin.clone() },
+    );
+    Events::admin_transfer_proposed(env, &current_admin, &new_admin);
+    Ok(())
+}
+
+pub fn cancel_admin_transfer(env: &Env, current_admin: Address) -> Result<(), Error> {
+    current_admin.require_auth();
+    Validation::require_admin(env, &current_admin)?;
+    let pending = Storage::get_pending_admin_transfer(env).ok_or(Error::NotFound)?;
+    if pending.proposed_by != current_admin {
+        return Err(Error::Unauthorized);
+    }
+    Storage::remove_pending_admin_transfer(env);
+    Ok(())
+}
+
+pub fn accept_admin_transfer(env: &Env, new_admin: Address) -> Result<(), Error> {
+    new_admin.require_auth();
+    let pending = Storage::get_pending_admin_transfer(env).ok_or(Error::NotFound)?;
+    if pending.new_admin != new_admin {
+        return Err(Error::Unauthorized);
+    }
+    Storage::add_admin(env, &new_admin);
+    Storage::remove_admin(env, &pending.proposed_by);
+    Storage::remove_pending_admin_transfer(env);
+    Events::admin_transferred(env, &pending.proposed_by, &new_admin);
+    Ok(())
+}
+
+pub fn add_admin(env: &Env, existing_admin: Address, new_admin: Address) -> Result<(), Error> {
+    existing_admin.require_auth();
+    Validation::require_admin(env, &existing_admin)?;
+    if Storage::is_admin(env, &new_admin) {
+        return Ok(());
+    }
+    Storage::add_admin(env, &new_admin);
+    Events::admin_added(env, &existing_admin, &new_admin, env.ledger().timestamp());
+    Ok(())
+}
+
+pub fn remove_admin(env: &Env, existing_admin: Address, admin_to_remove: Address) -> Result<(), Error> {
+    existing_admin.require_auth();
+    Validation::require_admin(env, &existing_admin)?;
+    let council = Storage::get_admin_council(env)?;
+    if council.len() <= 1 {
+        return Err(Error::LastAdminCannotBeRemoved);
+    }
+    if !Storage::is_admin(env, &admin_to_remove) {
+        return Ok(());
+    }
+    Storage::remove_admin(env, &admin_to_remove);
+    Events::admin_removed(env, &existing_admin, &admin_to_remove, env.ledger().timestamp());
+    Ok(())
+}
+
+pub fn get_admin(env: &Env) -> Result<Address, Error> {
+    Storage::get_admin(env)
+}
+
+// -----------------------------------------------------------------------
+// Issuer management
+// -----------------------------------------------------------------------
+
+pub fn register_issuer(env: &Env, admin: Address, issuer: Address) -> Result<(), Error> {
+    admin.require_auth();
+    Validation::require_admin(env, &admin)?;
+    Validation::require_not_paused(env)?;
+    if Storage::is_bridge(env, &issuer) {
+        return Err(Error::Unauthorized);
+    }
+    Storage::add_issuer(env, &issuer);
+    Storage::increment_total_issuers(env);
+    Events::issuer_registered(env, &issuer, &admin, env.ledger().timestamp());
+    Ok(())
+}
+
+pub fn remove_issuer(env: &Env, admin: Address, issuer: Address) -> Result<(), Error> {
+    admin.require_auth();
+    Validation::require_admin(env, &admin)?;
+    Storage::remove_issuer(env, &issuer);
+    Storage::decrement_total_issuers(env);
+    Events::issuer_removed(env, &issuer, &admin, env.ledger().timestamp());
+    Ok(())
+}
+
+pub fn add_to_whitelist(env: &Env, issuer: Address, subject: Address) -> Result<(), Error> {
+    issuer.require_auth();
+    Validation::require_issuer(env, &issuer)?;
+    Storage::add_to_whitelist(env, &issuer, &subject);
+    Ok(())
+}
+
+pub fn remove_from_whitelist(env: &Env, issuer: Address, subject: Address) -> Result<(), Error> {
+    issuer.require_auth();
+    Validation::require_issuer(env, &issuer)?;
+    Storage::remove_from_whitelist(env, &issuer, &subject);
+    Ok(())
+}
+
+pub fn is_whitelisted(env: &Env, issuer: Address, subject: Address) -> bool {
+    Storage::is_whitelisted(env, &issuer, &subject)
+}
+
+pub fn is_whitelist_enabled(env: &Env, issuer: Address) -> bool {
+    Storage::is_whitelist_enabled(env, &issuer)
+}
+
+pub fn set_issuer_tier(env: &Env, admin: Address, issuer: Address, tier: IssuerTier) -> Result<(), Error> {
+    admin.require_auth();
+    Validation::require_admin(env, &admin)?;
+    Validation::require_issuer(env, &issuer)?;
+    Storage::set_issuer_tier(env, &issuer, &tier);
+    Events::issuer_tier_updated(env, &issuer, &tier);
+    Ok(())
+}
+
+pub fn get_confidence_score(env: &Env, attestation_id: String) -> Option<u32> {
+    let attestation = Storage::get_attestation(env, &attestation_id).ok()?;
+    let tier_score = match Storage::get_issuer_tier(env, &attestation.issuer) {
+        Some(IssuerTier::Premium) => 90u32,
+        Some(IssuerTier::Verified) => 60u32,
+        Some(IssuerTier::Basic) | None => 30u32,
+    };
+    let endorsements = Storage::get_endorsements(env, &attestation_id);
+    let endorsement_score = (endorsements.len() * 2).min(10);
+    Some(tier_score + endorsement_score)
+}
+
+pub fn get_issuer_metadata(env: &Env, issuer: Address) -> Option<IssuerMetadata> {
+    Storage::get_issuer_metadata(env, &issuer)
+}
+
+pub fn set_issuer_metadata(env: &Env, issuer: Address, metadata: IssuerMetadata) -> Result<(), Error> {
+    issuer.require_auth();
+    Validation::require_issuer(env, &issuer)?;
+    Storage::set_issuer_metadata(env, &issuer, &metadata);
+    Ok(())
+}
+
+pub fn get_issuer_stats(env: &Env, issuer: Address) -> IssuerStats {
+    Storage::get_issuer_stats(env, &issuer)
+}
+
+pub fn is_issuer(env: &Env, address: Address) -> bool {
+    Storage::is_issuer(env, &address)
+}
+
+pub fn get_issuer_tier(env: &Env, issuer: Address) -> Option<IssuerTier> {
+    Storage::get_issuer_tier(env, &issuer)
+}
+
+// -----------------------------------------------------------------------
+// Bridge management
+// -----------------------------------------------------------------------
+
+pub fn register_bridge(env: &Env, admin: Address, bridge_contract: Address) -> Result<(), Error> {
+    admin.require_auth();
+    Validation::require_admin(env, &admin)?;
+    if Storage::is_issuer(env, &bridge_contract) {
+        return Err(Error::Unauthorized);
+    }
+    Storage::add_bridge(env, &bridge_contract);
+    Ok(())
+}
+
+pub fn is_bridge(env: &Env, address: Address) -> bool {
+    Storage::is_bridge(env, &address)
+}
+
+// -----------------------------------------------------------------------
+// Whitelist mode
+// -----------------------------------------------------------------------
+
+pub fn set_whitelist_enabled(env: &Env, issuer: Address, enabled: bool) -> Result<(), Error> {
+    issuer.require_auth();
+    Validation::require_issuer(env, &issuer)?;
+    Storage::set_whitelist_enabled(env, &issuer, enabled);
+    Ok(())
+}
+
+pub fn enable_whitelist_mode(env: &Env, issuer: Address) -> Result<(), Error> {
+    issuer.require_auth();
+    Validation::require_issuer(env, &issuer)?;
+    Storage::set_whitelist_mode(env, &issuer, true);
+    Events::whitelist_mode_enabled(env, &issuer);
+    Ok(())
+}
+
+// -----------------------------------------------------------------------
+// Fee & rate limit
+// -----------------------------------------------------------------------
+
+pub fn get_fee_config(env: &Env) -> Result<FeeConfig, Error> {
+    Storage::get_fee_config(env).ok_or(Error::NotInitialized)
+}
+
+pub fn set_fee(env: &Env, admin: Address, fee: i128, collector: Address, fee_token: Option<Address>) -> Result<(), Error> {
+    admin.require_auth();
+    Validation::require_admin(env, &admin)?;
+    validate_fee_config(env, fee, &fee_token)?;
+    if admin == collector {
+        return Err(Error::Unauthorized);
+    }
+    Storage::set_fee_config(env, &FeeConfig { attestation_fee: fee, fee_collector: collector, fee_token });
+    Ok(())
+}
+
+pub fn set_rate_limit(env: &Env, admin: Address, min_issuance_interval: u64) -> Result<(), Error> {
+    admin.require_auth();
+    Validation::require_admin(env, &admin)?;
+    Storage::set_rate_limit_config(env, &RateLimitConfig { min_issuance_interval });
+    Ok(())
+}
+
+pub fn get_rate_limit(env: &Env) -> Option<RateLimitConfig> {
+    Storage::get_rate_limit_config(env)
+}
+
+// -----------------------------------------------------------------------
+// Pause / unpause
+// -----------------------------------------------------------------------
+
+pub fn pause(env: &Env, admin: Address) -> Result<(), Error> {
+    admin.require_auth();
+    Validation::require_admin(env, &admin)?;
+    Storage::set_paused(env, true);
+    Events::contract_paused(env, &admin, env.ledger().timestamp());
+    Ok(())
+}
+
+pub fn unpause(env: &Env, admin: Address) -> Result<(), Error> {
+    admin.require_auth();
+    Validation::require_admin(env, &admin)?;
+    Storage::set_paused(env, false);
+    Events::contract_unpaused(env, &admin, env.ledger().timestamp());
+    Ok(())
+}
+
+pub fn is_paused(env: &Env) -> bool {
+    Storage::is_paused(env)
+}
+
+// -----------------------------------------------------------------------
+// Limits
+// -----------------------------------------------------------------------
+
+pub fn get_limits(env: &Env) -> StorageLimits {
+    Storage::get_limits(env)
+}
+
+pub fn set_limits(env: &Env, admin: Address, max_attestations_per_issuer: u32, max_attestations_per_subject: u32) -> Result<(), Error> {
+    admin.require_auth();
+    Validation::require_admin(env, &admin)?;
+    Storage::set_limits(env, &StorageLimits { max_attestations_per_issuer, max_attestations_per_subject });
+    Ok(())
+}
+
+// -----------------------------------------------------------------------
+// Claim type registry
+// -----------------------------------------------------------------------
+
+pub fn register_claim_type(env: &Env, admin: Address, claim_type: String, description: String) -> Result<(), Error> {
+    admin.require_auth();
+    Validation::require_admin(env, &admin)?;
+    Validation::validate_claim_type(&claim_type)?;
+    let info = ClaimTypeInfo { claim_type: claim_type.clone(), description: description.clone() };
+    Storage::set_claim_type(env, &info);
+    Events::claim_type_registered(env, &claim_type, &description);
+    Ok(())
+}
+
+pub fn get_claim_type_description(env: &Env, claim_type: String) -> Option<String> {
+    Storage::get_claim_type(env, &claim_type).map(|info| info.description)
+}
+
+pub fn list_claim_types(env: &Env, start: u32, limit: u32) -> Vec<String> {
+    crate::storage::paginate(env, &Storage::get_claim_type_list(env), start, limit)
+}
+
+// -----------------------------------------------------------------------
+// Delegation
+// -----------------------------------------------------------------------
+
+pub fn delegate_claim_type(
+    env: &Env,
+    issuer: Address,
+    delegate: Address,
+    claim_type: String,
+    expiration: Option<u64>,
+) -> Result<(), Error> {
+    issuer.require_auth();
+    Validation::require_issuer(env, &issuer)?;
+    if issuer == delegate {
+        return Err(Error::CannotDelegateToSelf);
+    }
+    crate::attestation::validate_native_expiration(env, expiration)?;
+    let delegation = Delegation {
+        delegator: issuer.clone(),
+        delegate: delegate.clone(),
+        claim_type: claim_type.clone(),
+        expiration,
+    };
+    Storage::set_delegation(env, &delegation);
+    Events::delegation_created(env, &issuer, &delegate, &claim_type, expiration);
+    Ok(())
+}
+
+// -----------------------------------------------------------------------
+// Expiration hooks
+// -----------------------------------------------------------------------
+
+pub fn register_expiration_hook(env: &Env, subject: Address, callback_contract: Address, notify_days_before: u32) -> Result<(), Error> {
+    subject.require_auth();
+    Storage::set_expiration_hook(env, &subject, &ExpirationHook { callback_contract, notify_days_before });
+    Ok(())
+}
+
+pub fn get_expiration_hook(env: &Env, subject: Address) -> Option<ExpirationHook> {
+    Storage::get_expiration_hook(env, &subject)
+}
+
+pub fn remove_expiration_hook(env: &Env, subject: Address) -> Result<(), Error> {
+    subject.require_auth();
+    Storage::remove_expiration_hook(env, &subject);
+    Ok(())
+}
+
+// -----------------------------------------------------------------------
+// Misc
+// -----------------------------------------------------------------------
+
+pub fn get_version(env: &Env) -> Result<String, Error> {
+    Storage::get_version(env).ok_or(Error::NotInitialized)
+}
+
+pub fn health_check(env: &Env) -> crate::types::HealthStatus {
+    let initialized = Storage::has_admin(env);
+    let stats = Storage::get_global_stats(env);
+    crate::types::HealthStatus {
+        initialized,
+        admin_set: initialized,
+        issuer_count: stats.total_issuers,
+        total_attestations: stats.total_attestations,
+    }
+}
+
+// -----------------------------------------------------------------------
+// Internal helpers
+// -----------------------------------------------------------------------
+
+fn validate_fee_config(env: &Env, fee: i128, fee_token: &Option<Address>) -> Result<(), Error> {
+    if fee < 0 {
+        return Err(Error::InvalidFee);
+    }
+    if fee > 0 && fee_token.is_none() {
+        return Err(Error::FeeTokenRequired);
+    }
+    if let Some(token_addr) = fee_token {
+        let token = TokenClient::new(env, token_addr);
+        token
+            .try_balance(&env.current_contract_address())
+            .map_err(|_| Error::InvalidFeeToken)?;
+    }
+    Ok(())
+}

--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -1,0 +1,719 @@
+use soroban_sdk::{token::TokenClient, Address, Env, String, Vec};
+
+use crate::constants::SECS_PER_DAY;
+use crate::events::Events;
+use crate::storage::Storage;
+use crate::types::{
+    Attestation, AttestationOrigin, AuditAction, AuditEntry, Endorsement, Error, FeeConfig,
+};
+use crate::validation::Validation;
+
+pub const MAX_SOURCE_CHAIN_LEN: u32 = 32;
+pub const MAX_SOURCE_TX_LEN: u32 = 128;
+
+// -----------------------------------------------------------------------
+// Shared helpers (pub so admin.rs / multisig.rs / request.rs can reuse)
+// -----------------------------------------------------------------------
+
+pub fn validate_native_expiration(env: &Env, expiration: Option<u64>) -> Result<(), Error> {
+    if let Some(v) = expiration {
+        if v <= env.ledger().timestamp() {
+            return Err(Error::InvalidExpiration);
+        }
+    }
+    Ok(())
+}
+
+pub fn validate_valid_from(env: &Env, valid_from: Option<u64>) -> Result<(), Error> {
+    if let Some(vf) = valid_from {
+        if vf <= env.ledger().timestamp() {
+            return Err(Error::InvalidValidFrom);
+        }
+    }
+    Ok(())
+}
+
+pub fn validate_import_timestamps(env: &Env, timestamp: u64, expiration: Option<u64>) -> Result<(), Error> {
+    if timestamp > env.ledger().timestamp() {
+        return Err(Error::InvalidTimestamp);
+    }
+    if let Some(v) = expiration {
+        if v <= timestamp {
+            return Err(Error::InvalidExpiration);
+        }
+    }
+    Ok(())
+}
+
+pub fn validate_reason(reason: &Option<String>) -> Result<(), Error> {
+    if let Some(r) = reason {
+        if r.len() > 128 {
+            return Err(Error::ReasonTooLong);
+        }
+    }
+    Ok(())
+}
+
+pub fn validate_source_reference(source_chain: &String, source_tx: &String) -> Result<(), Error> {
+    if source_chain.len() > MAX_SOURCE_CHAIN_LEN || source_tx.len() > MAX_SOURCE_TX_LEN {
+        return Err(Error::MetadataTooLong);
+    }
+    Ok(())
+}
+
+pub fn validate_tags(tags: &Option<Vec<String>>) -> Result<(), Error> {
+    if let Some(t) = tags {
+        if t.len() > 5 {
+            return Err(Error::TooManyTags);
+        }
+        for tag in t.iter() {
+            if tag.len() > 32 {
+                return Err(Error::TagTooLong);
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn validate_jurisdiction(env: &Env, jurisdiction: &Option<String>) -> Result<(), Error> {
+    if let Some(code) = jurisdiction {
+        if code.len() != 2 {
+            return Err(Error::InvalidJurisdiction);
+        }
+        let valid_codes = [
+            "AF","AX","AL","DZ","AS","AD","AO","AI","AQ","AG","AR","AM","AW","AU","AT","AZ",
+            "BS","BH","BD","BB","BY","BE","BZ","BJ","BM","BT","BO","BQ","BA","BW","BV","BR",
+            "IO","BN","BG","BF","BI","CV","KH","CM","CA","KY","CF","TD","CL","CN","CX","CC",
+            "CO","KM","CG","CD","CK","CR","CI","HR","CU","CW","CY","CZ","DK","DJ","DM","DO",
+            "EC","EG","SV","GQ","ER","EE","SZ","ET","FK","FO","FJ","FI","FR","GF","PF","TF",
+            "GA","GM","GE","DE","GH","GI","GR","GL","GD","GP","GU","GT","GG","GN","GW","GY",
+            "HT","HM","VA","HN","HK","HU","IS","IN","ID","IR","IQ","IE","IM","IL","IT","JM",
+            "JP","JE","JO","KZ","KE","KI","KP","KR","KW","KG","LA","LV","LB","LS","LR","LY",
+            "LI","LT","LU","MO","MK","MG","MW","MY","MV","ML","MT","MH","MQ","MR","MU","YT",
+            "MX","FM","MD","MC","MN","ME","MS","MA","MZ","MM","NA","NR","NP","NL","NC","NZ",
+            "NI","NE","NG","NU","NF","MP","NO","OM","PK","PW","PS","PA","PG","PY","PE","PH",
+            "PN","PL","PT","PR","QA","RE","RO","RU","RW","BL","SH","KN","LC","MF","PM","VC",
+            "WS","SM","ST","SA","SN","RS","SC","SL","SG","SX","SK","SI","SB","SO","ZA","GS",
+            "SS","ES","LK","SD","SR","SJ","SE","CH","SY","TW","TJ","TZ","TH","TL","TG","TK",
+            "TO","TT","TN","TR","TM","TC","TV","UG","UA","AE","GB","US","UM","UY","UZ","VU",
+            "VE","VN","VG","VI","WF","EH","YE","ZM","ZW",
+        ];
+        let mut valid = false;
+        for iso in valid_codes.iter() {
+            if code == &String::from_str(env, iso) {
+                valid = true;
+                break;
+            }
+        }
+        if !valid {
+            return Err(Error::InvalidJurisdiction);
+        }
+    }
+    Ok(())
+}
+
+pub fn check_rate_limit(env: &Env, issuer: &Address) -> Result<(), Error> {
+    if let Some(config) = Storage::get_rate_limit_config(env) {
+        if config.min_issuance_interval == 0 {
+            return Ok(());
+        }
+        let current_time = env.ledger().timestamp();
+        if let Some(last) = Storage::get_last_issuance_time(env, issuer) {
+            if current_time.saturating_sub(last) < config.min_issuance_interval {
+                return Err(Error::RateLimited);
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn load_fee_config(env: &Env) -> Result<FeeConfig, Error> {
+    Storage::get_fee_config(env).ok_or(Error::NotInitialized)
+}
+
+pub fn charge_attestation_fee(env: &Env, issuer: &Address) -> Result<(), Error> {
+    let fee_config = load_fee_config(env)?;
+    if fee_config.attestation_fee == 0 {
+        return Ok(());
+    }
+    let fee_token = fee_config.fee_token.ok_or(Error::FeeTokenRequired)?;
+    TokenClient::new(env, &fee_token).transfer(issuer, &fee_config.fee_collector, &fee_config.attestation_fee);
+    Ok(())
+}
+
+pub fn store_attestation(env: &Env, attestation: &Attestation) {
+    Storage::set_attestation(env, attestation);
+    Storage::add_subject_attestation(env, &attestation.subject, &attestation.id);
+    Storage::add_issuer_attestation(env, &attestation.issuer, &attestation.id);
+    let mut stats = Storage::get_issuer_stats(env, &attestation.issuer);
+    stats.total_issued += 1;
+    Storage::set_issuer_stats(env, &attestation.issuer, &stats);
+    Storage::increment_total_attestations(env, 1);
+}
+
+pub fn maybe_trigger_expiration_hook(
+    env: &Env,
+    subject: &Address,
+    attestation_id: &String,
+    expiration: u64,
+    current_time: u64,
+) {
+    let hook = match Storage::get_expiration_hook(env, subject) {
+        Some(h) => h,
+        None => return,
+    };
+    let notify_window = (hook.notify_days_before as u64) * SECS_PER_DAY;
+    let notify_from = expiration.saturating_sub(notify_window);
+    if current_time >= notify_from && current_time < expiration {
+        Events::expiration_hook_triggered(env, subject, attestation_id, expiration);
+        let client = crate::callback::ExpirationCallbackClient::new(env, &hook.callback_contract);
+        let _ = client.try_notify_expiring(subject, attestation_id, &expiration);
+    }
+}
+
+// -----------------------------------------------------------------------
+// Attestation creation
+// -----------------------------------------------------------------------
+
+pub fn create_attestation_internal(
+    env: &Env,
+    issuer: Address,
+    subject: Address,
+    claim_type: String,
+    expiration: Option<u64>,
+    metadata: Option<String>,
+    jurisdiction: Option<String>,
+    tags: Option<Vec<String>>,
+    valid_from: Option<u64>,
+) -> Result<String, Error> {
+    issuer.require_auth();
+    Validation::require_not_paused(env)?;
+    Validation::require_issuer(env, &issuer)?;
+    Validation::validate_claim_type(&claim_type)?;
+    Validation::validate_metadata(env, &metadata)?;
+    validate_jurisdiction(env, &jurisdiction)?;
+    validate_tags(&tags)?;
+    validate_native_expiration(env, expiration)?;
+    validate_valid_from(env, valid_from)?;
+
+    if issuer == subject {
+        return Err(Error::Unauthorized);
+    }
+
+    if Storage::is_whitelist_mode(env, &issuer) && !Storage::is_whitelisted(env, &issuer, &subject) {
+        return Err(Error::SubjectNotWhitelisted);
+    }
+
+    check_rate_limit(env, &issuer)?;
+
+    let limits = Storage::get_limits(env);
+    let issuer_count = Storage::get_issuer_attestations(env, &issuer).len();
+    if issuer_count >= limits.max_attestations_per_issuer {
+        return Err(Error::LimitExceeded);
+    }
+    let subject_count = Storage::get_subject_attestations(env, &subject).len();
+    if subject_count >= limits.max_attestations_per_subject {
+        return Err(Error::LimitExceeded);
+    }
+
+    let timestamp = env.ledger().timestamp();
+    let attestation_id = Attestation::generate_id(env, &issuer, &subject, &claim_type, timestamp);
+
+    if Storage::has_attestation(env, &attestation_id) {
+        return Err(Error::DuplicateAttestation);
+    }
+
+    let attestation = Attestation {
+        id: attestation_id.clone(),
+        issuer: issuer.clone(),
+        subject,
+        claim_type,
+        timestamp,
+        expiration,
+        revoked: false,
+        deleted: false,
+        metadata,
+        jurisdiction,
+        valid_from,
+        origin: AttestationOrigin::Native,
+        source_chain: None,
+        source_tx: None,
+        tags,
+        revocation_reason: None,
+    };
+
+    store_attestation(env, &attestation);
+    Storage::append_audit_entry(
+        env,
+        &attestation_id,
+        &AuditEntry {
+            action: AuditAction::Created,
+            actor: attestation.issuer.clone(),
+            timestamp,
+            details: None,
+        },
+    );
+    Storage::set_last_issuance_time(env, &issuer, timestamp);
+
+    charge_attestation_fee(env, &issuer)?;
+
+    Events::attestation_created(env, &attestation);
+    Ok(attestation_id)
+}
+
+pub fn create_attestation(
+    env: &Env,
+    issuer: Address,
+    subject: Address,
+    claim_type: String,
+    expiration: Option<u64>,
+    metadata: Option<String>,
+    tags: Option<Vec<String>>,
+) -> Result<String, Error> {
+    create_attestation_internal(env, issuer, subject, claim_type, expiration, metadata, None, tags, None)
+}
+
+pub fn create_attestation_valid_from(
+    env: &Env,
+    issuer: Address,
+    subject: Address,
+    claim_type: String,
+    expiration: Option<u64>,
+    metadata: Option<String>,
+    tags: Option<Vec<String>>,
+    valid_from: u64,
+) -> Result<String, Error> {
+    create_attestation_internal(env, issuer, subject, claim_type, expiration, metadata, None, tags, Some(valid_from))
+}
+
+pub fn create_attestation_jurisdiction(
+    env: &Env,
+    issuer: Address,
+    subject: Address,
+    claim_type: String,
+    expiration: Option<u64>,
+    metadata: Option<String>,
+    jurisdiction: Option<String>,
+    tags: Option<Vec<String>>,
+) -> Result<String, Error> {
+    create_attestation_internal(env, issuer, subject, claim_type, expiration, metadata, jurisdiction, tags, None)
+}
+
+pub fn import_attestation(
+    env: &Env,
+    admin: Address,
+    issuer: Address,
+    subject: Address,
+    claim_type: String,
+    timestamp: u64,
+    expiration: Option<u64>,
+) -> Result<String, Error> {
+    admin.require_auth();
+    Validation::require_admin(env, &admin)?;
+    Validation::require_not_paused(env)?;
+    Validation::require_issuer(env, &issuer)?;
+    validate_import_timestamps(env, timestamp, expiration)?;
+
+    let attestation_id = Attestation::generate_id(env, &issuer, &subject, &claim_type, timestamp);
+    if Storage::has_attestation(env, &attestation_id) {
+        return Err(Error::DuplicateAttestation);
+    }
+
+    let attestation = Attestation {
+        id: attestation_id.clone(),
+        issuer,
+        subject,
+        claim_type,
+        timestamp,
+        expiration,
+        revoked: false,
+        deleted: false,
+        metadata: None,
+        jurisdiction: None,
+        valid_from: None,
+        origin: AttestationOrigin::Imported,
+        source_chain: None,
+        source_tx: None,
+        tags: None,
+        revocation_reason: None,
+    };
+
+    store_attestation(env, &attestation);
+    Events::attestation_imported(env, &attestation);
+    Storage::append_audit_entry(
+        env,
+        &attestation_id,
+        &AuditEntry {
+            action: AuditAction::Created,
+            actor: admin.clone(),
+            timestamp,
+            details: None,
+        },
+    );
+    Ok(attestation_id)
+}
+
+pub fn bridge_attestation(
+    env: &Env,
+    bridge: Address,
+    subject: Address,
+    claim_type: String,
+    source_chain: String,
+    source_tx: String,
+) -> Result<String, Error> {
+    bridge.require_auth();
+    Validation::require_bridge(env, &bridge)?;
+    Validation::require_not_paused(env)?;
+    validate_source_reference(&source_chain, &source_tx)?;
+
+    let timestamp = env.ledger().timestamp();
+    let attestation_id = Attestation::generate_bridge_id(
+        env, &bridge, &subject, &claim_type, &source_chain, &source_tx, timestamp,
+    );
+    if Storage::has_attestation(env, &attestation_id) {
+        return Err(Error::DuplicateAttestation);
+    }
+
+    let attestation = Attestation {
+        id: attestation_id.clone(),
+        issuer: bridge,
+        subject,
+        claim_type,
+        timestamp,
+        expiration: None,
+        revoked: false,
+        deleted: false,
+        metadata: None,
+        jurisdiction: None,
+        valid_from: None,
+        origin: AttestationOrigin::Bridged,
+        source_chain: Some(source_chain),
+        source_tx: Some(source_tx),
+        tags: None,
+        revocation_reason: None,
+    };
+
+    store_attestation(env, &attestation);
+    Events::attestation_bridged(env, &attestation);
+    Storage::append_audit_entry(env, &attestation_id, &AuditEntry {
+        action: AuditAction::Created,
+        actor: attestation.issuer.clone(),
+        timestamp,
+        details: None,
+    });
+    Ok(attestation_id)
+}
+
+pub fn create_attestations_batch(
+    env: &Env,
+    issuer: Address,
+    subjects: Vec<Address>,
+    claim_type: String,
+    expiration: Option<u64>,
+) -> Result<Vec<String>, Error> {
+    issuer.require_auth();
+    Validation::require_issuer(env, &issuer)?;
+    Validation::require_not_paused(env)?;
+    Validation::validate_claim_type(&claim_type)?;
+    validate_native_expiration(env, expiration)?;
+    check_rate_limit(env, &issuer)?;
+
+    let timestamp = env.ledger().timestamp();
+    let limits = Storage::get_limits(env);
+    let issuer_count = Storage::get_issuer_attestations(env, &issuer).len();
+    if issuer_count.saturating_add(subjects.len()) > limits.max_attestations_per_issuer {
+        return Err(Error::LimitExceeded);
+    }
+
+    let mut ids: Vec<String> = Vec::new(env);
+    for subject in subjects.iter() {
+        let attestation_id = Attestation::generate_id(env, &issuer, &subject, &claim_type, timestamp);
+        if Storage::has_attestation(env, &attestation_id) {
+            return Err(Error::DuplicateAttestation);
+        }
+        let subject_count = Storage::get_subject_attestations(env, &subject).len();
+        if subject_count >= limits.max_attestations_per_subject {
+            return Err(Error::LimitExceeded);
+        }
+        let attestation = Attestation {
+            id: attestation_id.clone(),
+            issuer: issuer.clone(),
+            subject: subject.clone(),
+            claim_type: claim_type.clone(),
+            timestamp,
+            expiration,
+            revoked: false,
+            deleted: false,
+            metadata: None,
+            jurisdiction: None,
+            valid_from: None,
+            origin: AttestationOrigin::Native,
+            source_chain: None,
+            source_tx: None,
+            tags: None,
+            revocation_reason: None,
+        };
+        store_attestation(env, &attestation);
+        Events::attestation_created(env, &attestation);
+        Storage::append_audit_entry(
+            env,
+            &attestation_id,
+            &AuditEntry {
+                action: AuditAction::Created,
+                actor: issuer.clone(),
+                timestamp,
+                details: None,
+            },
+        );
+        ids.push_back(attestation_id);
+    }
+
+    Storage::set_last_issuance_time(env, &issuer, timestamp);
+    Ok(ids)
+}
+
+pub fn revoke_attestation(
+    env: &Env,
+    issuer: Address,
+    attestation_id: String,
+    reason: Option<String>,
+) -> Result<(), Error> {
+    issuer.require_auth();
+    Validation::require_not_paused(env)?;
+    Validation::require_issuer(env, &issuer)?;
+    validate_reason(&reason)?;
+
+    let mut attestation = Storage::get_attestation(env, &attestation_id)?;
+    if attestation.issuer != issuer {
+        return Err(Error::Unauthorized);
+    }
+    if attestation.revoked {
+        return Err(Error::AlreadyRevoked);
+    }
+
+    attestation.revoked = true;
+    attestation.revocation_reason = reason.clone();
+    Storage::set_attestation(env, &attestation);
+    Storage::remove_subject_attestation(env, &attestation.subject, &attestation_id);
+    Storage::remove_issuer_attestation(env, &issuer, &attestation_id);
+
+    Events::attestation_revoked(env, &attestation_id, &issuer, &reason);
+    Storage::append_audit_entry(env, &attestation_id, &AuditEntry {
+        action: AuditAction::Revoked,
+        actor: issuer.clone(),
+        timestamp: env.ledger().timestamp(),
+        details: reason.clone(),
+    });
+    Storage::increment_total_revocations(env, 1);
+    Ok(())
+}
+
+pub fn renew_attestation(
+    env: &Env,
+    issuer: Address,
+    attestation_id: String,
+    new_expiration: Option<u64>,
+) -> Result<(), Error> {
+    issuer.require_auth();
+    Validation::require_issuer(env, &issuer)?;
+    Validation::require_not_paused(env)?;
+    validate_native_expiration(env, new_expiration)?;
+
+    let mut attestation = Storage::get_attestation(env, &attestation_id)?;
+    if attestation.issuer != issuer {
+        return Err(Error::Unauthorized);
+    }
+    if attestation.revoked {
+        return Err(Error::AlreadyRevoked);
+    }
+
+    attestation.expiration = new_expiration;
+    Storage::set_attestation(env, &attestation);
+    Events::attestation_renewed(env, &attestation_id, &issuer, new_expiration);
+    Storage::append_audit_entry(env, &attestation_id, &AuditEntry {
+        action: AuditAction::Renewed,
+        actor: issuer.clone(),
+        timestamp: env.ledger().timestamp(),
+        details: None,
+    });
+    Ok(())
+}
+
+pub fn revoke_attestations_batch(
+    env: &Env,
+    issuer: Address,
+    attestation_ids: Vec<String>,
+    reason: Option<String>,
+) -> Result<u32, Error> {
+    const MAX_BATCH: u32 = 50;
+
+    issuer.require_auth();
+    Validation::require_issuer(env, &issuer)?;
+    validate_reason(&reason)?;
+
+    if attestation_ids.len() > MAX_BATCH {
+        return Err(Error::LimitExceeded);
+    }
+
+    for id in attestation_ids.iter() {
+        let attestation = Storage::get_attestation(env, &id)?;
+        if attestation.issuer != issuer {
+            return Err(Error::Unauthorized);
+        }
+        if attestation.revoked {
+            return Err(Error::AlreadyRevoked);
+        }
+    }
+
+    let mut count: u32 = 0;
+    for id in attestation_ids.iter() {
+        let mut attestation = Storage::get_attestation(env, &id)?;
+        attestation.revoked = true;
+        attestation.revocation_reason = reason.clone();
+        Storage::set_attestation(env, &attestation);
+        Storage::remove_subject_attestation(env, &attestation.subject, &id);
+        Storage::remove_issuer_attestation(env, &issuer, &id);
+        Events::attestation_revoked_with_reason(env, &id, &issuer, &reason);
+        Storage::append_audit_entry(
+            env,
+            &id,
+            &AuditEntry {
+                action: AuditAction::Revoked,
+                actor: issuer.clone(),
+                timestamp: env.ledger().timestamp(),
+                details: reason.clone(),
+            },
+        );
+        count += 1;
+    }
+
+    Storage::increment_total_revocations(env, count as u64);
+    Ok(count)
+}
+
+pub fn update_expiration(
+    env: &Env,
+    issuer: Address,
+    attestation_id: String,
+    new_expiration: Option<u64>,
+) -> Result<(), Error> {
+    issuer.require_auth();
+    Validation::require_issuer(env, &issuer)?;
+    Validation::require_not_paused(env)?;
+    validate_native_expiration(env, new_expiration)?;
+
+    let mut attestation = Storage::get_attestation(env, &attestation_id)?;
+    if attestation.issuer != issuer {
+        return Err(Error::Unauthorized);
+    }
+    if attestation.revoked {
+        return Err(Error::AlreadyRevoked);
+    }
+
+    attestation.expiration = new_expiration;
+    Storage::set_attestation(env, &attestation);
+    Events::attestation_renewed(env, &attestation_id, &issuer, new_expiration);
+    Storage::append_audit_entry(env, &attestation_id, &AuditEntry {
+        action: AuditAction::Updated,
+        actor: issuer.clone(),
+        timestamp: env.ledger().timestamp(),
+        details: None,
+    });
+    Ok(())
+}
+
+pub fn transfer_attestation(
+    env: &Env,
+    admin: Address,
+    attestation_id: String,
+    new_issuer: Address,
+) -> Result<(), Error> {
+    admin.require_auth();
+    Validation::require_admin(env, &admin)?;
+    Validation::require_issuer(env, &new_issuer)?;
+
+    let mut attestation = Storage::get_attestation(env, &attestation_id)?;
+    let old_issuer = attestation.issuer.clone();
+
+    if old_issuer == new_issuer {
+        return Ok(());
+    }
+
+    Storage::remove_issuer_attestation(env, &old_issuer, &attestation_id);
+    Storage::add_issuer_attestation(env, &new_issuer, &attestation_id);
+
+    let mut old_stats = Storage::get_issuer_stats(env, &old_issuer);
+    old_stats.total_issued = old_stats.total_issued.saturating_sub(1);
+    Storage::set_issuer_stats(env, &old_issuer, &old_stats);
+
+    let mut new_stats = Storage::get_issuer_stats(env, &new_issuer);
+    new_stats.total_issued = new_stats.total_issued.saturating_add(1);
+    Storage::set_issuer_stats(env, &new_issuer, &new_stats);
+
+    attestation.issuer = new_issuer.clone();
+    Storage::set_attestation(env, &attestation);
+
+    Storage::append_audit_entry(env, &attestation_id, &AuditEntry {
+        action: AuditAction::Transferred,
+        actor: admin.clone(),
+        timestamp: env.ledger().timestamp(),
+        details: Some(new_issuer.to_string()),
+    });
+
+    Events::attestation_transferred(env, &attestation_id, &old_issuer, &new_issuer);
+    Ok(())
+}
+
+pub fn request_deletion(env: &Env, subject: Address, attestation_id: String) -> Result<(), Error> {
+    subject.require_auth();
+
+    let mut attestation = Storage::get_attestation(env, &attestation_id)?;
+    if attestation.subject != subject {
+        return Err(Error::Unauthorized);
+    }
+
+    attestation.deleted = true;
+    Storage::set_attestation(env, &attestation);
+    Storage::remove_subject_attestation(env, &subject, &attestation_id);
+
+    let timestamp = env.ledger().timestamp();
+    Events::deletion_requested(env, &subject, &attestation_id, timestamp);
+    Ok(())
+}
+
+// -----------------------------------------------------------------------
+// Endorsement
+// -----------------------------------------------------------------------
+
+pub fn endorse_attestation(env: &Env, endorser: Address, attestation_id: String) -> Result<(), Error> {
+    endorser.require_auth();
+    Validation::require_issuer(env, &endorser)?;
+    Validation::require_not_paused(env)?;
+
+    let attestation = Storage::get_attestation(env, &attestation_id)?;
+    if attestation.issuer == endorser {
+        return Err(Error::CannotEndorseOwn);
+    }
+    if attestation.revoked {
+        return Err(Error::AlreadyRevoked);
+    }
+
+    let existing = Storage::get_endorsements(env, &attestation_id);
+    for e in existing.iter() {
+        if e.endorser == endorser {
+            return Err(Error::AlreadyEndorsed);
+        }
+    }
+
+    let endorsement = Endorsement {
+        attestation_id: attestation_id.clone(),
+        endorser: endorser.clone(),
+        timestamp: env.ledger().timestamp(),
+    };
+    Storage::add_endorsement(env, &endorsement);
+    Ok(())
+}
+
+pub fn get_endorsement_count(env: &Env, attestation_id: String) -> u32 {
+    Storage::get_endorsements(env, &attestation_id).len()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,13 @@
 #![no_std]
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 
+mod admin;
+mod attestation;
 mod errors;
 mod events;
+mod multisig;
+mod query;
+mod request;
 mod storage;
 mod constants;
 pub mod types;
@@ -11,25 +16,7 @@ mod validation;
 #[cfg(test)]
 mod test;
 
-use soroban_sdk::{contract, contractimpl, token::TokenClient, Address, Env, String, Vec};
-
-use crate::constants::SECS_PER_DAY;
-use crate::events::Events;
-use crate::storage::Storage;
-use crate::types::{
-    AdminCouncil, Attestation, AttestationOrigin, AttestationRequest, AttestationStatus,
-    AuditAction, AuditEntry, ClaimTypeInfo, ContractConfig, ContractMetadata, CouncilOperation,
-    CouncilProposal, Delegation, Endorsement, Error, FeeConfig, GlobalStats, HealthStatus, IssuerMetadata,
-    IssuerStats, IssuerTier, MultiSigProposal, PendingAdminTransfer, RateLimitConfig,
-    RequestStatus, StorageLimits, TtlConfig, ATTESTATION_REQUEST_TTL_SECS,
-    MULTISIG_PROPOSAL_TTL_SECS,
-};
-use crate::validation::Validation;
-
-const MAX_SOURCE_CHAIN_LEN: u32 = 32;
-const MAX_SOURCE_TX_LEN: u32 = 128;
-
-mod callback {
+pub(crate) mod callback {
     use soroban_sdk::{contractclient, Address, Env, String};
     #[contractclient(name = "ExpirationCallbackClient")]
     #[allow(dead_code)]
@@ -37,201 +24,14 @@ mod callback {
         fn notify_expiring(env: Env, subject: Address, attestation_id: String, expiration: u64);
     }
 }
-use callback::ExpirationCallbackClient;
 
-fn validate_metadata(env: &Env, metadata: &Option<String>) -> Result<(), Error> {
-    Validation::validate_metadata(env, metadata)
-}
+use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
 
-fn validate_claim_type(claim_type: &String) -> Result<(), Error> {
-    Validation::validate_claim_type(claim_type)
-}
-
-fn validate_reason(reason: &Option<String>) -> Result<(), Error> {
-    if let Some(r) = reason {
-        if r.len() > 128 {
-            return Err(Error::ReasonTooLong);
-        }
-    }
-    Ok(())
-}
-
-fn validate_source_reference(source_chain: &String, source_tx: &String) -> Result<(), Error> {
-    if source_chain.len() > MAX_SOURCE_CHAIN_LEN || source_tx.len() > MAX_SOURCE_TX_LEN {
-        return Err(Error::MetadataTooLong);
-    }
-    Ok(())
-}
-
-fn validate_tags(tags: &Option<Vec<String>>) -> Result<(), Error> {
-    if let Some(t) = tags {
-        if t.len() > 5 {
-            return Err(Error::TooManyTags);
-        }
-        for tag in t.iter() {
-            if tag.len() > 32 {
-                return Err(Error::TagTooLong);
-            }
-        }
-    }
-    Ok(())
-}
-
-fn validate_jurisdiction(env: &Env, jurisdiction: &Option<String>) -> Result<(), Error> {
-    if let Some(code) = jurisdiction {
-        if code.len() != 2 {
-            return Err(Error::InvalidJurisdiction);
-        }
-        let valid_codes = [
-            "AF","AX","AL","DZ","AS","AD","AO","AI","AQ","AG","AR","AM","AW","AU","AT","AZ",
-            "BS","BH","BD","BB","BY","BE","BZ","BJ","BM","BT","BO","BQ","BA","BW","BV","BR",
-            "IO","BN","BG","BF","BI","CV","KH","CM","CA","KY","CF","TD","CL","CN","CX","CC",
-            "CO","KM","CG","CD","CK","CR","CI","HR","CU","CW","CY","CZ","DK","DJ","DM","DO",
-            "EC","EG","SV","GQ","ER","EE","SZ","ET","FK","FO","FJ","FI","FR","GF","PF","TF",
-            "GA","GM","GE","DE","GH","GI","GR","GL","GD","GP","GU","GT","GG","GN","GW","GY",
-            "HT","HM","VA","HN","HK","HU","IS","IN","ID","IR","IQ","IE","IM","IL","IT","JM",
-            "JP","JE","JO","KZ","KE","KI","KP","KR","KW","KG","LA","LV","LB","LS","LR","LY",
-            "LI","LT","LU","MO","MK","MG","MW","MY","MV","ML","MT","MH","MQ","MR","MU","YT",
-            "MX","FM","MD","MC","MN","ME","MS","MA","MZ","MM","NA","NR","NP","NL","NC","NZ",
-            "NI","NE","NG","NU","NF","MP","NO","OM","PK","PW","PS","PA","PG","PY","PE","PH",
-            "PN","PL","PT","PR","QA","RE","RO","RU","RW","BL","SH","KN","LC","MF","PM","VC",
-            "WS","SM","ST","SA","SN","RS","SC","SL","SG","SX","SK","SI","SB","SO","ZA","GS",
-            "SS","ES","LK","SD","SR","SJ","SE","CH","SY","TW","TJ","TZ","TH","TL","TG","TK",
-            "TO","TT","TN","TR","TM","TC","TV","UG","UA","AE","GB","US","UM","UY","UZ","VU",
-            "VE","VN","VG","VI","WF","EH","YE","ZM","ZW",
-        ];
-        let mut valid = false;
-        for iso in valid_codes.iter() {
-            if code == &String::from_str(env, iso) {
-                valid = true;
-                break;
-            }
-        }
-        if !valid {
-            return Err(Error::InvalidJurisdiction);
-        }
-    }
-    Ok(())
-}
-
-fn validate_native_expiration(env: &Env, expiration: Option<u64>) -> Result<(), Error> {
-    if let Some(v) = expiration {
-        if v <= env.ledger().timestamp() {
-            return Err(Error::InvalidExpiration);
-        }
-    }
-    Ok(())
-}
-
-/// Validate that `valid_from`, when provided, is strictly in the future.
-///
-/// A `valid_from` equal to or before the current ledger timestamp would
-/// immediately resolve to `Valid`, making the field meaningless. Callers
-/// that want an immediately-active attestation should omit `valid_from`.
-fn validate_valid_from(env: &Env, valid_from: Option<u64>) -> Result<(), Error> {
-    if let Some(vf) = valid_from {
-        if vf <= env.ledger().timestamp() {
-            return Err(Error::InvalidValidFrom);
-        }
-    }
-    Ok(())
-}
-
-fn validate_import_timestamps(env: &Env, timestamp: u64, expiration: Option<u64>) -> Result<(), Error> {
-    if timestamp > env.ledger().timestamp() {
-        return Err(Error::InvalidTimestamp);
-    }
-    if let Some(v) = expiration {
-        if v <= timestamp {
-            return Err(Error::InvalidExpiration);
-        }
-    }
-    Ok(())
-}
-
-fn validate_fee_config(env: &Env, fee: i128, fee_token: &Option<Address>) -> Result<(), Error> {
-    if fee < 0 {
-        return Err(Error::InvalidFee);
-    }
-    if fee > 0 && fee_token.is_none() {
-        return Err(Error::FeeTokenRequired);
-    }
-
-    // Validate that fee_token is a real token contract by attempting a balance call.
-    // Using try_balance (non-panicking) so a non-token address returns InvalidFeeToken
-    // instead of causing a runtime panic inside create_attestation.
-    if let Some(token_addr) = fee_token {
-        let token = TokenClient::new(env, token_addr);
-        token
-            .try_balance(&env.current_contract_address())
-            .map_err(|_| Error::InvalidFeeToken)?;
-    }
-    Ok(())
-}
-
-fn check_rate_limit(env: &Env, issuer: &Address) -> Result<(), Error> {
-    if let Some(config) = Storage::get_rate_limit_config(env) {
-        if config.min_issuance_interval == 0 {
-            return Ok(());
-        }
-        let current_time = env.ledger().timestamp();
-        if let Some(last) = Storage::get_last_issuance_time(env, issuer) {
-            if current_time.saturating_sub(last) < config.min_issuance_interval {
-                return Err(Error::RateLimited);
-            }
-        }
-    }
-    Ok(())
-}
-
-fn default_fee_config(admin: &Address) -> FeeConfig {
-    FeeConfig { attestation_fee: 0, fee_collector: admin.clone(), fee_token: None }
-}
-
-fn load_fee_config(env: &Env) -> Result<FeeConfig, Error> {
-    Storage::get_fee_config(env).ok_or(Error::NotInitialized)
-}
-
-fn charge_attestation_fee(env: &Env, issuer: &Address) -> Result<(), Error> {
-    let fee_config = load_fee_config(env)?;
-    if fee_config.attestation_fee == 0 {
-        return Ok(());
-    }
-    let fee_token = fee_config.fee_token.ok_or(Error::FeeTokenRequired)?;
-    TokenClient::new(env, &fee_token).transfer(issuer, &fee_config.fee_collector, &fee_config.attestation_fee);
-    Ok(())
-}
-
-/// Shared helper: persist attestation + update indexes + increment counters.
-fn store_attestation(env: &Env, attestation: &Attestation) {
-    Storage::set_attestation(env, attestation);
-    Storage::add_subject_attestation(env, &attestation.subject, &attestation.id);
-    Storage::add_issuer_attestation(env, &attestation.issuer, &attestation.id);
-    let mut stats = Storage::get_issuer_stats(env, &attestation.issuer);
-    stats.total_issued += 1;
-    Storage::set_issuer_stats(env, &attestation.issuer, &stats);
-    Storage::increment_total_attestations(env, 1);
-}
-
-fn maybe_trigger_expiration_hook(
-    env: &Env,
-    subject: &Address,
-    attestation_id: &String,
-    expiration: u64,
-    current_time: u64,
-) {
-    let hook = match Storage::get_expiration_hook(env, subject) {
-        Some(h) => h,
-        None => return,
-    };
-    let notify_window = (hook.notify_days_before as u64) * SECS_PER_DAY;
-    let notify_from = expiration.saturating_sub(notify_window);
-    if current_time >= notify_from && current_time < expiration {
-        Events::expiration_hook_triggered(env, subject, attestation_id, expiration);
-        let client = ExpirationCallbackClient::new(env, &hook.callback_contract);
-        let _ = client.try_notify_expiring(subject, attestation_id, &expiration);
-    }
-}
+use crate::types::{
+    Attestation, AttestationRequest, AttestationStatus, AuditEntry, Error,
+    ExpirationHook, FeeConfig, GlobalStats, HealthStatus, IssuerMetadata, IssuerStats, IssuerTier,
+    MultiSigProposal, RateLimitConfig, StorageLimits,
+};
 
 #[contract]
 pub struct TrustLinkContract;
@@ -243,124 +43,35 @@ impl TrustLinkContract {
     // -----------------------------------------------------------------------
 
     pub fn initialize(env: Env, admin: Address, ttl_days: Option<u32>) -> Result<(), Error> {
-        admin.require_auth();
-        if Storage::has_admin(&env) {
-            return Err(Error::AlreadyInitialized);
-        }
-        let mut council: AdminCouncil = Vec::new(&env);
-        council.push_back(admin.clone());
-        Storage::set_admin_council(&env, &council);
-        Storage::set_version(&env, &String::from_str(&env, "1.0.0"));
-        Storage::set_fee_config(&env, &default_fee_config(&admin));
-        let days = ttl_days.unwrap_or(30);
-        Storage::set_ttl_config(&env, &TtlConfig { ttl_days: days });
-        Events::admin_initialized(&env, &admin, env.ledger().timestamp());
-        Ok(())
+        admin::initialize(&env, admin, ttl_days)
     }
 
     pub fn transfer_admin(env: Env, current_admin: Address, new_admin: Address) -> Result<(), Error> {
-        current_admin.require_auth();
-        Validation::require_admin(&env, &current_admin)?;
-        Storage::add_admin(&env, &new_admin);
-        Storage::remove_admin(&env, &current_admin);
-        Events::admin_transferred(&env, &current_admin, &new_admin);
-        Ok(())
+        admin::transfer_admin(&env, current_admin, new_admin)
     }
 
-    /// Step 1 of two-step admin transfer: propose a new admin.
-    ///
-    /// Stores the pending transfer. The new admin must call `accept_admin_transfer`
-    /// to complete the handover, preventing lockout from a typo in the address.
-    ///
-    /// # Errors
-    /// - [`Error::Unauthorized`] — caller is not the current admin.
-    pub fn propose_admin_transfer(
-        env: Env,
-        current_admin: Address,
-        new_admin: Address,
-    ) -> Result<(), Error> {
-        current_admin.require_auth();
-        Validation::require_admin(&env, &current_admin)?;
-        Storage::set_pending_admin_transfer(
-            &env,
-            &PendingAdminTransfer {
-                proposed_by: current_admin.clone(),
-                new_admin: new_admin.clone(),
-            },
-        );
-        Events::admin_transfer_proposed(&env, &current_admin, &new_admin);
-        Ok(())
+    pub fn propose_admin_transfer(env: Env, current_admin: Address, new_admin: Address) -> Result<(), Error> {
+        admin::propose_admin_transfer(&env, current_admin, new_admin)
     }
 
-    /// Cancel a pending two-step admin transfer.
-    ///
-    /// Only the current admin who proposed the transfer may cancel it.
-    ///
-    /// # Errors
-    /// - [`Error::Unauthorized`] — caller is not the current admin.
-    /// - [`Error::NotFound`] — no pending transfer exists.
     pub fn cancel_admin_transfer(env: Env, current_admin: Address) -> Result<(), Error> {
-        current_admin.require_auth();
-        Validation::require_admin(&env, &current_admin)?;
-        let pending = Storage::get_pending_admin_transfer(&env).ok_or(Error::NotFound)?;
-        if pending.proposed_by != current_admin {
-            return Err(Error::Unauthorized);
-        }
-        Storage::remove_pending_admin_transfer(&env);
-        Ok(())
+        admin::cancel_admin_transfer(&env, current_admin)
     }
 
-    /// Step 2 of two-step admin transfer: new admin accepts the pending transfer.
-    ///
-    /// # Errors
-    /// - [`Error::NotFound`] — no pending transfer exists.
-    /// - [`Error::Unauthorized`] — caller is not the proposed new admin.
     pub fn accept_admin_transfer(env: Env, new_admin: Address) -> Result<(), Error> {
-        new_admin.require_auth();
-        let pending = Storage::get_pending_admin_transfer(&env).ok_or(Error::NotFound)?;
-        if pending.new_admin != new_admin {
-            return Err(Error::Unauthorized);
-        }
-        Storage::add_admin(&env, &new_admin);
-        Storage::remove_admin(&env, &pending.proposed_by);
-        Storage::remove_pending_admin_transfer(&env);
-        Events::admin_transferred(&env, &pending.proposed_by, &new_admin);
-        Ok(())
+        admin::accept_admin_transfer(&env, new_admin)
     }
 
-    /// Add new admin to council (any existing admin).
-    pub fn add_admin(
-        env: Env,
-        existing_admin: Address,
-        new_admin: Address,
-    ) -> Result<(), Error> {
-        existing_admin.require_auth();
-        Validation::require_admin(&env, &existing_admin)?;
-        if Storage::is_admin(&env, &new_admin) {
-            return Ok(());
-        }
-        Storage::add_admin(&env, &new_admin);
-        Events::admin_added(&env, &existing_admin, &new_admin, env.ledger().timestamp());
-        Ok(())
+    pub fn add_admin(env: Env, existing_admin: Address, new_admin: Address) -> Result<(), Error> {
+        admin::add_admin(&env, existing_admin, new_admin)
     }
 
     pub fn remove_admin(env: Env, existing_admin: Address, admin_to_remove: Address) -> Result<(), Error> {
-        existing_admin.require_auth();
-        Validation::require_admin(&env, &existing_admin)?;
-        let council = Storage::get_admin_council(&env)?;
-        if council.len() <= 1 {
-            return Err(Error::LastAdminCannotBeRemoved);
-        }
-        if !Storage::is_admin(&env, &admin_to_remove) {
-            return Ok(());
-        }
-        Storage::remove_admin(&env, &admin_to_remove);
-        Events::admin_removed(&env, &existing_admin, &admin_to_remove, env.ledger().timestamp());
-        Ok(())
+        admin::remove_admin(&env, existing_admin, admin_to_remove)
     }
 
     pub fn get_admin(env: Env) -> Result<Address, Error> {
-        Storage::get_admin(&env)
+        admin::get_admin(&env)
     }
 
     // -----------------------------------------------------------------------
@@ -368,95 +79,60 @@ impl TrustLinkContract {
     // -----------------------------------------------------------------------
 
     pub fn register_issuer(env: Env, admin: Address, issuer: Address) -> Result<(), Error> {
-        admin.require_auth();
-        Validation::require_admin(&env, &admin)?;
-        Validation::require_not_paused(&env)?;
-        if Storage::is_bridge(&env, &issuer) {
-            return Err(Error::Unauthorized);
-        }
-        Storage::add_issuer(&env, &issuer);
-        Storage::increment_total_issuers(&env);
-        Events::issuer_registered(&env, &issuer, &admin, env.ledger().timestamp());
-        Ok(())
+        admin::register_issuer(&env, admin, issuer)
     }
 
     pub fn remove_issuer(env: Env, admin: Address, issuer: Address) -> Result<(), Error> {
-        admin.require_auth();
-        Validation::require_admin(&env, &admin)?;
-        Storage::remove_issuer(&env, &issuer);
-        Storage::decrement_total_issuers(&env);
-        Events::issuer_removed(&env, &issuer, &admin, env.ledger().timestamp());
-        Ok(())
+        admin::remove_issuer(&env, admin, issuer)
     }
 
-    /// Add `subject` to `issuer`'s whitelist.
     pub fn add_to_whitelist(env: Env, issuer: Address, subject: Address) -> Result<(), Error> {
-        issuer.require_auth();
-        Validation::require_issuer(&env, &issuer)?;
-        Storage::add_to_whitelist(&env, &issuer, &subject);
-        Ok(())
+        admin::add_to_whitelist(&env, issuer, subject)
     }
 
-    /// Remove `subject` from `issuer`'s whitelist.
     pub fn remove_from_whitelist(env: Env, issuer: Address, subject: Address) -> Result<(), Error> {
-        issuer.require_auth();
-        Validation::require_issuer(&env, &issuer)?;
-        Storage::remove_from_whitelist(&env, &issuer, &subject);
-        Ok(())
+        admin::remove_from_whitelist(&env, issuer, subject)
     }
 
-    /// Return `true` if `subject` is whitelisted for `issuer`.
     #[must_use]
     pub fn is_whitelisted(env: Env, issuer: Address, subject: Address) -> bool {
-        Storage::is_whitelisted(&env, &issuer, &subject)
+        admin::is_whitelisted(&env, issuer, subject)
     }
 
-    /// Return `true` if whitelist mode is enabled for `issuer`.
     #[must_use]
     pub fn is_whitelist_enabled(env: Env, issuer: Address) -> bool {
-        Storage::is_whitelist_enabled(&env, &issuer)
+        admin::is_whitelist_enabled(&env, issuer)
     }
 
-    /// Update the trust tier of an already-registered issuer.
-    ///
-    /// # Errors
-    /// - [`Error::Unauthorized`] — caller is not admin, or `issuer` is not registered.
-    pub fn set_issuer_tier(
-        env: Env,
-        admin: Address,
-        issuer: Address,
-        tier: IssuerTier,
-    ) -> Result<(), Error> {
-        admin.require_auth();
-        Validation::require_admin(&env, &admin)?;
-        Validation::require_issuer(&env, &issuer)?;
-        Storage::set_issuer_tier(&env, &issuer, &tier);
-        Events::issuer_tier_updated(&env, &issuer, &tier);
-        Ok(())
+    pub fn set_issuer_tier(env: Env, admin: Address, issuer: Address, tier: IssuerTier) -> Result<(), Error> {
+        admin::set_issuer_tier(&env, admin, issuer, tier)
     }
 
-    /// Return a confidence score (0–100) for an attestation based on:
-    /// - Issuer tier: Basic=30, Verified=60, Premium=90
-    /// - Each endorsement adds 2 points (capped at 10 points total from endorsements)
-    ///
-    /// Returns `None` if the attestation does not exist.
     pub fn get_confidence_score(env: Env, attestation_id: String) -> Option<u32> {
-        let attestation = Storage::get_attestation(&env, &attestation_id).ok()?;
-
-        let tier_score = match Storage::get_issuer_tier(&env, &attestation.issuer) {
-            Some(IssuerTier::Premium) => 90u32,
-            Some(IssuerTier::Verified) => 60u32,
-            Some(IssuerTier::Basic) | None => 30u32,
-        };
-
-        let endorsements = Storage::get_endorsements(&env, &attestation_id);
-        let endorsement_score = (endorsements.len() * 2).min(10);
-
-        Some(tier_score + endorsement_score)
+        admin::get_confidence_score(&env, attestation_id)
     }
 
     pub fn get_issuer_metadata(env: Env, issuer: Address) -> Option<IssuerMetadata> {
-        Storage::get_issuer_metadata(&env, &issuer)
+        admin::get_issuer_metadata(&env, issuer)
+    }
+
+    pub fn set_issuer_metadata(env: Env, issuer: Address, metadata: IssuerMetadata) -> Result<(), Error> {
+        admin::set_issuer_metadata(&env, issuer, metadata)
+    }
+
+    #[must_use]
+    pub fn get_issuer_stats(env: Env, issuer: Address) -> IssuerStats {
+        admin::get_issuer_stats(&env, issuer)
+    }
+
+    #[must_use]
+    pub fn is_issuer(env: Env, address: Address) -> bool {
+        admin::is_issuer(&env, address)
+    }
+
+    #[must_use]
+    pub fn get_issuer_tier(env: Env, issuer: Address) -> Option<IssuerTier> {
+        admin::get_issuer_tier(&env, issuer)
     }
 
     // -----------------------------------------------------------------------
@@ -464,58 +140,44 @@ impl TrustLinkContract {
     // -----------------------------------------------------------------------
 
     pub fn register_bridge(env: Env, admin: Address, bridge_contract: Address) -> Result<(), Error> {
-        admin.require_auth();
-        Validation::require_admin(&env, &admin)?;
-        if Storage::is_issuer(&env, &bridge_contract) {
-            return Err(Error::Unauthorized);
-        }
-        Storage::add_bridge(&env, &bridge_contract);
-        Ok(())
+        admin::register_bridge(&env, admin, bridge_contract)
     }
 
     pub fn is_bridge(env: Env, address: Address) -> bool {
-        Storage::is_bridge(&env, &address)
+        admin::is_bridge(&env, address)
     }
 
     // -----------------------------------------------------------------------
-    // Whitelist management
+    // Whitelist mode
     // -----------------------------------------------------------------------
 
     pub fn set_whitelist_enabled(env: Env, issuer: Address, enabled: bool) -> Result<(), Error> {
-        issuer.require_auth();
-        Validation::require_issuer(&env, &issuer)?;
-        Storage::set_whitelist_enabled(&env, &issuer, enabled);
-        Ok(())
+        admin::set_whitelist_enabled(&env, issuer, enabled)
     }
 
     pub fn enable_whitelist_mode(env: Env, issuer: Address) -> Result<(), Error> {
-        issuer.require_auth();
-        Validation::require_issuer(&env, &issuer)?;
-        Storage::set_whitelist_mode(&env, &issuer, true);
-        Events::whitelist_mode_enabled(&env, &issuer);
-        Ok(())
+        admin::enable_whitelist_mode(&env, issuer)
     }
 
-    /// Create a new attestation about a subject address.    ///
-    /// The attestation ID is derived deterministically from `(issuer, subject,
-    /// claim_type, timestamp)`, so the same combination at the same ledger
-    /// timestamp will always produce the same ID.
-    ///
+    // -----------------------------------------------------------------------
+    // Fee & rate limit
+    // -----------------------------------------------------------------------
+
     pub fn get_fee_config(env: Env) -> Result<FeeConfig, Error> {
-        load_fee_config(&env)
+        admin::get_fee_config(&env)
+    }
+
+    pub fn set_fee(env: Env, admin: Address, fee: i128, collector: Address, fee_token: Option<Address>) -> Result<(), Error> {
+        admin::set_fee(&env, admin, fee, collector, fee_token)
     }
 
     pub fn set_rate_limit(env: Env, admin: Address, min_issuance_interval: u64) -> Result<(), Error> {
-        admin.require_auth();
-        Validation::require_admin(&env, &admin)?;
-        Storage::set_rate_limit_config(&env, &RateLimitConfig { min_issuance_interval });
-        Ok(())
+        admin::set_rate_limit(&env, admin, min_issuance_interval)
     }
 
-    /// Retrieve the current rate limit configuration, or `None` if not set.
     #[must_use]
     pub fn get_rate_limit(env: Env) -> Option<RateLimitConfig> {
-        Storage::get_rate_limit_config(&env)
+        admin::get_rate_limit(&env)
     }
 
     // -----------------------------------------------------------------------
@@ -523,124 +185,77 @@ impl TrustLinkContract {
     // -----------------------------------------------------------------------
 
     pub fn pause(env: Env, admin: Address) -> Result<(), Error> {
-        admin.require_auth();
-        Validation::require_admin(&env, &admin)?;
-        Storage::set_paused(&env, true);
-        Events::contract_paused(&env, &admin, env.ledger().timestamp());
-        Ok(())
+        admin::pause(&env, admin)
     }
 
     pub fn unpause(env: Env, admin: Address) -> Result<(), Error> {
-        admin.require_auth();
-        Validation::require_admin(&env, &admin)?;
-        Storage::set_paused(&env, false);
-        Events::contract_unpaused(&env, &admin, env.ledger().timestamp());
-        Ok(())
+        admin::unpause(&env, admin)
     }
 
-    /// Return `true` if the contract is currently paused.
     #[must_use]
     pub fn is_paused(env: Env) -> bool {
-        Storage::is_paused(&env)
+        admin::is_paused(&env)
     }
 
+    // -----------------------------------------------------------------------
+    // Limits
+    // -----------------------------------------------------------------------
 
-        fn create_attestation_internal(
-        env: &Env,
-        issuer: Address,
-        subject: Address,
-        claim_type: String,
-        expiration: Option<u64>,
-        metadata: Option<String>,
-        jurisdiction: Option<String>,
-        tags: Option<Vec<String>>,
-        valid_from: Option<u64>,
-    ) -> Result<String, Error> {
-        issuer.require_auth();
-        Validation::require_not_paused(&env)?;
-        Validation::require_issuer(&env, &issuer)?;
-        Validation::validate_claim_type(&claim_type)?;
-        validate_metadata(&env, &metadata)?;
-        validate_jurisdiction(env, &jurisdiction)?;
-        validate_tags(&tags)?;
-        validate_native_expiration(env, expiration)?;
-        validate_valid_from(env, valid_from)?;
-
-        if issuer == subject {
-            return Err(Error::Unauthorized);
-        }
-
-        if Storage::is_whitelist_mode(env, &issuer) && !Storage::is_whitelisted(env, &issuer, &subject) {
-            return Err(Error::SubjectNotWhitelisted);
-        }
-
-        check_rate_limit(env, &issuer)?;
-
-        let limits = Storage::get_limits(env);
-        let issuer_count = Storage::get_issuer_attestations(env, &issuer).len();
-        if issuer_count >= limits.max_attestations_per_issuer {
-            return Err(Error::LimitExceeded);
-        }
-        let subject_count = Storage::get_subject_attestations(env, &subject).len();
-        if subject_count >= limits.max_attestations_per_subject {
-            return Err(Error::LimitExceeded);
-        }
-
-        let timestamp = env.ledger().timestamp();
-        let attestation_id = Attestation::generate_id(env, &issuer, &subject, &claim_type, timestamp);
-
-        if Storage::has_attestation(env, &attestation_id) {
-            return Err(Error::DuplicateAttestation);
-        }
-        
-        // Reject subject if issuer has whitelist mode enabled and subject is not listed
-        if Storage::is_whitelist_mode(&env, &issuer)
-            && !Storage::is_whitelisted(&env, &issuer, &subject)
-        {
-            return Err(Error::SubjectNotWhitelisted);
-        }
-
-        let attestation = Attestation {
-            id: attestation_id.clone(),
-            issuer: issuer.clone(),
-            subject,
-            claim_type,
-            timestamp,
-            expiration,
-            revoked: false,
-            deleted: false,
-            metadata,
-            jurisdiction,
-            valid_from,
-            origin: AttestationOrigin::Native,
-            source_chain: None,
-            source_tx: None,
-            tags,
-            revocation_reason: None,
-                    };
-
-        // CHECKS-EFFECTS-INTERACTIONS: persist all state BEFORE calling the
-        // external token contract so a re-entrant call sees a fully-committed
-        // attestation and is blocked by the duplicate-ID guard.
-        store_attestation(env, &attestation);
-        Storage::append_audit_entry(
-            env,
-            &attestation_id,
-            &AuditEntry {
-                action: AuditAction::Created,
-                actor: attestation.issuer.clone(),
-                timestamp,
-                details: None,
-            },
-        );
-        Storage::set_last_issuance_time(env, &issuer, timestamp);
-
-        // INTERACTION: call external token contract after state is fully persisted.
-        charge_attestation_fee(env, &issuer)?;
-
-        Events::attestation_created(env, &attestation);
-        Ok(attestation_id)
+    #[must_use]
+    pub fn get_limits(env: Env) -> StorageLimits {
+        admin::get_limits(&env)
     }
+
+    pub fn set_limits(env: Env, admin: Address, max_attestations_per_issuer: u32, max_attestations_per_subject: u32) -> Result<(), Error> {
+        admin::set_limits(&env, admin, max_attestations_per_issuer, max_attestations_per_subject)
+    }
+
+    // -----------------------------------------------------------------------
+    // Claim type registry
+    // -----------------------------------------------------------------------
+
+    pub fn register_claim_type(env: Env, admin: Address, claim_type: String, description: String) -> Result<(), Error> {
+        admin::register_claim_type(&env, admin, claim_type, description)
+    }
+
+    #[must_use]
+    pub fn get_claim_type_description(env: Env, claim_type: String) -> Option<String> {
+        admin::get_claim_type_description(&env, claim_type)
+    }
+
+    #[must_use]
+    pub fn list_claim_types(env: Env, start: u32, limit: u32) -> Vec<String> {
+        admin::list_claim_types(&env, start, limit)
+    }
+
+    // -----------------------------------------------------------------------
+    // Delegation
+    // -----------------------------------------------------------------------
+
+    pub fn delegate_claim_type(env: Env, issuer: Address, delegate: Address, claim_type: String, expiration: Option<u64>) -> Result<(), Error> {
+        admin::delegate_claim_type(&env, issuer, delegate, claim_type, expiration)
+    }
+
+    // -----------------------------------------------------------------------
+    // Expiration hooks
+    // -----------------------------------------------------------------------
+
+    pub fn register_expiration_hook(env: Env, subject: Address, callback_contract: Address, notify_days_before: u32) -> Result<(), Error> {
+        admin::register_expiration_hook(&env, subject, callback_contract, notify_days_before)
+    }
+
+    #[must_use]
+    pub fn get_expiration_hook(env: Env, subject: Address) -> Option<ExpirationHook> {
+        admin::get_expiration_hook(&env, subject)
+    }
+
+    pub fn remove_expiration_hook(env: Env, subject: Address) -> Result<(), Error> {
+        admin::remove_expiration_hook(&env, subject)
+    }
+
+    // -----------------------------------------------------------------------
+    // Attestation creation
+    // -----------------------------------------------------------------------
 
     pub fn create_attestation(
         env: Env,
@@ -651,19 +266,9 @@ impl TrustLinkContract {
         metadata: Option<String>,
         tags: Option<Vec<String>>,
     ) -> Result<String, Error> {
-        Self::create_attestation_internal(&env, issuer, subject, claim_type, expiration, metadata, None, tags, None)
+        attestation::create_attestation(&env, issuer, subject, claim_type, expiration, metadata, tags)
     }
 
-    /// Create an attestation that becomes active only at `valid_from`.
-    ///
-    /// Until `valid_from` is reached the attestation has status `Pending` and
-    /// `has_valid_claim` returns `false` for it. Once the ledger timestamp
-    /// reaches `valid_from` the status automatically resolves to `Valid`
-    /// (assuming it is not revoked or expired).
-    ///
-    /// # Errors
-    /// - [`Error::InvalidValidFrom`] — `valid_from` is not strictly in the future.
-    /// - All errors from [`create_attestation`].
     pub fn create_attestation_valid_from(
         env: Env,
         issuer: Address,
@@ -674,7 +279,7 @@ impl TrustLinkContract {
         tags: Option<Vec<String>>,
         valid_from: u64,
     ) -> Result<String, Error> {
-        Self::create_attestation_internal(&env, issuer, subject, claim_type, expiration, metadata, None, tags, Some(valid_from))
+        attestation::create_attestation_valid_from(&env, issuer, subject, claim_type, expiration, metadata, tags, valid_from)
     }
 
     pub fn create_attestation_jurisdiction(
@@ -687,7 +292,7 @@ impl TrustLinkContract {
         jurisdiction: Option<String>,
         tags: Option<Vec<String>>,
     ) -> Result<String, Error> {
-        Self::create_attestation_internal(&env, issuer, subject, claim_type, expiration, metadata, jurisdiction, tags, None)
+        attestation::create_attestation_jurisdiction(&env, issuer, subject, claim_type, expiration, metadata, jurisdiction, tags)
     }
 
     pub fn import_attestation(
@@ -699,51 +304,7 @@ impl TrustLinkContract {
         timestamp: u64,
         expiration: Option<u64>,
     ) -> Result<String, Error> {
-        admin.require_auth();
-        Validation::require_admin(&env, &admin)?;
-        Validation::require_not_paused(&env)?;
-        Validation::require_issuer(&env, &issuer)?;
-        validate_import_timestamps(&env, timestamp, expiration)?;
-
-        let attestation_id =
-            Attestation::generate_id(&env, &issuer, &subject, &claim_type, timestamp);
-
-        if Storage::has_attestation(&env, &attestation_id) {
-            return Err(Error::DuplicateAttestation);
-        }
-
-        let attestation = Attestation {
-            id: attestation_id.clone(),
-            issuer,
-            subject,
-            claim_type,
-            timestamp,
-            expiration,
-            revoked: false,
-            deleted: false,
-            metadata: None,
-            jurisdiction: None,
-            valid_from: None,
-            origin: AttestationOrigin::Imported,
-            source_chain: None,
-            source_tx: None,
-            tags: None,
-            revocation_reason: None,
-        };
-
-        store_attestation(&env, &attestation);
-        Events::attestation_imported(&env, &attestation);
-        Storage::append_audit_entry(
-            &env,
-            &attestation_id,
-            &AuditEntry {
-                action: AuditAction::Created,
-                actor: admin.clone(),
-                timestamp,
-                details: None,
-            },
-        );
-        Ok(attestation_id)
+        attestation::import_attestation(&env, admin, issuer, subject, claim_type, timestamp, expiration)
     }
 
     pub fn bridge_attestation(
@@ -754,53 +315,7 @@ impl TrustLinkContract {
         source_chain: String,
         source_tx: String,
     ) -> Result<String, Error> {
-        bridge.require_auth();
-        Validation::require_bridge(&env, &bridge)?;
-        Validation::require_not_paused(&env)?;
-
-        if source_chain.len() > MAX_SOURCE_CHAIN_LEN {
-            return Err(Error::MetadataTooLong);
-        }
-        if source_tx.len() > MAX_SOURCE_TX_LEN {
-            return Err(Error::MetadataTooLong);
-        }
-
-        let timestamp = env.ledger().timestamp();
-        let attestation_id = Attestation::generate_bridge_id(
-            &env, &bridge, &subject, &claim_type, &source_chain, &source_tx, timestamp,
-        );
-        if Storage::has_attestation(&env, &attestation_id) {
-            return Err(Error::DuplicateAttestation);
-        }
-
-        let attestation = Attestation {
-            id: attestation_id.clone(),
-            issuer: bridge,
-            subject,
-            claim_type,
-            timestamp,
-            expiration: None,
-            revoked: false,
-            deleted: false,
-            metadata: None,
-            jurisdiction: None,
-            valid_from: None,
-            origin: AttestationOrigin::Bridged,
-            source_chain: Some(source_chain),
-            source_tx: Some(source_tx),
-            tags: None,
-            revocation_reason: None,
-                    };
-
-        store_attestation(&env, &attestation);
-        Events::attestation_bridged(&env, &attestation);
-        Storage::append_audit_entry(&env, &attestation_id, &AuditEntry {
-            action: AuditAction::Created,
-            actor: attestation.issuer.clone(),
-            timestamp,
-            details: None,
-        });
-        Ok(attestation_id)
+        attestation::bridge_attestation(&env, bridge, subject, claim_type, source_chain, source_tx)
     }
 
     pub fn create_attestations_batch(
@@ -810,643 +325,134 @@ impl TrustLinkContract {
         claim_type: String,
         expiration: Option<u64>,
     ) -> Result<Vec<String>, Error> {
-        issuer.require_auth();
-        Validation::require_issuer(&env, &issuer)?;
-        Validation::require_not_paused(&env)?;
-        validate_claim_type(&claim_type)?;
-        validate_native_expiration(&env, expiration)?;
-        check_rate_limit(&env, &issuer)?;
-
-        let timestamp = env.ledger().timestamp();
-
-        // Enforce issuer-level limit up front for the whole batch
-        let limits = Storage::get_limits(&env);
-        let issuer_count = Storage::get_issuer_attestations(&env, &issuer).len();
-        if issuer_count.saturating_add(subjects.len()) > limits.max_attestations_per_issuer {
-            return Err(Error::LimitExceeded);
-        }
-
-        let mut ids: Vec<String> = Vec::new(&env);
-
-        for subject in subjects.iter() {
-            let attestation_id =
-                Attestation::generate_id(&env, &issuer, &subject, &claim_type, timestamp);
-
-            if Storage::has_attestation(&env, &attestation_id) {
-                return Err(Error::DuplicateAttestation);
-            }
-
-            // Per-subject limit check
-            let subject_count = Storage::get_subject_attestations(&env, &subject).len();
-            if subject_count >= limits.max_attestations_per_subject {
-                return Err(Error::LimitExceeded);
-            }
-
-            let attestation = Attestation {
-                id: attestation_id.clone(),
-                issuer: issuer.clone(),
-                subject: subject.clone(),
-                claim_type: claim_type.clone(),
-                timestamp,
-                expiration,
-                revoked: false,
-                deleted: false,
-                metadata: None,
-                jurisdiction: None,
-                valid_from: None,
-                origin: AttestationOrigin::Native,
-                source_chain: None,
-                source_tx: None,
-                tags: None,
-                revocation_reason: None,
-                            };
-
-            store_attestation(&env, &attestation);
-            Events::attestation_created(&env, &attestation);
-            Storage::append_audit_entry(
-                &env,
-                &attestation_id,
-                &AuditEntry {
-                    action: AuditAction::Created,
-                    actor: issuer.clone(),
-                    timestamp,
-                    details: None,
-                },
-            );
-            ids.push_back(attestation_id);
-        }
-
-        Storage::set_last_issuance_time(&env, &issuer, timestamp);
-        Ok(ids)
+        attestation::create_attestations_batch(&env, issuer, subjects, claim_type, expiration)
     }
 
-    /// Revoke an attestation.
-    ///
-    /// SECURITY (FINDING-002): `require_issuer` ensures the caller is a
-    /// currently registered issuer, preventing deregistered issuers from
-    /// revoking attestations.
-    pub fn revoke_attestation(
-        env: Env,
-        issuer: Address,
-        attestation_id: String,
-        reason: Option<String>,
-    ) -> Result<(), Error> {
-        issuer.require_auth();
-        Validation::require_not_paused(&env)?;
-        // FINDING-002 fix: verify caller is a currently registered issuer.
-        Validation::require_issuer(&env, &issuer)?;
-        validate_reason(&reason)?;
-
-        let mut attestation = Storage::get_attestation(&env, &attestation_id)?;
-        if attestation.issuer != issuer {
-            return Err(Error::Unauthorized);
-        }
-        if attestation.revoked {
-            return Err(Error::AlreadyRevoked);
-        }
-
-        attestation.revoked = true;
-        attestation.revocation_reason = reason.clone();
-        Storage::set_attestation(&env, &attestation);
-        Storage::remove_subject_attestation(&env, &attestation.subject, &attestation_id);
-        Storage::remove_issuer_attestation(&env, &issuer, &attestation_id);
-
-        Events::attestation_revoked(&env, &attestation_id, &issuer, &reason);
-        Storage::append_audit_entry(&env, &attestation_id, &AuditEntry {
-            action: AuditAction::Revoked,
-            actor: issuer.clone(),
-            timestamp: env.ledger().timestamp(),
-            details: reason.clone(),
-        });
-        Storage::increment_total_revocations(&env, 1);
-        Ok(())
+    pub fn revoke_attestation(env: Env, issuer: Address, attestation_id: String, reason: Option<String>) -> Result<(), Error> {
+        attestation::revoke_attestation(&env, issuer, attestation_id, reason)
     }
 
-    pub fn renew_attestation(
-        env: Env,
-        issuer: Address,
-        attestation_id: String,
-        new_expiration: Option<u64>,
-    ) -> Result<(), Error> {
-        issuer.require_auth();
-        Validation::require_issuer(&env, &issuer)?;
-        Validation::require_not_paused(&env)?;
-        validate_native_expiration(&env, new_expiration)?;
-
-        let mut attestation = Storage::get_attestation(&env, &attestation_id)?;
-        if attestation.issuer != issuer {
-            return Err(Error::Unauthorized);
-        }
-        if attestation.revoked {
-            return Err(Error::AlreadyRevoked);
-        }
-
-        attestation.expiration = new_expiration;
-        Storage::set_attestation(&env, &attestation);
-        Events::attestation_renewed(&env, &attestation_id, &issuer, new_expiration);
-        Storage::append_audit_entry(&env, &attestation_id, &AuditEntry {
-            action: AuditAction::Renewed,
-            actor: issuer.clone(),
-            timestamp: env.ledger().timestamp(),
-            details: None,
-        });
-        Ok(())
+    pub fn renew_attestation(env: Env, issuer: Address, attestation_id: String, new_expiration: Option<u64>) -> Result<(), Error> {
+        attestation::renew_attestation(&env, issuer, attestation_id, new_expiration)
     }
 
-    /// Revoke multiple attestations in a single atomic call (issuer only).
-    ///
-    /// Authorization is checked once for the issuer. If any attestation does
-    /// not belong to the caller or is already revoked the entire batch is
-    /// rolled back — no partial writes occur.
-    ///
-    /// Max batch size is 50. Passing more IDs returns [`Error::BatchTooLarge`].
-    ///
-    /// Emits one `revoked` event per attestation.
-    ///
-    /// # Parameters
-    /// - `issuer` — authorized issuer (must authorize).
-    /// - `attestation_ids` — list of IDs to revoke (max 50).
-    /// - `reason` — optional human-readable reason stored in the event data.
-    ///
-    /// # Returns
-    /// Count of revoked attestations.
-    ///
-    /// # Errors
-    /// - [`Error::BatchTooLarge`] — more than 50 IDs supplied.
-    /// - [`Error::Unauthorized`] — issuer is not registered or does not own an attestation.
-    /// - [`Error::NotFound`] — an ID does not exist.
-    /// - [`Error::AlreadyRevoked`] — an attestation is already revoked.
-    pub fn revoke_attestations_batch(
-        env: Env,
-        issuer: Address,
-        attestation_ids: Vec<String>,
-        reason: Option<String>,
-    ) -> Result<u32, Error> {
-        const MAX_BATCH: u32 = 50;
-
-        issuer.require_auth();
-        Validation::require_issuer(&env, &issuer)?;
-        validate_reason(&reason)?;
-
-        if attestation_ids.len() > MAX_BATCH {
-            return Err(Error::LimitExceeded);
-        }
-
-        // Validate all attestations first (atomic — no partial writes)
-        for id in attestation_ids.iter() {
-            let attestation = Storage::get_attestation(&env, &id)?;
-            if attestation.issuer != issuer {
-                return Err(Error::Unauthorized);
-            }
-            if attestation.revoked {
-                return Err(Error::AlreadyRevoked);
-            }
-        }
-
-        // All checks passed — apply writes
-        let mut count: u32 = 0;
-        for id in attestation_ids.iter() {
-            let mut attestation = Storage::get_attestation(&env, &id)?;
-            attestation.revoked = true;
-            attestation.revocation_reason = reason.clone();
-            Storage::set_attestation(&env, &attestation);
-            Storage::remove_subject_attestation(&env, &attestation.subject, &id);
-            Storage::remove_issuer_attestation(&env, &issuer, &id);
-            Events::attestation_revoked_with_reason(&env, &id, &issuer, &reason);
-            Storage::append_audit_entry(
-                &env,
-                &id,
-                &AuditEntry {
-                    action: AuditAction::Revoked,
-                    actor: issuer.clone(),
-                    timestamp: env.ledger().timestamp(),
-                    details: reason.clone(),
-                },
-            );
-            count += 1;
-        }
-
-        Storage::increment_total_revocations(&env, count as u64);
-        Ok(count)
+    pub fn revoke_attestations_batch(env: Env, issuer: Address, attestation_ids: Vec<String>, reason: Option<String>) -> Result<u32, Error> {
+        attestation::revoke_attestations_batch(&env, issuer, attestation_ids, reason)
     }
 
-    /// Return `true` if `subject` holds any valid attestation of `claim_type`.
-    /// Uses OR-logic: returns `true` if at least one matching attestation is valid.
+    pub fn update_expiration(env: Env, issuer: Address, attestation_id: String, new_expiration: Option<u64>) -> Result<(), Error> {
+        attestation::update_expiration(&env, issuer, attestation_id, new_expiration)
+    }
+
+    pub fn transfer_attestation(env: Env, admin: Address, attestation_id: String, new_issuer: Address) -> Result<(), Error> {
+        attestation::transfer_attestation(&env, admin, attestation_id, new_issuer)
+    }
+
+    pub fn request_deletion(env: Env, subject: Address, attestation_id: String) -> Result<(), Error> {
+        attestation::request_deletion(&env, subject, attestation_id)
+    }
+
+    pub fn endorse_attestation(env: Env, endorser: Address, attestation_id: String) -> Result<(), Error> {
+        attestation::endorse_attestation(&env, endorser, attestation_id)
+    }
+
+    #[must_use]
+    pub fn get_endorsement_count(env: Env, attestation_id: String) -> u32 {
+        attestation::get_endorsement_count(&env, attestation_id)
+    }
+
+    // -----------------------------------------------------------------------
+    // Query
+    // -----------------------------------------------------------------------
+
     #[must_use]
     pub fn has_valid_claim(env: Env, subject: Address, claim_type: String) -> bool {
-        let attestation_ids = Storage::get_subject_attestations(&env, &subject);
-        let current_time = env.ledger().timestamp();
-
-        for attestation_id in attestation_ids.iter() {
-            if let Ok(attestation) = Storage::get_attestation(&env, &attestation_id) {
-                if attestation.deleted || attestation.claim_type != claim_type {
-                    continue;
-                }
-                if attestation.get_status(current_time) == AttestationStatus::Valid {
-                    maybe_trigger_expiration_hook(
-                        &env,
-                        &subject,
-                        &attestation_id,
-                        attestation.expiration.unwrap_or(u64::MAX),
-                        current_time,
-                    );
-                    return true;
-                }
-            }
-        }
-        false
+        query::has_valid_claim(&env, subject, claim_type)
     }
 
     pub fn has_valid_claim_from_issuer(env: Env, subject: Address, claim_type: String, issuer: Address) -> bool {
-        let attestation_ids = Storage::get_subject_attestations(&env, &subject);
-        let current_time = env.ledger().timestamp();
-        for attestation_id in attestation_ids.iter() {
-            if let Ok(attestation) = Storage::get_attestation(&env, &attestation_id) {
-                if attestation.deleted { continue; }
-                if attestation.claim_type == claim_type && attestation.issuer == issuer {
-                    match attestation.get_status(current_time) {
-                        AttestationStatus::Valid => return true,
-                        AttestationStatus::Expired => {
-                            Events::attestation_expired(&env, &attestation_id, &subject);
-                        }
-                        _ => {}
-                    }
-                }
-            }
-        }
-        false
+        query::has_valid_claim_from_issuer(&env, subject, claim_type, issuer)
     }
 
     #[must_use]
     pub fn has_any_claim(env: Env, subject: Address, claim_types: Vec<String>) -> bool {
-        if claim_types.is_empty() {
-            return false;
-        }
-        let attestation_ids = Storage::get_subject_attestations(&env, &subject);
-        let current_time = env.ledger().timestamp();
-        for claim_type in claim_types.iter() {
-            for attestation_id in attestation_ids.iter() {
-                if let Ok(attestation) = Storage::get_attestation(&env, &attestation_id) {
-                    if !attestation.deleted
-                        && attestation.claim_type == claim_type
-                        && attestation.get_status(current_time) == AttestationStatus::Valid
-                    {
-                        return true;
-                    }
-                }
-            }
-        }
-        false
+        query::has_any_claim(&env, subject, claim_types)
     }
 
     #[must_use]
     pub fn has_all_claims(env: Env, subject: Address, claim_types: Vec<String>) -> bool {
-        if claim_types.is_empty() { return true; }
-        let attestation_ids = Storage::get_subject_attestations(&env, &subject);
-        let current_time = env.ledger().timestamp();
-        'claims: for claim_type in claim_types.iter() {
-            for attestation_id in attestation_ids.iter() {
-                if let Ok(attestation) = Storage::get_attestation(&env, &attestation_id) {
-                    if !attestation.deleted
-                        && attestation.claim_type == claim_type
-                        && attestation.get_status(current_time) == AttestationStatus::Valid
-                    {
-                        continue 'claims;
-                    }
-                }
-            }
-            return false;
-        }
-        true
+        query::has_all_claims(&env, subject, claim_types)
     }
 
     #[must_use]
     pub fn get_attestation(env: Env, attestation_id: String) -> Result<Attestation, Error> {
-        let attestation = Storage::get_attestation(&env, &attestation_id)?;
-        if attestation.deleted {
-            return Err(Error::NotFound);
-        }
-        Ok(attestation)
+        query::get_attestation(&env, attestation_id)
     }
 
-    /// Request GDPR deletion of an attestation.
-    ///
-    /// Only the subject of the attestation may call this. The attestation is
-    /// marked as `deleted` (soft-delete) and removed from the subject index so
-    /// it no longer appears in any query result. The record itself is retained
-    /// in storage for audit purposes, but is invisible to all public queries.
-    ///
-    /// A `DeletionRequested` event is emitted for off-chain compliance audit trails.
-    ///
-    /// # Errors
-    /// - [`Error::NotFound`] — attestation does not exist.
-    /// - [`Error::Unauthorized`] — caller is not the subject of the attestation.
-    pub fn request_deletion(
-        env: Env,
-        subject: Address,
-        attestation_id: String,
-    ) -> Result<(), Error> {
-        subject.require_auth();
-
-        let mut attestation = Storage::get_attestation(&env, &attestation_id)?;
-
-        if attestation.subject != subject {
-            return Err(Error::Unauthorized);
-        }
-
-        attestation.deleted = true;
-        Storage::set_attestation(&env, &attestation);
-        Storage::remove_subject_attestation(&env, &subject, &attestation_id);
-
-        let timestamp = env.ledger().timestamp();
-        Events::deletion_requested(&env, &subject, &attestation_id, timestamp);
-        Ok(())
-    }
-
-    /// Return the full audit log for `attestation_id`.
-    ///
-    /// The log is append-only and contains one entry per state change
-    /// (create, revoke, renew, update). Returns an empty list if the
-    /// attestation has no recorded history.
     #[must_use]
     pub fn get_audit_log(env: Env, attestation_id: String) -> Vec<AuditEntry> {
-        Storage::get_audit_log(&env, &attestation_id)
+        query::get_audit_log(&env, attestation_id)
     }
 
     #[must_use]
-    pub fn get_attestation_status(
-        env: Env,
-        attestation_id: String,
-    ) -> Result<AttestationStatus, Error> {
-        let attestation = Storage::get_attestation(&env, &attestation_id)?;
-        if attestation.deleted {
-            return Err(Error::NotFound);
-        }
-        let status = attestation.get_status(env.ledger().timestamp());
-        if status == AttestationStatus::Expired {
-            Events::attestation_expired(&env, &attestation_id, &attestation.subject);
-        }
-        Ok(status)
+    pub fn get_attestation_status(env: Env, attestation_id: String) -> Result<AttestationStatus, Error> {
+        query::get_attestation_status(&env, attestation_id)
     }
 
     #[must_use]
-    pub fn get_subject_attestations(
-        env: Env,
-        subject: Address,
-        start: u32,
-        limit: u32,
-    ) -> Vec<String> {
-        let ids = Storage::get_subject_attestations(&env, &subject);
-        let mut filtered = Vec::new(&env);
-        for id in ids.iter() {
-            if let Ok(a) = Storage::get_attestation(&env, &id) {
-                if !a.deleted {
-                    filtered.push_back(id);
-                }
-            }
-        }
-        crate::storage::paginate(&env, &filtered, start, limit)
+    pub fn get_subject_attestations(env: Env, subject: Address, start: u32, limit: u32) -> Vec<String> {
+        query::get_subject_attestations(&env, subject, start, limit)
     }
 
     #[must_use]
-    pub fn get_attestations_in_range(
-        env: Env,
-        subject: Address,
-        from_ts: u64,
-        to_ts: u64,
-        start: u32,
-        limit: u32,
-    ) -> Vec<Attestation> {
-        let attestation_ids = Storage::get_subject_attestations(&env, &subject);
-        let mut filtered_ids = Vec::new(&env);
-        for id in attestation_ids.iter() {
-            if let Ok(attestation) = Storage::get_attestation(&env, &id) {
-                if !attestation.deleted && attestation.timestamp >= from_ts && attestation.timestamp <= to_ts {
-                    filtered_ids.push_back(id);
-                }
-            }
-        }
-
-        let paginated_ids = crate::storage::paginate(&env, &filtered_ids, start, limit);
-        let mut result = Vec::new(&env);
-        for id in paginated_ids.iter() {
-            if let Ok(attestation) = Storage::get_attestation(&env, &id) {
-                result.push_back(attestation);
-            }
-        }
-        result
+    pub fn get_attestations_in_range(env: Env, subject: Address, from_ts: u64, to_ts: u64, start: u32, limit: u32) -> Vec<Attestation> {
+        query::get_attestations_in_range(&env, subject, from_ts, to_ts, start, limit)
     }
 
     #[must_use]
     pub fn get_attestations_by_tag(env: Env, subject: Address, tag: String) -> Vec<String> {
-        let attestation_ids = Storage::get_subject_attestations(&env, &subject);
-        let mut result = Vec::new(&env);
-        for id in attestation_ids.iter() {
-            if let Ok(attestation) = Storage::get_attestation(&env, &id) {
-                if attestation.deleted { continue; }
-                if let Some(tags) = attestation.tags {
-                    for t in tags.iter() {
-                        if t == tag {
-                            result.push_back(id.clone());
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-        result
+        query::get_attestations_by_tag(&env, subject, tag)
     }
 
     #[must_use]
-    pub fn get_attestations_by_jurisdiction(
-        env: Env,
-        subject: Address,
-        jurisdiction: String,
-        start: u32,
-        limit: u32,
-    ) -> Vec<String> {
-        let attestation_ids = Storage::get_subject_attestations(&env, &subject);
-        let mut filtered = Vec::new(&env);
-
-        for id in attestation_ids.iter() {
-            if let Ok(attestation) = Storage::get_attestation(&env, &id) {
-                if attestation.deleted {
-                    continue;
-                }
-                if let Some(att_jurisdiction) = attestation.jurisdiction {
-                    if att_jurisdiction == jurisdiction {
-                        filtered.push_back(id.clone());
-                    }
-                }
-            }
-        }
-
-        crate::storage::paginate(&env, &filtered, start, limit)
+    pub fn get_attestations_by_jurisdiction(env: Env, subject: Address, jurisdiction: String, start: u32, limit: u32) -> Vec<String> {
+        query::get_attestations_by_jurisdiction(&env, subject, jurisdiction, start, limit)
     }
 
     #[must_use]
-    pub fn get_issuer_attestations(
-        env: Env,
-        issuer: Address,
-        start: u32,
-        limit: u32,
-    ) -> Vec<String> {
-        let ids = Storage::get_issuer_attestations(&env, &issuer);
-        let mut filtered = Vec::new(&env);
-        for id in ids.iter() {
-            if let Ok(a) = Storage::get_attestation(&env, &id) {
-                if !a.deleted {
-                    filtered.push_back(id);
-                }
-            }
-        }
-        crate::storage::paginate(&env, &filtered, start, limit)
+    pub fn get_issuer_attestations(env: Env, issuer: Address, start: u32, limit: u32) -> Vec<String> {
+        query::get_issuer_attestations(&env, issuer, start, limit)
     }
 
-    /// Returns the total number of attestations created by `issuer` from the issuer index.
     pub fn get_issuer_attestation_count(env: Env, issuer: Address) -> u32 {
-        Storage::get_issuer_attestations(&env, &issuer).len()
+        query::get_issuer_attestation_count(&env, issuer)
     }
 
     #[must_use]
     pub fn get_valid_claims(env: Env, subject: Address) -> Vec<String> {
-        let current_time = env.ledger().timestamp();
-        let mut result = Vec::new(&env);
-        for attestation_id in Storage::get_subject_attestations(&env, &subject).iter() {
-            if let Ok(attestation) = Storage::get_attestation(&env, &attestation_id) {
-                if !attestation.deleted && attestation.get_status(current_time) == AttestationStatus::Valid {
-                    let mut already_present = false;
-                    for existing in result.iter() {
-                        if existing == attestation.claim_type {
-                            already_present = true;
-                            break;
-                        }
-                    }
-                    if !already_present {
-                        result.push_back(attestation.claim_type);
-                    }
-                }
-            }
-        }
-        result
+        query::get_valid_claims(&env, subject)
     }
 
     #[must_use]
-    pub fn get_attestation_by_type(
-        env: Env,
-        subject: Address,
-        claim_type: String,
-    ) -> Option<Attestation> {
-        let attestation_ids = Storage::get_subject_attestations(&env, &subject);
-        let current_time = env.ledger().timestamp();
-        let mut index = attestation_ids.len();
-        while index > 0 {
-            index -= 1;
-            if let Some(attestation_id) = attestation_ids.get(index) {
-                if let Ok(attestation) = Storage::get_attestation(&env, &attestation_id) {
-                    if !attestation.deleted
-                        && attestation.claim_type == claim_type
-                        && attestation.get_status(current_time) == AttestationStatus::Valid
-                    {
-                        return Some(attestation);
-                    }
-                }
-            }
-        }
+    pub fn get_attestation_by_type(env: Env, subject: Address, claim_type: String) -> Option<Attestation> {
+        query::get_attestation_by_type(&env, subject, claim_type)
+    }
 
-        None
+    pub fn get_subject_attestation_count(env: Env, subject: Address) -> u32 {
+        query::get_subject_attestation_count(&env, subject)
+    }
+
+    pub fn get_valid_claim_count(env: Env, subject: Address) -> u32 {
+        query::get_valid_claim_count(&env, subject)
     }
 
     #[must_use]
-    pub fn is_issuer(env: Env, address: Address) -> bool {
-        Storage::is_issuer(&env, &address)
-    }
-
-    #[must_use]
-    pub fn get_issuer_stats(env: Env, issuer: Address) -> IssuerStats {
-        Storage::get_issuer_stats(&env, &issuer)
-    }
-
-    pub fn set_issuer_metadata(
-        env: Env,
-        issuer: Address,
-        metadata: IssuerMetadata,
-    ) -> Result<(), Error> {
-        issuer.require_auth();
-        Validation::require_issuer(&env, &issuer)?;
-        Storage::set_issuer_metadata(&env, &issuer, &metadata);
-        Ok(())
-    }
-
-    /// Register a callback contract to be notified before an attestation expires.
-    ///
-    /// Only the subject may register or overwrite their own hook.
-    /// Re-registering overwrites the previous hook.
-    ///
-    /// # Errors
-    /// - [`Error::Unauthorized`] — caller is not `subject`.
-    pub fn register_expiration_hook(
-        env: Env,
-        subject: Address,
-        callback_contract: Address,
-        notify_days_before: u32,
-    ) -> Result<(), Error> {
-        subject.require_auth();
-        Storage::set_expiration_hook(
-            &env,
-            &subject,
-            &crate::types::ExpirationHook { callback_contract, notify_days_before },
-        );
-        Ok(())
-    }
-
-    /// Return the expiration hook registered by `subject`, or `None`.
-    #[must_use]
-    pub fn get_expiration_hook(
-        env: Env,
-        subject: Address,
-    ) -> Option<crate::types::ExpirationHook> {
-        Storage::get_expiration_hook(&env, &subject)
-    }
-
-    /// Remove the expiration hook for `subject`.
-    ///
-    /// Only the subject may remove their own hook.
-    ///
-    /// # Errors
-    /// - [`Error::Unauthorized`] — caller is not `subject`.
-    pub fn remove_expiration_hook(env: Env, subject: Address) -> Result<(), Error> {
-        subject.require_auth();
-        Storage::remove_expiration_hook(&env, &subject);
-        Ok(())
-    }
-
-    pub fn register_claim_type(env: Env, admin: Address, claim_type: String, description: String) -> Result<(), Error> {
-        admin.require_auth();
-        Validation::require_admin(&env, &admin)?;
-        Validation::validate_claim_type(&claim_type)?;
-
-        let info = ClaimTypeInfo {
-            claim_type: claim_type.clone(),
-            description: description.clone(),
-        };
-        Storage::set_claim_type(&env, &info);
-        Events::claim_type_registered(&env, &claim_type, &description);
-        Ok(())
-    }
-
-    #[must_use]
-    pub fn get_claim_type_description(env: Env, claim_type: String) -> Option<String> {
-        Storage::get_claim_type(&env, &claim_type).map(|info| info.description)
-    }
-
-    #[must_use]
-    pub fn list_claim_types(env: Env, start: u32, limit: u32) -> Vec<String> {
-        crate::storage::paginate(&env, &Storage::get_claim_type_list(&env), start, limit)
+    pub fn get_global_stats(env: Env) -> GlobalStats {
+        query::get_global_stats(&env)
     }
 
     // -----------------------------------------------------------------------
-    // Multi-sig attestation proposals
+    // Multi-sig
     // -----------------------------------------------------------------------
 
     pub fn propose_attestation(
@@ -1457,704 +463,63 @@ impl TrustLinkContract {
         required_signers: Vec<Address>,
         threshold: u32,
     ) -> Result<String, Error> {
-        proposer.require_auth();
-        Validation::require_issuer(&env, &proposer)?;
-        Validation::require_not_paused(&env)?;
-
-        // Premium issuers bypass multi-sig for ACCREDITED_INVESTOR (#305).
-        let accredited = String::from_str(&env, "ACCREDITED_INVESTOR");
-        if claim_type == accredited {
-            if let Some(IssuerTier::Premium) = Storage::get_issuer_tier(&env, &proposer) {
-                let timestamp = env.ledger().timestamp();
-                let attestation_id =
-                    Attestation::generate_id(&env, &proposer, &subject, &claim_type, timestamp);
-                let attestation = Attestation {
-                    id: attestation_id.clone(),
-                    issuer: proposer.clone(),
-                    subject: subject.clone(),
-                    claim_type: claim_type.clone(),
-                    timestamp,
-                    expiration: None,
-                    revoked: false,
-                    metadata: None,
-                    jurisdiction: None,
-                    valid_from: None,
-                    origin: AttestationOrigin::Native,
-                    source_chain: None,
-                    source_tx: None,
-                    tags: None,
-                    revocation_reason: None,
-                    deleted: false,
-                };
-                store_attestation(&env, &attestation);
-                Events::attestation_created(&env, &attestation);
-                return Ok(attestation_id);
-            }
-        }
-
-        // Validate all required signers are registered issuers.
-        for signer in required_signers.iter() {
-            Validation::require_issuer(&env, &signer)?;
-        }
-        let signer_count = required_signers.len();
-        if threshold == 0 || threshold > signer_count {
-            return Err(Error::InvalidThreshold);
-        }
-        let timestamp = env.ledger().timestamp();
-        let proposal_id = MultiSigProposal::generate_id(&env, &proposer, &subject, &claim_type, timestamp);
-        let mut signers = Vec::new(&env);
-        signers.push_back(proposer.clone());
-        let proposal = MultiSigProposal {
-            id: proposal_id.clone(),
-            proposer: proposer.clone(),
-            subject: subject.clone(),
-            claim_type,
-            required_signers,
-            threshold,
-            signers,
-            created_at: timestamp,
-            expires_at: timestamp + MULTISIG_PROPOSAL_TTL_SECS,
-            finalized: false,
-        };
-        Storage::set_multisig_proposal(&env, &proposal);
-        Events::multisig_proposed(&env, &proposal_id, &proposer, &subject, threshold);
-        Ok(proposal_id)
+        multisig::propose_attestation(&env, proposer, subject, claim_type, required_signers, threshold)
     }
 
     pub fn cosign_attestation(env: Env, issuer: Address, proposal_id: String) -> Result<(), Error> {
-        issuer.require_auth();
-        Validation::require_issuer(&env, &issuer)?;
-        Validation::require_not_paused(&env)?;
-
-        let mut proposal = Storage::get_multisig_proposal(&env, &proposal_id)?;
-        if proposal.finalized { return Err(Error::ProposalFinalized); }
-        let current_time = env.ledger().timestamp();
-        if current_time >= proposal.expires_at { return Err(Error::ProposalExpired); }
-
-        let mut is_required = false;
-        for signer in proposal.required_signers.iter() {
-            if signer == issuer { is_required = true; break; }
-        }
-        if !is_required { return Err(Error::NotRequiredSigner); }
-
-        for signer in proposal.signers.iter() {
-            if signer == issuer { return Err(Error::AlreadySigned); }
-        }
-
-        proposal.signers.push_back(issuer.clone());
-        let sig_count = proposal.signers.len();
-        Events::multisig_cosigned(&env, &proposal_id, &issuer, sig_count, proposal.threshold);
-
-        if sig_count >= proposal.threshold {
-            proposal.finalized = true;
-            Storage::set_multisig_proposal(&env, &proposal);
-
-            let attestation_id = Attestation::generate_id(
-                &env, &proposal.proposer, &proposal.subject, &proposal.claim_type, proposal.created_at,
-            );
-            let attestation = Attestation {
-                id: attestation_id.clone(),
-                issuer: proposal.proposer.clone(),
-                subject: proposal.subject.clone(),
-                claim_type: proposal.claim_type.clone(),
-                timestamp: proposal.created_at,
-                expiration: None,
-                revoked: false,
-                deleted: false,
-                metadata: None,
-                jurisdiction: None,
-                valid_from: None,
-                origin: AttestationOrigin::Native,
-                source_chain: None,
-                source_tx: None,
-                tags: None,
-                revocation_reason: None,
-                            };
-
-            store_attestation(&env, &attestation);
-            Events::attestation_created(&env, &attestation);
-            Events::multisig_activated(&env, &proposal_id, &attestation_id);
-        } else {
-            Storage::set_multisig_proposal(&env, &proposal);
-        }
-        Ok(())
+        multisig::cosign_attestation(&env, issuer, proposal_id)
     }
 
-    /// Retrieve a multi-sig proposal by ID.
     #[must_use]
     pub fn get_multisig_proposal(env: Env, proposal_id: String) -> Result<MultiSigProposal, Error> {
-        Storage::get_multisig_proposal(&env, &proposal_id)
+        multisig::get_multisig_proposal(&env, proposal_id)
     }
 
-    /// Endorse an existing attestation, adding a layer of social proof.
-    ///
-    /// Only registered issuers may endorse. An issuer cannot endorse their own
-    /// attestation, and cannot endorse a revoked attestation. Each issuer may
-    /// endorse a given attestation at most once.
-    ///
-    /// # Errors
-    /// - [`Error::Unauthorized`] — endorser is not a registered issuer.
-    /// - [`Error::NotFound`] — attestation does not exist.
-    /// - [`Error::CannotEndorseOwn`] — endorser is the attestation's issuer.
-    /// - [`Error::AlreadyRevoked`] — attestation has been revoked.
-    /// - [`Error::AlreadyEndorsed`] — endorser has already endorsed this attestation.
-    pub fn endorse_attestation(env: Env, endorser: Address, attestation_id: String) -> Result<(), Error> {
-        endorser.require_auth();
-        Validation::require_issuer(&env, &endorser)?;
-        Validation::require_not_paused(&env)?;
-
-        let attestation = Storage::get_attestation(&env, &attestation_id)?;
-
-        if attestation.issuer == endorser {
-            return Err(Error::CannotEndorseOwn);
-        }
-        if attestation.revoked {
-            return Err(Error::AlreadyRevoked);
-        }
-
-        // Check for duplicate endorsement.
-        let existing = Storage::get_endorsements(&env, &attestation_id);
-        for e in existing.iter() {
-            if e.endorser == endorser {
-                return Err(Error::AlreadyEndorsed);
-            }
-        }
-
-        let endorsement = Endorsement {
-            attestation_id: attestation_id.clone(),
-            endorser: endorser.clone(),
-            timestamp: env.ledger().timestamp(),
-        };
-        Storage::add_endorsement(&env, &endorsement);
-        Ok(())
-    }
-
-    /// Return the number of endorsements for `attestation_id`.
-    #[must_use]
-    pub fn get_endorsement_count(env: Env, attestation_id: String) -> u32 {
-        Storage::get_endorsements(&env, &attestation_id).len()
-    }
-
-    /// Endorse an existing attestation, adding a layer of social proof.
-    ///
-    /// Only registered issuers may endorse. An issuer cannot endorse their own
-    /// attestation, and cannot endorse a revoked attestation. Each issuer may
-    /// endorse a given attestation at most once.
-    ///
-    /// # Errors
-    /// - [`Error::Unauthorized`] — endorser is not a registered issuer.
-    /// - [`Error::NotFound`] — attestation does not exist.
-    /// - [`Error::CannotEndorseOwn`] — endorser is the attestation's issuer.
-    /// - [`Error::AlreadyRevoked`] — attestation has been revoked.
-    /// - [`Error::AlreadyEndorsed`] — endorser has already endorsed this attestation.
-    pub fn endorse_attestation(env: Env, endorser: Address, attestation_id: String) -> Result<(), Error> {
-        endorser.require_auth();
-        Validation::require_issuer(&env, &endorser)?;
-        Validation::require_not_paused(&env)?;
-
-        let attestation = Storage::get_attestation(&env, &attestation_id)?;
-
-        if attestation.issuer == endorser {
-            return Err(Error::CannotEndorseOwn);
-        }
-        if attestation.revoked {
-            return Err(Error::AlreadyRevoked);
-        }
-
-        // Check for duplicate endorsement.
-        let existing = Storage::get_endorsements(&env, &attestation_id);
-        for e in existing.iter() {
-            if e.endorser == endorser {
-                return Err(Error::AlreadyEndorsed);
-            }
-        }
-
-        let endorsement = Endorsement {
-            attestation_id: attestation_id.clone(),
-            endorser: endorser.clone(),
-            timestamp: env.ledger().timestamp(),
-        };
-        Storage::add_endorsement(&env, &attestation_id, &endorsement);
-        Ok(())
-    }
-
-    /// Return the number of endorsements for `attestation_id`.
-    #[must_use]
-    pub fn get_endorsement_count(env: Env, attestation_id: String) -> u32 {
-        Storage::get_endorsements(&env, &attestation_id).len()
-    }
-
-    /// Delegate authority to create attestations of `claim_type` to `delegate`.
-    ///
-    /// # Errors
-    /// - [`Error::Unauthorized`] — `issuer` is not a registered issuer.
-    /// - [`Error::CannotDelegateToSelf`] — `issuer == delegate`.
-    pub fn delegate_claim_type(
-        env: Env,
-        issuer: Address,
-        delegate: Address,
-        claim_type: String,
-        expiration: Option<u64>,
-    ) -> Result<(), Error> {
-        issuer.require_auth();
-        Validation::require_issuer(&env, &issuer)?;
-        if issuer == delegate {
-            return Err(Error::CannotDelegateToSelf);
-        }
-        validate_native_expiration(&env, expiration)?;
-        let delegation = Delegation {
-            delegator: issuer.clone(),
-            delegate: delegate.clone(),
-            claim_type: claim_type.clone(),
-            expiration,
-        };
-        Storage::set_delegation(&env, &delegation);
-        Events::delegation_created(&env, &issuer, &delegate, &claim_type, expiration);
-        Ok(())
-    }
-
-    /// Return the current multisig proposal TTL in days (default 7).
     #[must_use]
     pub fn get_multisig_ttl(env: Env) -> u32 {
-        Storage::get_multisig_ttl_days(&env)
+        multisig::get_multisig_ttl(&env)
     }
 
     // -----------------------------------------------------------------------
-    // Attestation Request Workflow (#304)
+    // Attestation request workflow
     // -----------------------------------------------------------------------
 
-    /// Submit a pull-based attestation request from a subject to a registered issuer.
-    ///
-    /// The request is stored with `RequestStatus::Pending` and expires after
-    /// `ATTESTATION_REQUEST_TTL_SECS` seconds. Duplicate requests (same subject,
-    /// issuer, claim_type at the same ledger timestamp) are rejected.
-    ///
-    /// # Errors
-    /// - [`Error::Unauthorized`] — `issuer` is not a registered issuer.
-    /// - [`Error::DuplicateAttestation`] — an identical pending request already exists.
-    pub fn request_attestation(
-        env: Env,
-        subject: Address,
-        issuer: Address,
-        claim_type: String,
-    ) -> Result<String, Error> {
-        subject.require_auth();
-        Validation::require_not_paused(&env)?;
-        Validation::require_issuer(&env, &issuer)?;
-        validate_claim_type(&claim_type)?;
-
-        let timestamp = env.ledger().timestamp();
-        let request_id =
-            AttestationRequest::generate_id(&env, &subject, &issuer, &claim_type, timestamp);
-
-        // Prevent duplicate requests at the same timestamp.
-        if Storage::get_request(&env, &request_id).is_ok() {
-            return Err(Error::DuplicateRequest);
-        }
-
-        let expires_at = timestamp + ATTESTATION_REQUEST_TTL_SECS;
-
-        let request = AttestationRequest {
-            id: request_id.clone(),
-            subject: subject.clone(),
-            issuer: issuer.clone(),
-            claim_type: claim_type.clone(),
-            timestamp,
-            expires_at,
-            status: RequestStatus::Pending,
-            rejection_reason: None,
-        };
-
-        Storage::set_request(&env, &request);
-        Storage::add_pending_request(&env, &issuer, &request_id);
-        Events::attestation_requested(
-            &env,
-            &request_id,
-            &subject,
-            &issuer,
-            &claim_type,
-            expires_at,
-        );
-
-        Ok(request_id)
+    pub fn request_attestation(env: Env, subject: Address, issuer: Address, claim_type: String) -> Result<String, Error> {
+        request::request_attestation(&env, subject, issuer, claim_type)
     }
 
-    /// Fulfill a pending attestation request by creating the attestation.
-    ///
-    /// The issuer must be registered. The request must be in `Pending` status
-    /// and must not have expired. On success the request is marked `Fulfilled`
-    /// and a normal attestation is created and stored.
-    ///
-    /// # Errors
-    /// - [`Error::NotFound`] — request does not exist.
-    /// - [`Error::Unauthorized`] — caller is not the request's target issuer,
-    ///   or is not a registered issuer.
-    /// - [`Error::Expired`] — the request TTL has elapsed.
-    /// - [`Error::AlreadyRevoked`] — request was already rejected.
-    /// - [`Error::ProposalFinalized`] — request was already fulfilled.
-    pub fn fulfill_request(
-        env: Env,
-        issuer: Address,
-        request_id: String,
-        expiration: Option<u64>,
-    ) -> Result<String, Error> {
-        issuer.require_auth();
-        Validation::require_not_paused(&env)?;
-        Validation::require_issuer(&env, &issuer)?;
-
-        let mut request = Storage::get_request(&env, &request_id)?;
-
-        // Only the target issuer may fulfill.
-        if request.issuer != issuer {
-            return Err(Error::Unauthorized);
-        }
-
-        // Guard against double-fulfillment.
-        match request.status {
-            RequestStatus::Fulfilled => return Err(Error::RequestAlreadyProcessed),
-            RequestStatus::Rejected => return Err(Error::RequestAlreadyProcessed),
-            RequestStatus::Pending => {}
-        }
-
-        // Check TTL expiry.
-        let current_time = env.ledger().timestamp();
-        if current_time >= request.expires_at {
-            return Err(Error::RequestExpired);
-        }
-
-        validate_native_expiration(&env, expiration)?;
-
-        // Create the attestation.
-        let attestation_id = Attestation::generate_id(
-            &env,
-            &issuer,
-            &request.subject,
-            &request.claim_type,
-            current_time,
-        );
-
-        if Storage::has_attestation(&env, &attestation_id) {
-            return Err(Error::DuplicateAttestation);
-        }
-
-        let limits = Storage::get_limits(&env);
-        let issuer_count = Storage::get_issuer_attestations(&env, &issuer).len();
-        if issuer_count >= limits.max_attestations_per_issuer {
-            return Err(Error::LimitExceeded);
-        }
-        let subject_count =
-            Storage::get_subject_attestations(&env, &request.subject).len();
-        if subject_count >= limits.max_attestations_per_subject {
-            return Err(Error::LimitExceeded);
-        }
-
-        let attestation = Attestation {
-            id: attestation_id.clone(),
-            issuer: issuer.clone(),
-            subject: request.subject.clone(),
-            claim_type: request.claim_type.clone(),
-            timestamp: current_time,
-            expiration,
-            revoked: false,
-            metadata: None,
-            jurisdiction: None,
-            valid_from: None,
-            origin: AttestationOrigin::Native,
-            source_chain: None,
-            source_tx: None,
-            tags: None,
-            revocation_reason: None,
-            deleted: false,
-        };
-
-        store_attestation(&env, &attestation);
-        Events::attestation_created(&env, &attestation);
-
-        // Mark request fulfilled and remove from pending index.
-        request.status = RequestStatus::Fulfilled;
-        Storage::set_request(&env, &request);
-        Storage::remove_pending_request(&env, &issuer, &request_id);
-
-        Events::request_fulfilled(&env, &request_id, &issuer, &attestation_id);
-
-        Ok(attestation_id)
+    pub fn fulfill_request(env: Env, issuer: Address, request_id: String, expiration: Option<u64>) -> Result<String, Error> {
+        request::fulfill_request(&env, issuer, request_id, expiration)
     }
 
-    /// Reject a pending attestation request.
-    ///
-    /// The issuer must be registered and must be the target of the request.
-    /// The request must be in `Pending` status and must not have expired.
-    ///
-    /// # Errors
-    /// - [`Error::NotFound`] — request does not exist.
-    /// - [`Error::Unauthorized`] — caller is not the request's target issuer.
-    /// - [`Error::Expired`] — the request TTL has elapsed.
-    /// - [`Error::AlreadyRevoked`] — request was already rejected.
-    /// - [`Error::ProposalFinalized`] — request was already fulfilled.
-    pub fn reject_request(
-        env: Env,
-        issuer: Address,
-        request_id: String,
-        reason: Option<String>,
-    ) -> Result<(), Error> {
-        issuer.require_auth();
-        Validation::require_not_paused(&env)?;
-        Validation::require_issuer(&env, &issuer)?;
-        validate_reason(&reason)?;
-
-        let mut request = Storage::get_request(&env, &request_id)?;
-
-        if request.issuer != issuer {
-            return Err(Error::Unauthorized);
-        }
-
-        match request.status {
-            RequestStatus::Fulfilled => return Err(Error::RequestAlreadyProcessed),
-            RequestStatus::Rejected => return Err(Error::RequestAlreadyProcessed),
-            RequestStatus::Pending => {}
-        }
-
-        let current_time = env.ledger().timestamp();
-        if current_time >= request.expires_at {
-            return Err(Error::RequestExpired);
-        }
-
-        request.status = RequestStatus::Rejected;
-        request.rejection_reason = reason.clone();
-        Storage::set_request(&env, &request);
-        Storage::remove_pending_request(&env, &issuer, &request_id);
-
-        Events::request_rejected(&env, &request_id, &issuer, &reason);
-
-        Ok(())
+    pub fn reject_request(env: Env, issuer: Address, request_id: String, reason: Option<String>) -> Result<(), Error> {
+        request::reject_request(&env, issuer, request_id, reason)
     }
 
-    /// Return a paginated list of pending (non-expired) request IDs for `issuer`.
-    ///
-    /// Expired requests are filtered out of the result even if they have not
-    /// been explicitly rejected.
-    pub fn get_pending_requests(
-        env: Env,
-        issuer: Address,
-        start: u32,
-        limit: u32,
-    ) -> Vec<AttestationRequest> {
-        let current_time = env.ledger().timestamp();
-        let all_ids = Storage::get_pending_request_ids(&env, &issuer);
-        let mut pending = Vec::new(&env);
-
-        for id in all_ids.iter() {
-            if let Ok(req) = Storage::get_request(&env, &id) {
-                if req.status == RequestStatus::Pending && current_time < req.expires_at {
-                    pending.push_back(req);
-                }
-            }
-        }
-
-        // Manual pagination over the filtered list.
-        let total = pending.len();
-        let start = start.min(total);
-        let end = (start + limit).min(total);
-        let mut result = Vec::new(&env);
-        let mut i = start;
-        while i < end {
-            if let Some(req) = pending.get(i) {
-                result.push_back(req);
-            }
-            i += 1;
-        }
-        result
+    pub fn get_pending_requests(env: Env, issuer: Address, start: u32, limit: u32) -> Vec<AttestationRequest> {
+        request::get_pending_requests(&env, issuer, start, limit)
     }
 
-    /// Retrieve a single attestation request by ID.
-    ///
-    /// # Errors
-    /// - [`Error::NotFound`] — request does not exist.
     pub fn get_request(env: Env, request_id: String) -> Result<AttestationRequest, Error> {
-        Storage::get_request(&env, &request_id)
+        request::get_request(&env, request_id)
     }
 
-    /// Return the semver version string set at initialization.
-    ///
-    /// # Errors
-    /// - [`Error::NotInitialized`] — contract has not been initialized.
+    /// Alias for `get_request`.
+    pub fn get_attestation_request(env: Env, request_id: String) -> Result<AttestationRequest, Error> {
+        request::get_request(&env, request_id)
+    }
+
+    // -----------------------------------------------------------------------
+    // Misc
+    // -----------------------------------------------------------------------
+
     #[must_use]
     pub fn get_version(env: Env) -> Result<String, Error> {
-        Storage::get_version(&env).ok_or(Error::NotInitialized)
+        admin::get_version(&env)
     }
 
-    /// Return global contract statistics.
-    ///
-    /// No authentication required — safe to call from dashboards and analytics tools.
-    #[must_use]
-    pub fn get_global_stats(env: Env) -> GlobalStats {
-        Storage::get_global_stats(&env)
-    }
-
-    /// Return current storage limits.
-    #[must_use]
-    pub fn get_limits(env: Env) -> StorageLimits {
-        Storage::get_limits(&env)
-    }
-
-    /// Update storage limits (admin only).
-    ///
-    /// # Errors
-    /// - [`Error::Unauthorized`] — caller is not admin.
-    pub fn set_limits(
-        env: Env,
-        admin: Address,
-        max_attestations_per_issuer: u32,
-        max_attestations_per_subject: u32,
-    ) -> Result<(), Error> {
-        admin.require_auth();
-        Validation::require_admin(&env, &admin)?;
-        Storage::set_limits(&env, &StorageLimits {
-            max_attestations_per_issuer,
-            max_attestations_per_subject,
-        });
-        Ok(())
-    }
-
-    /// Configure attestation fees (admin only).
-    ///
-    /// # Errors
-    /// - [`Error::Unauthorized`] — caller is not admin, or admin == collector.
-    /// - [`Error::InvalidFee`] — fee is negative.
-    /// - [`Error::FeeTokenRequired`] — fee > 0 but no token provided.
-    pub fn set_fee(
-        env: Env,
-        admin: Address,
-        fee: i128,
-        collector: Address,
-        fee_token: Option<Address>,
-    ) -> Result<(), Error> {
-        admin.require_auth();
-        Validation::require_admin(&env, &admin)?;
-        validate_fee_config(&env, fee, &fee_token)?;
-        if admin == collector {
-            return Err(Error::Unauthorized);
-        }
-        Storage::set_fee_config(&env, &FeeConfig { attestation_fee: fee, fee_collector: collector, fee_token });
-        Ok(())
-    }
-
-    /// Update the expiration of an existing attestation (issuer only).
-    ///
-    /// # Errors
-    /// - [`Error::Unauthorized`] — caller is not the attestation's issuer.
-    /// - [`Error::NotFound`] — attestation does not exist.
-    /// - [`Error::AlreadyRevoked`] — attestation has been revoked.
-    pub fn update_expiration(
-        env: Env,
-        issuer: Address,
-        attestation_id: String,
-        new_expiration: Option<u64>,
-    ) -> Result<(), Error> {
-        issuer.require_auth();
-        Validation::require_issuer(&env, &issuer)?;
-        Validation::require_not_paused(&env)?;
-        validate_native_expiration(&env, new_expiration)?;
-
-        let mut attestation = Storage::get_attestation(&env, &attestation_id)?;
-        if attestation.issuer != issuer {
-            return Err(Error::Unauthorized);
-        }
-        if attestation.revoked {
-            return Err(Error::AlreadyRevoked);
-        }
-
-        attestation.expiration = new_expiration;
-        Storage::set_attestation(&env, &attestation);
-        Events::attestation_renewed(&env, &attestation_id, &issuer, new_expiration);
-        Storage::append_audit_entry(&env, &attestation_id, &AuditEntry {
-            action: AuditAction::Updated,
-            actor: issuer.clone(),
-            timestamp: env.ledger().timestamp(),
-            details: None,
-        });
-        Ok(())
-    }
-
-    /// Return the trust tier of a registered issuer, or `None` if not set.
-    #[must_use]
-    pub fn get_issuer_tier(env: Env, issuer: Address) -> Option<IssuerTier> {
-        Storage::get_issuer_tier(&env, &issuer)
-    }
-
-    /// Lightweight health probe for monitoring dashboards and uptime checks.
-    ///
-    /// No authentication required.
     #[must_use]
     pub fn health_check(env: Env) -> HealthStatus {
-        let initialized = Storage::has_admin(&env);
-        let stats = Storage::get_global_stats(&env);
-        HealthStatus {
-            initialized,
-            admin_set: initialized,
-            issuer_count: stats.total_issuers,
-            total_attestations: stats.total_attestations,
-        }
-    }
-
-    /// Retrieve an attestation request by ID.
-    ///
-    /// Alias for `get_request`.
-    ///
-    /// # Errors
-    /// - [`Error::NotFound`] — request does not exist.
-    pub fn get_attestation_request(env: Env, request_id: String) -> Result<AttestationRequest, Error> {
-        Storage::get_request(&env, &request_id)
-    }
-
-    /// Transfer an attestation from its current issuer to a new registered issuer (admin only).
-    ///
-    /// # Errors
-    /// - [`Error::Unauthorized`] — caller is not admin, or `new_issuer` is not registered.
-    /// - [`Error::NotFound`] — attestation does not exist.
-    pub fn transfer_attestation(
-        env: Env,
-        admin: Address,
-        attestation_id: String,
-        new_issuer: Address,
-    ) -> Result<(), Error> {
-        admin.require_auth();
-        Validation::require_admin(&env, &admin)?;
-        Validation::require_issuer(&env, &new_issuer)?;
-
-        let mut attestation = Storage::get_attestation(&env, &attestation_id)?;
-        let old_issuer = attestation.issuer.clone();
-
-        if old_issuer == new_issuer {
-            return Ok(());
-        }
-
-        // Update issuer indexes.
-        Storage::remove_issuer_attestation(&env, &old_issuer, &attestation_id);
-        Storage::add_issuer_attestation(&env, &new_issuer, &attestation_id);
-
-        // Update issuer stats.
-        let mut old_stats = Storage::get_issuer_stats(&env, &old_issuer);
-        old_stats.total_issued = old_stats.total_issued.saturating_sub(1);
-        Storage::set_issuer_stats(&env, &old_issuer, &old_stats);
-
-        let mut new_stats = Storage::get_issuer_stats(&env, &new_issuer);
-        new_stats.total_issued = new_stats.total_issued.saturating_add(1);
-        Storage::set_issuer_stats(&env, &new_issuer, &new_stats);
-
-        // Update attestation record.
-        attestation.issuer = new_issuer.clone();
-        Storage::set_attestation(&env, &attestation);
-
-        // Audit entry.
-        Storage::append_audit_entry(&env, &attestation_id, &AuditEntry {
-            action: AuditAction::Transferred,
-            actor: admin.clone(),
-            timestamp: env.ledger().timestamp(),
-            details: Some(new_issuer.to_string()),
-        });
-
-        Events::attestation_transferred(&env, &attestation_id, &old_issuer, &new_issuer);
-        Ok(())
+        admin::health_check(&env)
     }
 }

--- a/src/multisig.rs
+++ b/src/multisig.rs
@@ -1,0 +1,149 @@
+use soroban_sdk::{Address, Env, String, Vec};
+
+use crate::attestation::store_attestation;
+use crate::events::Events;
+use crate::storage::Storage;
+use crate::types::{
+    Attestation, AttestationOrigin, Error, IssuerTier, MultiSigProposal,
+    MULTISIG_PROPOSAL_TTL_SECS,
+};
+use crate::validation::Validation;
+
+pub fn propose_attestation(
+    env: &Env,
+    proposer: Address,
+    subject: Address,
+    claim_type: String,
+    required_signers: Vec<Address>,
+    threshold: u32,
+) -> Result<String, Error> {
+    proposer.require_auth();
+    Validation::require_issuer(env, &proposer)?;
+    Validation::require_not_paused(env)?;
+
+    // Premium issuers bypass multi-sig for ACCREDITED_INVESTOR.
+    let accredited = String::from_str(env, "ACCREDITED_INVESTOR");
+    if claim_type == accredited {
+        if let Some(IssuerTier::Premium) = Storage::get_issuer_tier(env, &proposer) {
+            let timestamp = env.ledger().timestamp();
+            let attestation_id =
+                Attestation::generate_id(env, &proposer, &subject, &claim_type, timestamp);
+            let attestation = Attestation {
+                id: attestation_id.clone(),
+                issuer: proposer.clone(),
+                subject: subject.clone(),
+                claim_type: claim_type.clone(),
+                timestamp,
+                expiration: None,
+                revoked: false,
+                metadata: None,
+                jurisdiction: None,
+                valid_from: None,
+                origin: AttestationOrigin::Native,
+                source_chain: None,
+                source_tx: None,
+                tags: None,
+                revocation_reason: None,
+                deleted: false,
+            };
+            store_attestation(env, &attestation);
+            Events::attestation_created(env, &attestation);
+            return Ok(attestation_id);
+        }
+    }
+
+    for signer in required_signers.iter() {
+        Validation::require_issuer(env, &signer)?;
+    }
+    let signer_count = required_signers.len();
+    if threshold == 0 || threshold > signer_count {
+        return Err(Error::InvalidThreshold);
+    }
+
+    let timestamp = env.ledger().timestamp();
+    let proposal_id = MultiSigProposal::generate_id(env, &proposer, &subject, &claim_type, timestamp);
+    let mut signers = Vec::new(env);
+    signers.push_back(proposer.clone());
+    let proposal = MultiSigProposal {
+        id: proposal_id.clone(),
+        proposer: proposer.clone(),
+        subject: subject.clone(),
+        claim_type,
+        required_signers,
+        threshold,
+        signers,
+        created_at: timestamp,
+        expires_at: timestamp + MULTISIG_PROPOSAL_TTL_SECS,
+        finalized: false,
+    };
+    Storage::set_multisig_proposal(env, &proposal);
+    Events::multisig_proposed(env, &proposal_id, &proposer, &subject, threshold);
+    Ok(proposal_id)
+}
+
+pub fn cosign_attestation(env: &Env, issuer: Address, proposal_id: String) -> Result<(), Error> {
+    issuer.require_auth();
+    Validation::require_issuer(env, &issuer)?;
+    Validation::require_not_paused(env)?;
+
+    let mut proposal = Storage::get_multisig_proposal(env, &proposal_id)?;
+    if proposal.finalized { return Err(Error::ProposalFinalized); }
+    let current_time = env.ledger().timestamp();
+    if current_time >= proposal.expires_at { return Err(Error::ProposalExpired); }
+
+    let mut is_required = false;
+    for signer in proposal.required_signers.iter() {
+        if signer == issuer { is_required = true; break; }
+    }
+    if !is_required { return Err(Error::NotRequiredSigner); }
+
+    for signer in proposal.signers.iter() {
+        if signer == issuer { return Err(Error::AlreadySigned); }
+    }
+
+    proposal.signers.push_back(issuer.clone());
+    let sig_count = proposal.signers.len();
+    Events::multisig_cosigned(env, &proposal_id, &issuer, sig_count, proposal.threshold);
+
+    if sig_count >= proposal.threshold {
+        proposal.finalized = true;
+        Storage::set_multisig_proposal(env, &proposal);
+
+        let attestation_id = Attestation::generate_id(
+            env, &proposal.proposer, &proposal.subject, &proposal.claim_type, proposal.created_at,
+        );
+        let attestation = Attestation {
+            id: attestation_id.clone(),
+            issuer: proposal.proposer.clone(),
+            subject: proposal.subject.clone(),
+            claim_type: proposal.claim_type.clone(),
+            timestamp: proposal.created_at,
+            expiration: None,
+            revoked: false,
+            deleted: false,
+            metadata: None,
+            jurisdiction: None,
+            valid_from: None,
+            origin: AttestationOrigin::Native,
+            source_chain: None,
+            source_tx: None,
+            tags: None,
+            revocation_reason: None,
+        };
+
+        store_attestation(env, &attestation);
+        Events::attestation_created(env, &attestation);
+        Events::multisig_activated(env, &proposal_id, &attestation_id);
+    } else {
+        Storage::set_multisig_proposal(env, &proposal);
+    }
+    Ok(())
+}
+
+pub fn get_multisig_proposal(env: &Env, proposal_id: String) -> Result<MultiSigProposal, Error> {
+    Storage::get_multisig_proposal(env, &proposal_id)
+}
+
+pub fn get_multisig_ttl(env: &Env) -> u32 {
+    Storage::get_multisig_ttl_days(env)
+}

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,0 +1,276 @@
+use soroban_sdk::{Address, Env, String, Vec};
+
+use crate::attestation::maybe_trigger_expiration_hook;
+use crate::events::Events;
+use crate::storage::Storage;
+use crate::types::{Attestation, AttestationStatus, AuditEntry, Error, GlobalStats};
+
+pub fn has_valid_claim(env: &Env, subject: Address, claim_type: String) -> bool {
+    let attestation_ids = Storage::get_subject_attestations(env, &subject);
+    let current_time = env.ledger().timestamp();
+
+    for attestation_id in attestation_ids.iter() {
+        if let Ok(attestation) = Storage::get_attestation(env, &attestation_id) {
+            if attestation.deleted || attestation.claim_type != claim_type {
+                continue;
+            }
+            if attestation.get_status(current_time) == AttestationStatus::Valid {
+                maybe_trigger_expiration_hook(
+                    env,
+                    &subject,
+                    &attestation_id,
+                    attestation.expiration.unwrap_or(u64::MAX),
+                    current_time,
+                );
+                return true;
+            }
+        }
+    }
+    false
+}
+
+pub fn has_valid_claim_from_issuer(env: &Env, subject: Address, claim_type: String, issuer: Address) -> bool {
+    let attestation_ids = Storage::get_subject_attestations(env, &subject);
+    let current_time = env.ledger().timestamp();
+    for attestation_id in attestation_ids.iter() {
+        if let Ok(attestation) = Storage::get_attestation(env, &attestation_id) {
+            if attestation.deleted { continue; }
+            if attestation.claim_type == claim_type && attestation.issuer == issuer {
+                match attestation.get_status(current_time) {
+                    AttestationStatus::Valid => return true,
+                    AttestationStatus::Expired => {
+                        Events::attestation_expired(env, &attestation_id, &subject);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    false
+}
+
+pub fn has_any_claim(env: &Env, subject: Address, claim_types: Vec<String>) -> bool {
+    if claim_types.is_empty() {
+        return false;
+    }
+    let attestation_ids = Storage::get_subject_attestations(env, &subject);
+    let current_time = env.ledger().timestamp();
+    for claim_type in claim_types.iter() {
+        for attestation_id in attestation_ids.iter() {
+            if let Ok(attestation) = Storage::get_attestation(env, &attestation_id) {
+                if !attestation.deleted
+                    && attestation.claim_type == claim_type
+                    && attestation.get_status(current_time) == AttestationStatus::Valid
+                {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+pub fn has_all_claims(env: &Env, subject: Address, claim_types: Vec<String>) -> bool {
+    if claim_types.is_empty() { return true; }
+    let attestation_ids = Storage::get_subject_attestations(env, &subject);
+    let current_time = env.ledger().timestamp();
+    'claims: for claim_type in claim_types.iter() {
+        for attestation_id in attestation_ids.iter() {
+            if let Ok(attestation) = Storage::get_attestation(env, &attestation_id) {
+                if !attestation.deleted
+                    && attestation.claim_type == claim_type
+                    && attestation.get_status(current_time) == AttestationStatus::Valid
+                {
+                    continue 'claims;
+                }
+            }
+        }
+        return false;
+    }
+    true
+}
+
+pub fn get_attestation(env: &Env, attestation_id: String) -> Result<Attestation, Error> {
+    let attestation = Storage::get_attestation(env, &attestation_id)?;
+    if attestation.deleted {
+        return Err(Error::NotFound);
+    }
+    Ok(attestation)
+}
+
+pub fn get_audit_log(env: &Env, attestation_id: String) -> Vec<AuditEntry> {
+    Storage::get_audit_log(env, &attestation_id)
+}
+
+pub fn get_attestation_status(env: &Env, attestation_id: String) -> Result<AttestationStatus, Error> {
+    let attestation = Storage::get_attestation(env, &attestation_id)?;
+    if attestation.deleted {
+        return Err(Error::NotFound);
+    }
+    let status = attestation.get_status(env.ledger().timestamp());
+    if status == AttestationStatus::Expired {
+        Events::attestation_expired(env, &attestation_id, &attestation.subject);
+    }
+    Ok(status)
+}
+
+pub fn get_subject_attestations(env: &Env, subject: Address, start: u32, limit: u32) -> Vec<String> {
+    let ids = Storage::get_subject_attestations(env, &subject);
+    let mut filtered = Vec::new(env);
+    for id in ids.iter() {
+        if let Ok(a) = Storage::get_attestation(env, &id) {
+            if !a.deleted {
+                filtered.push_back(id);
+            }
+        }
+    }
+    crate::storage::paginate(env, &filtered, start, limit)
+}
+
+pub fn get_attestations_in_range(
+    env: &Env,
+    subject: Address,
+    from_ts: u64,
+    to_ts: u64,
+    start: u32,
+    limit: u32,
+) -> Vec<Attestation> {
+    let attestation_ids = Storage::get_subject_attestations(env, &subject);
+    let mut filtered_ids = Vec::new(env);
+    for id in attestation_ids.iter() {
+        if let Ok(attestation) = Storage::get_attestation(env, &id) {
+            if !attestation.deleted && attestation.timestamp >= from_ts && attestation.timestamp <= to_ts {
+                filtered_ids.push_back(id);
+            }
+        }
+    }
+    let paginated_ids = crate::storage::paginate(env, &filtered_ids, start, limit);
+    let mut result = Vec::new(env);
+    for id in paginated_ids.iter() {
+        if let Ok(attestation) = Storage::get_attestation(env, &id) {
+            result.push_back(attestation);
+        }
+    }
+    result
+}
+
+pub fn get_attestations_by_tag(env: &Env, subject: Address, tag: String) -> Vec<String> {
+    let attestation_ids = Storage::get_subject_attestations(env, &subject);
+    let mut result = Vec::new(env);
+    for id in attestation_ids.iter() {
+        if let Ok(attestation) = Storage::get_attestation(env, &id) {
+            if attestation.deleted { continue; }
+            if let Some(tags) = attestation.tags {
+                for t in tags.iter() {
+                    if t == tag {
+                        result.push_back(id.clone());
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    result
+}
+
+pub fn get_attestations_by_jurisdiction(
+    env: &Env,
+    subject: Address,
+    jurisdiction: String,
+    start: u32,
+    limit: u32,
+) -> Vec<String> {
+    let attestation_ids = Storage::get_subject_attestations(env, &subject);
+    let mut filtered = Vec::new(env);
+    for id in attestation_ids.iter() {
+        if let Ok(attestation) = Storage::get_attestation(env, &id) {
+            if attestation.deleted { continue; }
+            if let Some(att_jurisdiction) = attestation.jurisdiction {
+                if att_jurisdiction == jurisdiction {
+                    filtered.push_back(id.clone());
+                }
+            }
+        }
+    }
+    crate::storage::paginate(env, &filtered, start, limit)
+}
+
+pub fn get_issuer_attestations(env: &Env, issuer: Address, start: u32, limit: u32) -> Vec<String> {
+    let ids = Storage::get_issuer_attestations(env, &issuer);
+    let mut filtered = Vec::new(env);
+    for id in ids.iter() {
+        if let Ok(a) = Storage::get_attestation(env, &id) {
+            if !a.deleted {
+                filtered.push_back(id);
+            }
+        }
+    }
+    crate::storage::paginate(env, &filtered, start, limit)
+}
+
+pub fn get_issuer_attestation_count(env: &Env, issuer: Address) -> u32 {
+    Storage::get_issuer_attestations(env, &issuer).len()
+}
+
+pub fn get_valid_claims(env: &Env, subject: Address) -> Vec<String> {
+    let current_time = env.ledger().timestamp();
+    let mut result = Vec::new(env);
+    for attestation_id in Storage::get_subject_attestations(env, &subject).iter() {
+        if let Ok(attestation) = Storage::get_attestation(env, &attestation_id) {
+            if !attestation.deleted && attestation.get_status(current_time) == AttestationStatus::Valid {
+                let mut already_present = false;
+                for existing in result.iter() {
+                    if existing == attestation.claim_type {
+                        already_present = true;
+                        break;
+                    }
+                }
+                if !already_present {
+                    result.push_back(attestation.claim_type);
+                }
+            }
+        }
+    }
+    result
+}
+
+pub fn get_attestation_by_type(env: &Env, subject: Address, claim_type: String) -> Option<Attestation> {
+    let attestation_ids = Storage::get_subject_attestations(env, &subject);
+    let current_time = env.ledger().timestamp();
+    let mut index = attestation_ids.len();
+    while index > 0 {
+        index -= 1;
+        if let Some(attestation_id) = attestation_ids.get(index) {
+            if let Ok(attestation) = Storage::get_attestation(env, &attestation_id) {
+                if !attestation.deleted
+                    && attestation.claim_type == claim_type
+                    && attestation.get_status(current_time) == AttestationStatus::Valid
+                {
+                    return Some(attestation);
+                }
+            }
+        }
+    }
+    None
+}
+
+pub fn get_subject_attestation_count(env: &Env, subject: Address) -> u32 {
+    Storage::get_subject_attestations(env, &subject).len()
+}
+
+pub fn get_valid_claim_count(env: &Env, subject: Address) -> u32 {
+    let current_time = env.ledger().timestamp();
+    let mut count = 0u32;
+    for attestation_id in Storage::get_subject_attestations(env, &subject).iter() {
+        if let Ok(attestation) = Storage::get_attestation(env, &attestation_id) {
+            if !attestation.deleted && attestation.get_status(current_time) == AttestationStatus::Valid {
+                count += 1;
+            }
+        }
+    }
+    count
+}
+
+pub fn get_global_stats(env: &Env) -> GlobalStats {
+    Storage::get_global_stats(env)
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,0 +1,187 @@
+use soroban_sdk::{Address, Env, String, Vec};
+
+use crate::attestation::{store_attestation, validate_native_expiration};
+use crate::events::Events;
+use crate::storage::Storage;
+use crate::types::{
+    Attestation, AttestationOrigin, AttestationRequest, Error, RequestStatus,
+    ATTESTATION_REQUEST_TTL_SECS,
+};
+use crate::validation::Validation;
+
+pub fn request_attestation(
+    env: &Env,
+    subject: Address,
+    issuer: Address,
+    claim_type: String,
+) -> Result<String, Error> {
+    subject.require_auth();
+    Validation::require_not_paused(env)?;
+    Validation::require_issuer(env, &issuer)?;
+    Validation::validate_claim_type(&claim_type)?;
+
+    let timestamp = env.ledger().timestamp();
+    let request_id = AttestationRequest::generate_id(env, &subject, &issuer, &claim_type, timestamp);
+
+    if Storage::get_request(env, &request_id).is_ok() {
+        return Err(Error::DuplicateRequest);
+    }
+
+    let expires_at = timestamp + ATTESTATION_REQUEST_TTL_SECS;
+    let request = AttestationRequest {
+        id: request_id.clone(),
+        subject: subject.clone(),
+        issuer: issuer.clone(),
+        claim_type: claim_type.clone(),
+        timestamp,
+        expires_at,
+        status: RequestStatus::Pending,
+        rejection_reason: None,
+    };
+
+    Storage::set_request(env, &request);
+    Storage::add_pending_request(env, &issuer, &request_id);
+    Events::attestation_requested(env, &request_id, &subject, &issuer, &claim_type, expires_at);
+
+    Ok(request_id)
+}
+
+pub fn fulfill_request(
+    env: &Env,
+    issuer: Address,
+    request_id: String,
+    expiration: Option<u64>,
+) -> Result<String, Error> {
+    issuer.require_auth();
+    Validation::require_not_paused(env)?;
+    Validation::require_issuer(env, &issuer)?;
+
+    let mut request = Storage::get_request(env, &request_id)?;
+
+    if request.issuer != issuer {
+        return Err(Error::Unauthorized);
+    }
+
+    match request.status {
+        RequestStatus::Fulfilled | RequestStatus::Rejected => return Err(Error::RequestAlreadyProcessed),
+        RequestStatus::Pending => {}
+    }
+
+    let current_time = env.ledger().timestamp();
+    if current_time >= request.expires_at {
+        return Err(Error::RequestExpired);
+    }
+
+    validate_native_expiration(env, expiration)?;
+
+    let attestation_id = Attestation::generate_id(env, &issuer, &request.subject, &request.claim_type, current_time);
+    if Storage::has_attestation(env, &attestation_id) {
+        return Err(Error::DuplicateAttestation);
+    }
+
+    let limits = Storage::get_limits(env);
+    if Storage::get_issuer_attestations(env, &issuer).len() >= limits.max_attestations_per_issuer {
+        return Err(Error::LimitExceeded);
+    }
+    if Storage::get_subject_attestations(env, &request.subject).len() >= limits.max_attestations_per_subject {
+        return Err(Error::LimitExceeded);
+    }
+
+    let attestation = Attestation {
+        id: attestation_id.clone(),
+        issuer: issuer.clone(),
+        subject: request.subject.clone(),
+        claim_type: request.claim_type.clone(),
+        timestamp: current_time,
+        expiration,
+        revoked: false,
+        metadata: None,
+        jurisdiction: None,
+        valid_from: None,
+        origin: AttestationOrigin::Native,
+        source_chain: None,
+        source_tx: None,
+        tags: None,
+        revocation_reason: None,
+        deleted: false,
+    };
+
+    store_attestation(env, &attestation);
+    Events::attestation_created(env, &attestation);
+
+    request.status = RequestStatus::Fulfilled;
+    Storage::set_request(env, &request);
+    Storage::remove_pending_request(env, &issuer, &request_id);
+
+    Events::request_fulfilled(env, &request_id, &issuer, &attestation_id);
+
+    Ok(attestation_id)
+}
+
+pub fn reject_request(
+    env: &Env,
+    issuer: Address,
+    request_id: String,
+    reason: Option<String>,
+) -> Result<(), Error> {
+    issuer.require_auth();
+    Validation::require_not_paused(env)?;
+    Validation::require_issuer(env, &issuer)?;
+    crate::attestation::validate_reason(&reason)?;
+
+    let mut request = Storage::get_request(env, &request_id)?;
+
+    if request.issuer != issuer {
+        return Err(Error::Unauthorized);
+    }
+
+    match request.status {
+        RequestStatus::Fulfilled | RequestStatus::Rejected => return Err(Error::RequestAlreadyProcessed),
+        RequestStatus::Pending => {}
+    }
+
+    let current_time = env.ledger().timestamp();
+    if current_time >= request.expires_at {
+        return Err(Error::RequestExpired);
+    }
+
+    request.status = RequestStatus::Rejected;
+    request.rejection_reason = reason.clone();
+    Storage::set_request(env, &request);
+    Storage::remove_pending_request(env, &issuer, &request_id);
+
+    Events::request_rejected(env, &request_id, &issuer, &reason);
+
+    Ok(())
+}
+
+pub fn get_pending_requests(env: &Env, issuer: Address, start: u32, limit: u32) -> Vec<AttestationRequest> {
+    let current_time = env.ledger().timestamp();
+    let all_ids = Storage::get_pending_request_ids(env, &issuer);
+    let mut pending = Vec::new(env);
+
+    for id in all_ids.iter() {
+        if let Ok(req) = Storage::get_request(env, &id) {
+            if req.status == RequestStatus::Pending && current_time < req.expires_at {
+                pending.push_back(req);
+            }
+        }
+    }
+
+    let total = pending.len();
+    let start = start.min(total);
+    let end = (start + limit).min(total);
+    let mut result = Vec::new(env);
+    let mut i = start;
+    while i < end {
+        if let Some(req) = pending.get(i) {
+            result.push_back(req);
+        }
+        i += 1;
+    }
+    result
+}
+
+pub fn get_request(env: &Env, request_id: String) -> Result<AttestationRequest, Error> {
+    Storage::get_request(env, &request_id)
+}


### PR DESCRIPTION
   Lib.rs has been sucessfully split into the suggested files.                                 
  One bug fixed in the original: the duplicate endorse_attestation       
  definition (the first one called Storage::add_endorsement with a wrong 
  3-argument signature). The correct single-argument form is preserved.  
                                                                         
  The callback module is declared pub(crate) in lib.rs so attestation.rs 
  can reach crate::callback::ExpirationCallbackClient. All cross-module  
  helpers are pub fn free functions — no trait objects or dynamic        
  dispatch needed.       

Closes #249