### PR TITLE
feat: Feat/expose get pending admin transfer

### DIFF
--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -207,6 +207,10 @@ export class TrustLinkClient {
     return this.simulate("is_bridge", this.addr(address));
   }
 
+  async getBridgeList(start: number, limit: number): Promise<string[]> {
+    return this.simulate("get_bridge_list", this.u32(start), this.u32(limit));
+  }
+
   // ── Claim Type Registry ────────────────────────────────────────────────────
 
   async getClaimTypeDescription(claimType: string): Promise<string | null> {

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -211,6 +211,10 @@ export class TrustLinkClient {
     return this.simulate("get_bridge_list", this.u32(start), this.u32(limit));
   }
 
+  async getPendingAdminTransfer(): Promise<{ proposed_by: string; new_admin: string } | null> {
+    return this.simulate("get_pending_admin_transfer");
+  }
+
   // ── Claim Type Registry ────────────────────────────────────────────────────
 
   async getClaimTypeDescription(claimType: string): Promise<string | null> {

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -212,6 +212,10 @@ pub fn is_bridge(env: &Env, address: Address) -> bool {
     Storage::is_bridge(env, &address)
 }
 
+pub fn get_bridge_list(env: &Env, start: u32, limit: u32) -> Vec<Address> {
+    crate::storage::paginate_addresses(env, &Storage::get_bridge_list(env), start, limit)
+}
+
 // -----------------------------------------------------------------------
 // Whitelist mode
 // -----------------------------------------------------------------------

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -72,6 +72,10 @@ pub fn accept_admin_transfer(env: &Env, new_admin: Address) -> Result<(), Error>
     Ok(())
 }
 
+pub fn get_pending_admin_transfer(env: &Env) -> Option<PendingAdminTransfer> {
+    Storage::get_pending_admin_transfer(env)
+}
+
 pub fn add_admin(env: &Env, existing_admin: Address, new_admin: Address) -> Result<(), Error> {
     existing_admin.require_auth();
     Validation::require_admin(env, &existing_admin)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,11 @@ impl TrustLinkContract {
         admin::is_bridge(&env, address)
     }
 
+    #[must_use]
+    pub fn get_bridge_list(env: Env, start: u32, limit: u32) -> Vec<Address> {
+        admin::get_bridge_list(&env, start, limit)
+    }
+
     // -----------------------------------------------------------------------
     // Whitelist mode
     // -----------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ use crate::storage::Storage;
 use crate::types::{
     Attestation, AttestationRequest, AttestationStatus, AttestationTemplate, AuditEntry, Error,
     ExpirationHook, FeeConfig, GlobalStats, HealthStatus, IssuerMetadata, IssuerStats, IssuerTier,
-    MultiSigProposal, RateLimitConfig, StorageLimits,
+    MultiSigProposal, PendingAdminTransfer, RateLimitConfig, StorageLimits,
 };
 use crate::validation::Validation;
 
@@ -63,6 +63,11 @@ impl TrustLinkContract {
 
     pub fn accept_admin_transfer(env: Env, new_admin: Address) -> Result<(), Error> {
         admin::accept_admin_transfer(&env, new_admin)
+    }
+
+    #[must_use]
+    pub fn get_pending_admin_transfer(env: Env) -> Option<PendingAdminTransfer> {
+        admin::get_pending_admin_transfer(&env)
     }
 
     pub fn add_admin(env: Env, existing_admin: Address, new_admin: Address) -> Result<(), Error> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -60,6 +60,8 @@ pub enum StorageKey {
     AttestationTemplate(Address, String),
     AttestationTemplateList(Address),
     Delegation(Address, Address, String),
+    /// Ordered list of all registered bridge contract addresses.
+    BridgeList,
 }
 
 fn get_ttl_lifetime(env: &Env) -> u32 {
@@ -197,6 +199,24 @@ impl Storage {
         let ttl = get_ttl_lifetime(env);
         env.storage().persistent().set(&key, &true);
         env.storage().persistent().extend_ttl(&key, ttl, ttl);
+        // Maintain ordered BridgeList
+        let mut list = Self::get_bridge_list(env);
+        for existing in list.iter() {
+            if &existing == bridge {
+                return;
+            }
+        }
+        list.push_back(bridge.clone());
+        let list_key = StorageKey::BridgeList;
+        env.storage().persistent().set(&list_key, &list);
+        env.storage().persistent().extend_ttl(&list_key, ttl, ttl);
+    }
+
+    pub fn get_bridge_list(env: &Env) -> Vec<Address> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::BridgeList)
+            .unwrap_or(Vec::new(env))
     }
 
     pub fn has_attestation(env: &Env, id: &String) -> bool {
@@ -708,6 +728,21 @@ impl Storage {
 }
 
 pub fn paginate(env: &Env, list: &Vec<String>, start: u32, limit: u32) -> Vec<String> {
+    let mut result = Vec::new(env);
+    let len = list.len();
+    if start >= len {
+        return result;
+    }
+    let end = (start + limit).min(len);
+    for i in start..end {
+        if let Some(item) = list.get(i) {
+            result.push_back(item);
+        }
+    }
+    result
+}
+
+pub fn paginate_addresses(env: &Env, list: &Vec<Address>, start: u32, limit: u32) -> Vec<Address> {
     let mut result = Vec::new(env);
     let len = list.len();
     if start >= len {

--- a/tests/pending_admin_transfer_tests.rs
+++ b/tests/pending_admin_transfer_tests.rs
@@ -1,0 +1,81 @@
+//! Tests for get_pending_admin_transfer() read-only query.
+//!
+//! Acceptance criteria:
+//!   - Returns None before a transfer is proposed.
+//!   - Returns the correct PendingAdminTransfer after one is proposed.
+//!   - Returns None again after the transfer is cancelled.
+//!   - Returns None again after the transfer is accepted.
+
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+use trustlink::{types::PendingAdminTransfer, TrustLinkContract, TrustLinkContractClient};
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+fn setup(env: &Env) -> (Address, TrustLinkContractClient<'_>) {
+    let id = env.register_contract(None, TrustLinkContract);
+    let client = TrustLinkContractClient::new(env, &id);
+    let admin = Address::generate(env);
+    client.initialize(&admin, &None);
+    (admin, client)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_returns_none_before_transfer_proposed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+
+    assert_eq!(client.get_pending_admin_transfer(), None);
+}
+
+#[test]
+fn test_returns_correct_value_after_transfer_proposed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+    let new_admin = Address::generate(&env);
+
+    client.propose_admin_transfer(&admin, &new_admin);
+
+    let pending = client.get_pending_admin_transfer();
+    assert!(pending.is_some());
+    let transfer = pending.unwrap();
+    assert_eq!(transfer.proposed_by, admin);
+    assert_eq!(transfer.new_admin, new_admin);
+}
+
+#[test]
+fn test_returns_none_after_transfer_cancelled() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+    let new_admin = Address::generate(&env);
+
+    client.propose_admin_transfer(&admin, &new_admin);
+    assert!(client.get_pending_admin_transfer().is_some());
+
+    client.cancel_admin_transfer(&admin);
+    assert_eq!(client.get_pending_admin_transfer(), None);
+}
+
+#[test]
+fn test_returns_none_after_transfer_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+    let new_admin = Address::generate(&env);
+
+    client.propose_admin_transfer(&admin, &new_admin);
+    assert!(client.get_pending_admin_transfer().is_some());
+
+    client.accept_admin_transfer(&new_admin);
+    assert_eq!(client.get_pending_admin_transfer(), None);
+}


### PR DESCRIPTION
Closes #501

---

Summary
The two-step admin transfer stores a PendingAdminTransfer in storage, but there is no public read function to inspect it. Integrators and monitoring tools cannot check whether a transfer is in progress without reading raw storage.

Acceptance Criteria
 Add get_pending_admin_transfer(env: Env) -> Option.
 TypeScript SDK exposes getPendingAdminTransfer().
 A test confirms the function returns None before a transfer is proposed and the correct value after.
 closes # 501