### PR TITLE
feat: resolve issues #506 #507 #508 #509

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -99,6 +99,9 @@ const validClaims = await client.getValidClaims(subject);
 // Attestations by tag
 const tagged = await client.getAttestationsByTag(subject, "premium");
 
+// Attestations by jurisdiction (paginated)
+const euAtts = await client.getAttestationsByJurisdiction(subject, "EU", 0, 10);
+
 // Audit log for an attestation
 const log = await client.getAuditLog(attestationId);
 ```

--- a/sdk/typescript/examples/usage.ts
+++ b/sdk/typescript/examples/usage.ts
@@ -60,6 +60,10 @@ async function main() {
   const page = await client.getSubjectAttestations(USER_ADDRESS, 0, 5);
   console.log(`First page (up to 5):`, page);
 
+  // Attestations filtered by jurisdiction
+  const euAttestations = await client.getAttestationsByJurisdiction(USER_ADDRESS, "EU", 0, 10);
+  console.log(`EU-jurisdiction attestations:`, euAttestations);
+
   // ── Pagination helpers ──────────────────────────────────────────────────
   console.log("\n=== Pagination Helpers ===");
 

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -288,6 +288,29 @@ export class TrustLinkClient {
     );
   }
 
+  /**
+   * Returns a paginated list of attestation IDs for a subject filtered by jurisdiction.
+   *
+   * @param subject     - Stellar address of the subject.
+   * @param jurisdiction - Jurisdiction code to filter by (e.g. "US", "EU").
+   * @param start       - Zero-based page offset.
+   * @param limit       - Maximum number of IDs to return.
+   */
+  async getAttestationsByJurisdiction(
+    subject: string,
+    jurisdiction: string,
+    start: number,
+    limit: number
+  ): Promise<string[]> {
+    return this.simulate(
+      "get_attestations_by_jurisdiction",
+      this.addr(subject),
+      this.str(jurisdiction),
+      this.u32(start),
+      this.u32(limit)
+    );
+  }
+
   async getValidClaims(subject: string): Promise<string[]> {
     return this.simulate("get_valid_claims", this.addr(subject));
   }

--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -740,6 +740,12 @@ pub fn request_deletion(env: &Env, subject: Address, attestation_id: String) -> 
 
     let timestamp = env.ledger().timestamp();
     Events::deletion_requested(env, &subject, &attestation_id, timestamp);
+    Storage::append_audit_entry(env, &attestation_id, &AuditEntry {
+        action: AuditAction::Deleted,
+        actor: subject.clone(),
+        timestamp,
+        details: None,
+    });
     Ok(())
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -221,6 +221,7 @@ pub enum AuditAction {
     Renewed,
     Updated,
     Transferred,
+    Deleted,
 }
 
 /// A single immutable entry in an attestation's audit log.

--- a/tests/claim_status_proptest.rs
+++ b/tests/claim_status_proptest.rs
@@ -1,0 +1,166 @@
+// Property-based tests: has_valid_claim is consistent with get_attestation_status (#509)
+//
+// Invariant: has_valid_claim(subject, claim_type) == true
+//            iff at least one non-deleted attestation for (subject, claim_type)
+//            has get_attestation_status() == AttestationStatus::Valid.
+
+#![cfg(test)]
+
+use proptest::prelude::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env, String,
+};
+use trustlink::{TrustLinkContract, TrustLinkContractClient};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn deploy(env: &Env) -> TrustLinkContractClient {
+    let id = env.register_contract(None, TrustLinkContract);
+    TrustLinkContractClient::new(env, &id)
+}
+
+/// Possible states we can put an attestation into.
+#[derive(Debug, Clone)]
+enum AttestationState {
+    Valid,
+    Revoked,
+    Expired,
+    Pending,
+}
+
+fn attestation_state_strategy() -> impl Strategy<Value = AttestationState> {
+    prop_oneof![
+        Just(AttestationState::Valid),
+        Just(AttestationState::Revoked),
+        Just(AttestationState::Expired),
+        Just(AttestationState::Pending),
+    ]
+}
+
+// ── Core invariant ────────────────────────────────────────────────────────────
+
+proptest! {
+    /// Single attestation: has_valid_claim matches get_attestation_status.
+    #[test]
+    fn prop_has_valid_claim_consistent_with_status_single(
+        state in attestation_state_strategy(),
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+        // Base time: 10_000 seconds.
+        env.ledger().with_mut(|l| l.timestamp = 10_000);
+
+        let client = deploy(&env);
+        let admin   = Address::generate(&env);
+        let issuer  = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let claim_type = String::from_str(&env, "KYC_PASSED");
+
+        client.initialize(&admin, &None);
+        client.register_issuer(&admin, &issuer);
+
+        let now: u64 = 10_000;
+
+        let id = match state {
+            AttestationState::Valid => {
+                // No expiration → always valid.
+                client.create_attestation(&issuer, &subject, &claim_type, &None, &None, &None)
+            }
+            AttestationState::Revoked => {
+                let id = client.create_attestation(&issuer, &subject, &claim_type, &None, &None, &None);
+                client.revoke_attestation(&issuer, &id, &None);
+                id
+            }
+            AttestationState::Expired => {
+                // Expiration in the past.
+                let exp = now - 1;
+                client.create_attestation(&issuer, &subject, &claim_type, &Some(exp), &None, &None)
+            }
+            AttestationState::Pending => {
+                // valid_from in the future.
+                let valid_from = now + 10_000;
+                client.create_attestation_valid_from(
+                    &issuer, &subject, &claim_type, &None, &Some(valid_from), &None,
+                )
+            }
+        };
+
+        let status = client.get_attestation_status(&id);
+        let has_valid = client.has_valid_claim(&subject, &claim_type);
+
+        // Invariant: has_valid_claim ↔ at least one Valid attestation exists.
+        let status_is_valid = status == trustlink::types::AttestationStatus::Valid;
+        prop_assert_eq!(
+            has_valid,
+            status_is_valid,
+            "has_valid_claim={has_valid} but status={status:?}"
+        );
+    }
+
+    /// Multiple attestations with mixed states: has_valid_claim is true iff
+    /// at least one has status Valid.
+    #[test]
+    fn prop_has_valid_claim_consistent_with_status_multi(
+        states in prop::collection::vec(attestation_state_strategy(), 1..5),
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 10_000);
+
+        let client = deploy(&env);
+        let admin   = Address::generate(&env);
+        let issuer  = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let claim_type = String::from_str(&env, "KYC_PASSED");
+
+        client.initialize(&admin, &None);
+        client.register_issuer(&admin, &issuer);
+
+        let now: u64 = 10_000;
+        let mut any_valid = false;
+
+        for state in &states {
+            // Advance time slightly so each attestation gets a unique ID.
+            env.ledger().with_mut(|l| l.timestamp += 1);
+            let ts = env.ledger().timestamp();
+
+            let id = match state {
+                AttestationState::Valid => {
+                    client.create_attestation(&issuer, &subject, &claim_type, &None, &None, &None)
+                }
+                AttestationState::Revoked => {
+                    let id = client.create_attestation(&issuer, &subject, &claim_type, &None, &None, &None);
+                    client.revoke_attestation(&issuer, &id, &None);
+                    id
+                }
+                AttestationState::Expired => {
+                    let exp = now - 1;
+                    client.create_attestation(&issuer, &subject, &claim_type, &Some(exp), &None, &None)
+                }
+                AttestationState::Pending => {
+                    let valid_from = ts + 10_000;
+                    client.create_attestation_valid_from(
+                        &issuer, &subject, &claim_type, &None, &Some(valid_from), &None,
+                    )
+                }
+            };
+
+            // Track whether this attestation is valid at query time.
+            let status = client.get_attestation_status(&id);
+            if status == trustlink::types::AttestationStatus::Valid {
+                any_valid = true;
+            }
+        }
+
+        // Reset to base time for the final query.
+        env.ledger().with_mut(|l| l.timestamp = 10_000);
+        let has_valid = client.has_valid_claim(&subject, &claim_type);
+
+        prop_assert_eq!(
+            has_valid,
+            any_valid,
+            "has_valid_claim={has_valid} but expected any_valid={any_valid} (states={states:?})"
+        );
+    }
+}

--- a/tests/snapshot_test.rs
+++ b/tests/snapshot_test.rs
@@ -272,3 +272,60 @@ fn snapshot_after_expiration_hook_triggered() {
     assert_eq!(hook.callback_contract, callback_contract);
     assert_eq!(hook.notify_days_before, 7);
 }
+
+// ── 11. Multisig proposal lifecycle ─────────────────────────────────────────
+
+/// Snapshot: contract state after a multisig proposal is proposed, cosigned to
+/// threshold, and the resulting attestation is activated.
+/// Captures: MultiSigProposal (finalized=true), Attestation record,
+/// SubjectAttestations index, GlobalStats.total_attestations,
+/// multisig_proposed / multisig_cosigned / multisig_activated events.
+#[test]
+fn snapshot_after_multisig_activation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let proposer = Address::generate(&env);
+    let cosigner = Address::generate(&env);
+    let subject = Address::generate(&env);
+    let claim_type = String::from_str(&env, "KYC_PASSED");
+
+    client.initialize(&admin, &None);
+    client.register_issuer(&admin, &proposer);
+    client.register_issuer(&admin, &cosigner);
+
+    // Build required_signers vec: proposer + cosigner, threshold = 2.
+    let mut required_signers = soroban_sdk::Vec::new(&env);
+    required_signers.push_back(proposer.clone());
+    required_signers.push_back(cosigner.clone());
+
+    let proposal_id = client.propose_attestation(
+        &proposer,
+        &subject,
+        &claim_type,
+        &required_signers,
+        &2,
+    );
+
+    // Proposal exists and is not yet finalized.
+    let proposal = client.get_multisig_proposal(&proposal_id);
+    assert!(!proposal.finalized);
+    assert_eq!(proposal.signers.len(), 1);
+
+    // Cosigner brings the signature count to threshold → activates.
+    client.cosign_attestation(&cosigner, &proposal_id);
+
+    // Proposal is now finalized.
+    let proposal = client.get_multisig_proposal(&proposal_id);
+    assert!(proposal.finalized);
+
+    // Attestation was created for the subject.
+    assert_eq!(client.get_subject_attestations(&subject, &0, &10).len(), 1);
+    assert_eq!(client.get_global_stats().total_attestations, 1);
+
+    // Subject holds a valid claim.
+    assert!(client.has_valid_claim(&subject, &claim_type));
+}


### PR DESCRIPTION
closes #506 
closes #507 
closes #508 
closes #509 
#506 — AuditAction::Deleted

Added Deleted variant to AuditAction enum in 
types.rs
request_deletion in 
attestation.rs
 now appends an AuditEntry { action: Deleted, actor: subject } after marking the attestation deleted
#507 — TypeScript SDK getAttestationsByJurisdiction

Added getAttestationsByJurisdiction(subject, jurisdiction, start, limit) to TrustLinkClient in 
client.ts
Documented it in 
README.md
 under Attestation Queries
Added a usage example in 
usage.ts
#508 — Snapshot test: multisig lifecycle

Added snapshot_after_multisig_activation to 
snapshot_test.rs
 — registers two issuers, proposes with threshold=2, cosigns to threshold, then asserts the proposal is finalized and the attestation is live
#509 — Property-based test: has_valid_claim consistency

Created 
claim_status_proptest.rs
 with two proptests: one for a single attestation across all four states (Valid/Revoked/Expired/Pending), and one for a random mix of 1–5 attestations — both assert has_valid_claim == (any status is Valid)