### PR TITLE
feat(sdk): add typed error classes to TypeScript client

### DIFF
--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -30,6 +30,7 @@ import type {
   Network,
   TrustLinkClientOptions,
 } from "./types";
+import { parseTrustLinkError } from "./types";
 
 import {
   CircuitBreaker,
@@ -104,6 +105,8 @@ export class TrustLinkClient {
       const result = await this.server.simulateTransaction(tx);
 
       if (SorobanRpc.Api.isSimulationError(result)) {
+        const typed = parseTrustLinkError(result.error);
+        if (typed) throw typed;
         throw new Error(`Contract simulation failed: ${result.error}`);
       }
 

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -124,32 +124,157 @@ export interface AttestationRequest {
   rejection_reason: string | null;
 }
 
-/** Error codes returned by the TrustLink contract. */
-export enum TrustLinkError {
-  AlreadyInitialized = 1,
-  NotInitialized = 2,
-  Unauthorized = 3,
-  NotFound = 4,
-  DuplicateAttestation = 5,
-  AlreadyRevoked = 6,
-  Expired = 7,
-  InvalidValidFrom = 8,
-  InvalidExpiration = 9,
-  MetadataTooLong = 10,
-  InvalidTimestamp = 11,
-  InvalidFee = 12,
-  FeeTokenRequired = 13,
-  TooManyTags = 14,
-  TagTooLong = 15,
-  InvalidThreshold = 16,
-  NotRequiredSigner = 17,
-  AlreadySigned = 18,
-  ProposalFinalized = 19,
-  ProposalExpired = 20,
-  ReasonTooLong = 21,
-  CannotEndorseOwn = 22,
-  AlreadyEndorsed = 23,
-  ContractPaused = 24,
+/** Base class for all TrustLink contract errors. */
+export class TrustLinkError extends Error {
+  constructor(public readonly code: number, name: string, message?: string) {
+    super(message ?? name);
+    this.name = name;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class AlreadyInitializedError extends TrustLinkError {
+  constructor() { super(1, "AlreadyInitialized"); }
+}
+export class NotInitializedError extends TrustLinkError {
+  constructor() { super(2, "NotInitialized"); }
+}
+export class UnauthorizedError extends TrustLinkError {
+  constructor() { super(3, "Unauthorized"); }
+}
+export class NotFoundError extends TrustLinkError {
+  constructor() { super(4, "NotFound"); }
+}
+export class DuplicateAttestationError extends TrustLinkError {
+  constructor() { super(5, "DuplicateAttestation"); }
+}
+export class AlreadyRevokedError extends TrustLinkError {
+  constructor() { super(6, "AlreadyRevoked"); }
+}
+export class ExpiredError extends TrustLinkError {
+  constructor() { super(7, "Expired"); }
+}
+export class InvalidValidFromError extends TrustLinkError {
+  constructor() { super(8, "InvalidValidFrom"); }
+}
+export class InvalidExpirationError extends TrustLinkError {
+  constructor() { super(9, "InvalidExpiration"); }
+}
+export class MetadataTooLongError extends TrustLinkError {
+  constructor() { super(10, "MetadataTooLong"); }
+}
+export class InvalidTimestampError extends TrustLinkError {
+  constructor() { super(11, "InvalidTimestamp"); }
+}
+export class InvalidFeeError extends TrustLinkError {
+  constructor() { super(12, "InvalidFee"); }
+}
+export class FeeTokenRequiredError extends TrustLinkError {
+  constructor() { super(13, "FeeTokenRequired"); }
+}
+export class TooManyTagsError extends TrustLinkError {
+  constructor() { super(14, "TooManyTags"); }
+}
+export class TagTooLongError extends TrustLinkError {
+  constructor() { super(15, "TagTooLong"); }
+}
+export class InvalidThresholdError extends TrustLinkError {
+  constructor() { super(16, "InvalidThreshold"); }
+}
+export class NotRequiredSignerError extends TrustLinkError {
+  constructor() { super(17, "NotRequiredSigner"); }
+}
+export class AlreadySignedError extends TrustLinkError {
+  constructor() { super(18, "AlreadySigned"); }
+}
+export class ProposalFinalizedError extends TrustLinkError {
+  constructor() { super(19, "ProposalFinalized"); }
+}
+export class ProposalExpiredError extends TrustLinkError {
+  constructor() { super(20, "ProposalExpired"); }
+}
+export class ReasonTooLongError extends TrustLinkError {
+  constructor() { super(21, "ReasonTooLong"); }
+}
+export class CannotEndorseOwnError extends TrustLinkError {
+  constructor() { super(22, "CannotEndorseOwn"); }
+}
+export class AlreadyEndorsedError extends TrustLinkError {
+  constructor() { super(23, "AlreadyEndorsed"); }
+}
+export class ContractPausedError extends TrustLinkError {
+  constructor() { super(24, "ContractPaused"); }
+}
+export class LimitExceededError extends TrustLinkError {
+  constructor() { super(25, "LimitExceeded"); }
+}
+export class SelfAttestationError extends TrustLinkError {
+  constructor() { super(26, "SelfAttestation"); }
+}
+export class InvalidClaimTypeError extends TrustLinkError {
+  constructor() { super(27, "InvalidClaimType"); }
+}
+export class RequestNotFoundError extends TrustLinkError {
+  constructor() { super(28, "RequestNotFound"); }
+}
+export class RequestAlreadyFulfilledError extends TrustLinkError {
+  constructor() { super(29, "RequestAlreadyFulfilled"); }
+}
+
+const ERROR_BY_CODE: Record<number, new () => TrustLinkError> = {
+  1: AlreadyInitializedError,
+  2: NotInitializedError,
+  3: UnauthorizedError,
+  4: NotFoundError,
+  5: DuplicateAttestationError,
+  6: AlreadyRevokedError,
+  7: ExpiredError,
+  8: InvalidValidFromError,
+  9: InvalidExpirationError,
+  10: MetadataTooLongError,
+  11: InvalidTimestampError,
+  12: InvalidFeeError,
+  13: FeeTokenRequiredError,
+  14: TooManyTagsError,
+  15: TagTooLongError,
+  16: InvalidThresholdError,
+  17: NotRequiredSignerError,
+  18: AlreadySignedError,
+  19: ProposalFinalizedError,
+  20: ProposalExpiredError,
+  21: ReasonTooLongError,
+  22: CannotEndorseOwnError,
+  23: AlreadyEndorsedError,
+  24: ContractPausedError,
+  25: LimitExceededError,
+  26: SelfAttestationError,
+  27: InvalidClaimTypeError,
+  28: RequestNotFoundError,
+  29: RequestAlreadyFulfilledError,
+};
+
+const ERROR_BY_NAME: Record<string, new () => TrustLinkError> = Object.fromEntries(
+  Object.values(ERROR_BY_CODE).map((Cls) => {
+    const instance = new Cls();
+    return [instance.name, Cls];
+  })
+);
+
+/**
+ * Parse a contract simulation error string into a typed TrustLinkError.
+ * Returns null if the error string does not match a known contract error.
+ */
+export function parseTrustLinkError(errorMessage: string): TrustLinkError | null {
+  // Soroban encodes contract errors as "Error(Contract, #N)" or includes the name
+  const codeMatch = errorMessage.match(/Error\(Contract,\s*#(\d+)\)/);
+  if (codeMatch) {
+    const Cls = ERROR_BY_CODE[parseInt(codeMatch[1], 10)];
+    if (Cls) return new Cls();
+  }
+  for (const [name, Cls] of Object.entries(ERROR_BY_NAME)) {
+    if (errorMessage.includes(name)) return new Cls();
+  }
+  return null;
 }
 
 /** Network presets supported by TrustLinkClient. */


### PR DESCRIPTION
Map all 29 contract error codes to named TrustLinkError subclasses. Add parseTrustLinkError helper and wire it into simulate() so contract errors surface as typed exceptions instead of generic Error objects.

Closes #347