### PR TITLE
feat(sdk): add React hooks package

### DIFF
--- a/sdk/react/README.md
+++ b/sdk/react/README.md
@@ -1,0 +1,55 @@
+# @trustlink/react
+
+React hooks for the [TrustLink](https://github.com/afurious/TrustLink) on-chain attestation contract on Stellar.
+
+## Installation
+
+```bash
+npm install @trustlink/react @trustlink/sdk
+```
+
+## Usage
+
+```tsx
+import { useTrustLink, useHasValidClaim, useSubjectAttestations } from "@trustlink/react";
+
+const CONTRACT_ID = "C...";
+
+function KycGate({ subject }: { subject: string }) {
+  const client = useTrustLink({ contractId: CONTRACT_ID, network: "testnet" });
+  const { data: valid, loading, error } = useHasValidClaim(client, subject, "kyc_passed");
+
+  if (loading) return <p>Checking…</p>;
+  if (error)   return <p>Error: {error.message}</p>;
+  return <p>KYC: {valid ? "✅ passed" : "❌ not passed"}</p>;
+}
+
+function AttestationList({ subject }: { subject: string }) {
+  const client = useTrustLink({ contractId: CONTRACT_ID, network: "testnet" });
+  const { data: attestations, loading } = useSubjectAttestations(client, subject);
+
+  if (loading) return <p>Loading…</p>;
+  return (
+    <ul>
+      {attestations?.map((a) => (
+        <li key={a.id}>{a.claim_type} — {a.revoked ? "revoked" : "active"}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+## API
+
+### `useTrustLink(options: TrustLinkClientOptions): TrustLinkClient`
+
+Creates (and memoises) a `TrustLinkClient`. Pass the result to the other hooks.
+
+### `useHasValidClaim(client, subject, claimType)`
+
+Returns `{ data: boolean | null, loading, error, refetch }`.
+
+### `useSubjectAttestations(client, subject, { start?, limit? })`
+
+Returns `{ data: Attestation[] | null, loading, error, refetch }`.  
+Defaults: `start = 0`, `limit = 50`.

--- a/sdk/react/package.json
+++ b/sdk/react/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@trustlink/react",
+  "version": "0.1.0",
+  "description": "React hooks for the TrustLink on-chain attestation contract on Stellar",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist", "README.md"],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "prepublishOnly": "npm run clean && npm run build"
+  },
+  "keywords": ["stellar", "soroban", "attestation", "trustlink", "react", "hooks"],
+  "author": "TrustLink Team",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/afurious/TrustLink.git",
+    "directory": "sdk/react"
+  },
+  "publishConfig": { "access": "public" },
+  "dependencies": {
+    "@trustlink/sdk": "^0.1.0"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "@types/react": "^18.0.0"
+  }
+}

--- a/sdk/react/src/index.ts
+++ b/sdk/react/src/index.ts
@@ -1,0 +1,82 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { TrustLinkClient } from "@trustlink/sdk";
+import type { TrustLinkClientOptions, Attestation } from "@trustlink/sdk";
+
+// ── shared hook state shape ───────────────────────────────────────────────────
+
+interface AsyncState<T> {
+  data: T | null;
+  loading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+function useAsync<T>(fn: () => Promise<T>, deps: unknown[]): AsyncState<T> {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const counter = useRef(0);
+
+  const run = useCallback(() => {
+    const id = ++counter.current;
+    setLoading(true);
+    setError(null);
+    fn()
+      .then((result) => { if (id === counter.current) { setData(result); setLoading(false); } })
+      .catch((err) => { if (id === counter.current) { setError(err instanceof Error ? err : new Error(String(err))); setLoading(false); } });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  useEffect(() => { run(); }, [run]);
+
+  return { data, loading, error, refetch: run };
+}
+
+// ── useTrustLink ──────────────────────────────────────────────────────────────
+
+/**
+ * Returns a stable TrustLinkClient instance for the given contract.
+ * Re-creates the client only when contractId or network options change.
+ */
+export function useTrustLink(options: TrustLinkClientOptions): TrustLinkClient {
+  const ref = useRef<{ client: TrustLinkClient; key: string } | null>(null);
+  const key = `${options.contractId}:${options.network}:${options.rpcUrl ?? ""}`;
+
+  if (!ref.current || ref.current.key !== key) {
+    ref.current = { client: new TrustLinkClient(options), key };
+  }
+
+  return ref.current.client;
+}
+
+// ── useHasValidClaim ──────────────────────────────────────────────────────────
+
+/**
+ * Checks whether `subject` holds a valid claim of `claimType`.
+ */
+export function useHasValidClaim(
+  client: TrustLinkClient,
+  subject: string,
+  claimType: string
+): AsyncState<boolean> {
+  return useAsync(
+    () => client.hasValidClaim(subject, claimType),
+    [client, subject, claimType]
+  );
+}
+
+// ── useSubjectAttestations ────────────────────────────────────────────────────
+
+/**
+ * Fetches all attestations for `subject` (up to `limit`, default 50).
+ */
+export function useSubjectAttestations(
+  client: TrustLinkClient,
+  subject: string,
+  { start = 0, limit = 50 }: { start?: number; limit?: number } = {}
+): AsyncState<Attestation[]> {
+  return useAsync(
+    () => client.getSubjectAttestations(subject, start, limit),
+    [client, subject, start, limit]
+  );
+}

--- a/sdk/react/tsconfig.json
+++ b/sdk/react/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "lib": ["ES2020", "DOM"],
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "jsx": "react"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Adds sdk/react/ with three hooks for dApp developers:
- useTrustLink(options) — memoised TrustLinkClient instance
- useHasValidClaim(client, subject, claimType) — boolean validity check
- useSubjectAttestations(client, subject, opts) — paginated attestation list

Closes #350