### PR TITLE
feat: add get_bridge_list() paginated query

### DIFF
--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -207,6 +207,10 @@ export class TrustLinkClient {
     return this.simulate("is_bridge", this.addr(address));
   }
 
+  async getBridgeList(start: number, limit: number): Promise<string[]> {
+    return this.simulate("get_bridge_list", this.u32(start), this.u32(limit));
+  }
+
   // ── Claim Type Registry ────────────────────────────────────────────────────
 
   async getClaimTypeDescription(claimType: string): Promise<string | null> {

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -212,6 +212,10 @@ pub fn is_bridge(env: &Env, address: Address) -> bool {
     Storage::is_bridge(env, &address)
 }
 
+pub fn get_bridge_list(env: &Env, start: u32, limit: u32) -> Vec<Address> {
+    crate::storage::paginate_addresses(env, &Storage::get_bridge_list(env), start, limit)
+}
+
 // -----------------------------------------------------------------------
 // Whitelist mode
 // -----------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,11 @@ impl TrustLinkContract {
         admin::is_bridge(&env, address)
     }
 
+    #[must_use]
+    pub fn get_bridge_list(env: Env, start: u32, limit: u32) -> Vec<Address> {
+        admin::get_bridge_list(&env, start, limit)
+    }
+
     // -----------------------------------------------------------------------
     // Whitelist mode
     // -----------------------------------------------------------------------

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -60,6 +60,8 @@ pub enum StorageKey {
     AttestationTemplate(Address, String),
     AttestationTemplateList(Address),
     Delegation(Address, Address, String),
+    /// Ordered list of all registered bridge contract addresses.
+    BridgeList,
 }
 
 fn get_ttl_lifetime(env: &Env) -> u32 {
@@ -197,6 +199,24 @@ impl Storage {
         let ttl = get_ttl_lifetime(env);
         env.storage().persistent().set(&key, &true);
         env.storage().persistent().extend_ttl(&key, ttl, ttl);
+        // Maintain ordered BridgeList
+        let mut list = Self::get_bridge_list(env);
+        for existing in list.iter() {
+            if &existing == bridge {
+                return;
+            }
+        }
+        list.push_back(bridge.clone());
+        let list_key = StorageKey::BridgeList;
+        env.storage().persistent().set(&list_key, &list);
+        env.storage().persistent().extend_ttl(&list_key, ttl, ttl);
+    }
+
+    pub fn get_bridge_list(env: &Env) -> Vec<Address> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::BridgeList)
+            .unwrap_or(Vec::new(env))
     }
 
     pub fn has_attestation(env: &Env, id: &String) -> bool {
@@ -708,6 +728,21 @@ impl Storage {
 }
 
 pub fn paginate(env: &Env, list: &Vec<String>, start: u32, limit: u32) -> Vec<String> {
+    let mut result = Vec::new(env);
+    let len = list.len();
+    if start >= len {
+        return result;
+    }
+    let end = (start + limit).min(len);
+    for i in start..end {
+        if let Some(item) = list.get(i) {
+            result.push_back(item);
+        }
+    }
+    result
+}
+
+pub fn paginate_addresses(env: &Env, list: &Vec<Address>, start: u32, limit: u32) -> Vec<Address> {
     let mut result = Vec::new(env);
     let len = list.len();
     if start >= len {


### PR DESCRIPTION
- Add BridgeList storage key (ordered Vec<Address>) to StorageKey enum
- Update add_bridge() to maintain BridgeList on registration
- Add get_bridge_list() storage method and paginate_addresses() helper
- Expose get_bridge_list(start, limit) as contract function in lib.rs
- Add getBridgeList(start, limit) to TypeScript SDK client
closes #500 