### PR TITLE
fix: resolve issues #522, #523, #524, #525

### DIFF
--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -155,6 +155,10 @@ export class TrustLinkClient {
     return this.simulate("get_admin");
   }
 
+  async getAdminCouncil(): Promise<string[]> {
+    return this.simulate("get_admin_council");
+  }
+
   async getVersion(): Promise<string> {
     return this.simulate("get_version");
   }
@@ -492,6 +496,15 @@ export class TrustLinkClient {
 
   async getEndorsementCount(attestationId: string): Promise<number> {
     return this.simulate("get_endorsement_count", this.str(attestationId));
+  }
+
+  async listEndorsementsByEndorser(endorser: string, start: number, limit: number): Promise<Endorsement[]> {
+    return this.simulate("list_endorsements_by_endorser", this.addr(endorser), this.u32(start), this.u32(limit));
+  }
+
+  async bulkAddToWhitelist(issuer: string, subjects: string[]): Promise<void> {
+    const subjectsVal = xdr.ScVal.scvVec(subjects.map(s => this.addr(s)));
+    return this.simulate("bulk_add_to_whitelist", this.addr(issuer), subjectsVal);
   }
 
   // ── Pagination Helpers ─────────────────────────────────────────────────────

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -106,6 +106,10 @@ pub fn get_admin(env: &Env) -> Result<Address, Error> {
     Storage::get_admin(env)
 }
 
+pub fn get_admin_council(env: &Env) -> Result<AdminCouncil, Error> {
+    Storage::get_admin_council(env)
+}
+
 // -----------------------------------------------------------------------
 // Issuer management
 // -----------------------------------------------------------------------
@@ -140,6 +144,19 @@ pub fn add_to_whitelist(env: &Env, issuer: Address, subject: Address) -> Result<
     issuer.require_auth();
     Validation::require_issuer(env, &issuer)?;
     Storage::add_to_whitelist(env, &issuer, &subject);
+    Ok(())
+}
+
+pub fn bulk_add_to_whitelist(env: &Env, issuer: Address, subjects: Vec<Address>) -> Result<(), Error> {
+    const MAX_BATCH: u32 = 50;
+    issuer.require_auth();
+    Validation::require_issuer(env, &issuer)?;
+    if subjects.len() > MAX_BATCH {
+        return Err(Error::LimitExceeded);
+    }
+    for subject in subjects.iter() {
+        Storage::add_to_whitelist(env, &issuer, &subject);
+    }
     Ok(())
 }
 
@@ -440,6 +457,9 @@ pub fn revoke_delegation(
 // -----------------------------------------------------------------------
 
 pub fn register_expiration_hook(env: &Env, subject: Address, callback_contract: Address, notify_days_before: u32) -> Result<(), Error> {
+    if notify_days_before == 0 {
+        return Err(Error::InvalidExpiration);
+    }
     subject.require_auth();
     Storage::set_expiration_hook(env, &subject, &ExpirationHook { callback_contract, notify_days_before });
     Ok(())

--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -780,6 +780,18 @@ pub fn get_endorsement_count(env: &Env, attestation_id: String) -> u32 {
     Storage::get_endorsements(env, &attestation_id).len()
 }
 
+pub fn list_endorsements_by_endorser(env: &Env, endorser: Address, start: u32, limit: u32) -> Vec<Endorsement> {
+    let all = Storage::get_endorsements_by_endorser(env, &endorser);
+    let total = all.len();
+    let start = start.min(total);
+    let end = (start + limit).min(total);
+    let mut result = Vec::new(env);
+    for i in start..end {
+        result.push_back(all.get(i).unwrap());
+    }
+    result
+}
+
 // -----------------------------------------------------------------------
 // Delegated attestation creation
 // -----------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,9 +30,10 @@ use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
 use crate::events::Events;
 use crate::storage::Storage;
 use crate::types::{
-    Attestation, AttestationRequest, AttestationStatus, AttestationTemplate, AuditEntry, Error,
-    ExpirationHook, FeeConfig, GlobalStats, HealthStatus, IssuerMetadata, IssuerStats, IssuerTier,
-    MultiSigProposal, PendingAdminTransfer, RateLimitConfig, StorageLimits,
+    AdminCouncil, Attestation, AttestationRequest, AttestationStatus, AttestationTemplate,
+    AuditEntry, Endorsement, Error, ExpirationHook, FeeConfig, GlobalStats, HealthStatus,
+    IssuerMetadata, IssuerStats, IssuerTier, MultiSigProposal, PendingAdminTransfer,
+    RateLimitConfig, StorageLimits,
 };
 use crate::validation::Validation;
 
@@ -82,6 +83,11 @@ impl TrustLinkContract {
         admin::get_admin(&env)
     }
 
+    #[must_use]
+    pub fn get_admin_council(env: Env) -> Result<AdminCouncil, Error> {
+        admin::get_admin_council(&env)
+    }
+
     // -----------------------------------------------------------------------
     // Issuer management
     // -----------------------------------------------------------------------
@@ -101,6 +107,10 @@ impl TrustLinkContract {
 
     pub fn add_to_whitelist(env: Env, issuer: Address, subject: Address) -> Result<(), Error> {
         admin::add_to_whitelist(&env, issuer, subject)
+    }
+
+    pub fn bulk_add_to_whitelist(env: Env, issuer: Address, subjects: Vec<Address>) -> Result<(), Error> {
+        admin::bulk_add_to_whitelist(&env, issuer, subjects)
     }
 
     pub fn remove_from_whitelist(env: Env, issuer: Address, subject: Address) -> Result<(), Error> {
@@ -413,6 +423,11 @@ impl TrustLinkContract {
     #[must_use]
     pub fn get_endorsement_count(env: Env, attestation_id: String) -> u32 {
         attestation::get_endorsement_count(&env, attestation_id)
+    }
+
+    #[must_use]
+    pub fn list_endorsements_by_endorser(env: Env, endorser: Address, start: u32, limit: u32) -> Vec<Endorsement> {
+        attestation::list_endorsements_by_endorser(&env, endorser, start, limit)
     }
 
     pub fn create_attestation_as_delegate(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -63,6 +63,8 @@ pub enum StorageKey {
     Delegation(Address, Address, String),
     /// Ordered list of all registered bridge contract addresses.
     BridgeList,
+    /// Index of endorsement IDs made by a specific endorser.
+    EndorserIndex(Address),
     /// Per-claim-type rate limit override (claim_type -> min_issuance_interval).
     ClaimTypeRateLimit(String),
 }
@@ -658,6 +660,24 @@ impl Storage {
         list.push_back(endorsement.clone());
         env.storage().persistent().set(&key, &list);
         env.storage().persistent().extend_ttl(&key, ttl, ttl);
+
+        // Maintain per-endorser index
+        let endorser_key = StorageKey::EndorserIndex(endorsement.endorser.clone());
+        let mut endorser_list: Vec<Endorsement> = env
+            .storage()
+            .persistent()
+            .get(&endorser_key)
+            .unwrap_or(Vec::new(env));
+        endorser_list.push_back(endorsement.clone());
+        env.storage().persistent().set(&endorser_key, &endorser_list);
+        env.storage().persistent().extend_ttl(&endorser_key, ttl, ttl);
+    }
+
+    pub fn get_endorsements_by_endorser(env: &Env, endorser: &Address) -> Vec<Endorsement> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::EndorserIndex(endorser.clone()))
+            .unwrap_or(Vec::new(env))
     }
 
     pub fn next_proposal_id(env: &Env) -> u32 {

--- a/src/test.rs
+++ b/src/test.rs
@@ -7996,3 +7996,129 @@ mod get_valid_claims_tests {
         assert_eq!(claims.get(0).unwrap(), claim_type);
     }
 }
+
+// ── Issue #522: validate notify_days_before > 0 ───────────────────────────────
+
+#[test]
+fn test_register_expiration_hook_zero_days_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, _, client) = setup(&env);
+    let subject = Address::generate(&env);
+    let callback = Address::generate(&env);
+
+    let result = client.try_register_expiration_hook(&subject, &callback, &0);
+    assert_eq!(result, Err(Ok(crate::types::Error::InvalidExpiration)));
+}
+
+#[test]
+fn test_register_expiration_hook_nonzero_days_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, _, client) = setup(&env);
+    let subject = Address::generate(&env);
+    let callback = Address::generate(&env);
+
+    client.register_expiration_hook(&subject, &callback, &1);
+    let hook = client.get_expiration_hook(&subject).unwrap();
+    assert_eq!(hook.notify_days_before, 1);
+}
+
+// ── Issue #523: list_endorsements_by_endorser ─────────────────────────────────
+
+#[test]
+fn test_list_endorsements_by_endorser_returns_correct_entries() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, issuer, client) = setup(&env);
+    let endorser = Address::generate(&env);
+    client.register_issuer(&admin, &endorser);
+    let subject = Address::generate(&env);
+    let claim = String::from_str(&env, "KYC_PASSED");
+
+    let id = client.create_attestation(&issuer, &subject, &claim, &None, &None, &None);
+    client.endorse_attestation(&endorser, &id);
+
+    let results = client.list_endorsements_by_endorser(&endorser, &0, &10);
+    assert_eq!(results.len(), 1);
+    assert_eq!(results.get(0).unwrap().attestation_id, id);
+}
+
+#[test]
+fn test_list_endorsements_by_endorser_empty_for_new_endorser() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, _, client) = setup(&env);
+    let endorser = Address::generate(&env);
+
+    let results = client.list_endorsements_by_endorser(&endorser, &0, &10);
+    assert_eq!(results.len(), 0);
+}
+
+// ── Issue #524: bulk_add_to_whitelist ─────────────────────────────────────────
+
+#[test]
+fn test_bulk_add_to_whitelist_happy_path() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, issuer, client) = setup(&env);
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+    let mut subjects = soroban_sdk::Vec::new(&env);
+    subjects.push_back(s1.clone());
+    subjects.push_back(s2.clone());
+
+    client.bulk_add_to_whitelist(&issuer, &subjects);
+
+    assert!(client.is_whitelisted(&issuer, &s1));
+    assert!(client.is_whitelisted(&issuer, &s2));
+}
+
+#[test]
+fn test_bulk_add_to_whitelist_over_limit_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, issuer, client) = setup(&env);
+    let mut subjects = soroban_sdk::Vec::new(&env);
+    for _ in 0..51 {
+        subjects.push_back(Address::generate(&env));
+    }
+
+    let result = client.try_bulk_add_to_whitelist(&issuer, &subjects);
+    assert_eq!(result, Err(Ok(crate::types::Error::LimitExceeded)));
+}
+
+// ── Issue #525: get_admin_council ─────────────────────────────────────────────
+
+#[test]
+fn test_get_admin_council_returns_correct_list() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = {
+        let contract_id = env.register_contract(None, TrustLinkContract);
+        let client = TrustLinkContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin, &None);
+        (admin, client)
+    };
+
+    let council = client.get_admin_council().unwrap();
+    assert_eq!(council.len(), 1);
+}
+
+#[test]
+fn test_get_admin_council_reflects_add_and_remove() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, TrustLinkContract);
+    let client = TrustLinkContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &None);
+    let new_admin = Address::generate(&env);
+
+    client.add_admin(&admin, &new_admin);
+    assert_eq!(client.get_admin_council().unwrap().len(), 2);
+
+    client.remove_admin(&admin, &new_admin);
+    assert_eq!(client.get_admin_council().unwrap().len(), 1);
+}


### PR DESCRIPTION
## Summary

This PR resolves four enhancement issues in a single batch.

---

### #522 — Expiration hooks: validate `notify_days_before` is > 0

**Problem:** `register_expiration_hook` accepted `notify_days_before: u32 = 0`, which would only fire on the exact expiration second — practically useless and likely a user error.

**Fix:** Added an early return of `Error::InvalidExpiration` when `notify_days_before == 0` in `admin::register_expiration_hook`.

**Tests:** `test_register_expiration_hook_zero_days_rejected`, `test_register_expiration_hook_nonzero_days_accepted`

---

### #523 — Endorsements: add `list_endorsements_by_endorser()` query

**Problem:** No way to query all endorsements made by a specific issuer, needed for reputation dashboards.

**Fix:**
- Added `EndorserIndex(Address)` storage key to `StorageKey` enum.
- Updated `Storage::add_endorsement` to also write to the per-endorser index.
- Added `Storage::get_endorsements_by_endorser` helper.
- Added `attestation::list_endorsements_by_endorser` with offset pagination.
- Exposed as `list_endorsements_by_endorser(endorser, start, limit)` on the contract.
- Added `listEndorsementsByEndorser(endorser, start, limit)` to the TypeScript SDK.

**Tests:** `test_list_endorsements_by_endorser_returns_correct_entries`, `test_list_endorsements_by_endorser_empty_for_new_endorser`

---

### #524 — Whitelist: add `bulk_add_to_whitelist()` for batch onboarding

**Problem:** Issuers onboarding a large cohort had to call `add_to_whitelist` once per subject, expensive in transaction count and fees.

**Fix:**
- Added `admin::bulk_add_to_whitelist` with a batch size cap of 50 (matching `revoke_attestations_batch`). Returns `Error::LimitExceeded` if the batch exceeds the cap.
- Exposed as `bulk_add_to_whitelist(issuer, subjects)` on the contract.
- Added `bulkAddToWhitelist(issuer, subjects)` to the TypeScript SDK.

**Tests:** `test_bulk_add_to_whitelist_happy_path`, `test_bulk_add_to_whitelist_over_limit_rejected`

---

### #525 — Admin council: expose `get_admin_council()` as a public read function

**Problem:** The admin council list was stored in `AdminCouncil` storage but had no public contract function to read it.

**Fix:**
- Added `admin::get_admin_council` delegating to `Storage::get_admin_council`.
- Exposed as `get_admin_council() -> Vec<Address>` on the contract.
- Added `getAdminCouncil()` to the TypeScript SDK.

**Tests:** `test_get_admin_council_returns_correct_list`, `test_get_admin_council_reflects_add_and_remove`

---

## Files Changed

- `src/admin.rs` — #522 validation, #524 bulk whitelist, #525 council getter
- `src/attestation.rs` — #523 list by endorser
- `src/lib.rs` — expose all four new contract functions
- `src/storage.rs` — #523 EndorserIndex key + per-endorser index writes
- `src/test.rs` — tests for all four issues
- `sdk/typescript/src/client.ts` — SDK methods for #523, #524, #525

Closes #522, closes #523, closes #524, closes #525