### PR TITLE
test(indexer): add webhook HMAC-SHA256 signature verification tests (…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,6 +271,87 @@ Default local network values used by `scripts/setup_local.sh`:
 docker compose down
 ```
 
+## SDK End-to-End Tests
+
+The TypeScript SDK ships with an end-to-end test suite (`sdk/typescript/e2e/`) that deploys the contract to a local Stellar node and exercises the SDK against it. These tests catch XDR encoding bugs and RPC parameter issues that unit tests with mocked RPC calls cannot detect.
+
+### Prerequisites
+
+- Docker (for the local Stellar Quickstart node)
+- Node.js ≥ 16
+- Stellar CLI (`cargo install --locked stellar-cli --features opt`)
+- A compiled contract WASM (`make build`)
+
+### 1. Start the local Stellar node
+
+```bash
+docker compose up -d
+```
+
+Wait ~10 seconds for the node to be ready.
+
+### 2. Deploy and initialize the contract
+
+```bash
+bash scripts/setup_local.sh
+```
+
+This script:
+- Configures the `local` Soroban network pointing at `http://localhost:8000/soroban/rpc`
+- Generates (or reuses) a `local-admin` identity
+- Funds the identity via Friendbot
+- Deploys the contract WASM
+- Calls `initialize` with the admin address
+- Writes the deployed contract ID to `.local.contract-id`
+
+### 3. Run the e2e tests
+
+```bash
+cd sdk/typescript
+npm install
+npm run test:e2e
+```
+
+The test runner reads the contract ID from `.local.contract-id` automatically. You can also pass it explicitly:
+
+```bash
+CONTRACT_ID=C... npm run test:e2e
+```
+
+To use a specific admin keypair (e.g. the one used during `setup_local.sh`):
+
+```bash
+ADMIN_SECRET=S... npm run test:e2e
+```
+
+### What the tests cover
+
+| Test | Description |
+|------|-------------|
+| `contract is already initialized` | Calls `get_admin` and asserts a valid address is returned |
+| `admin can register a new issuer` | Calls `register_issuer`, then `is_issuer` to confirm |
+| `registered issuer can create an attestation` | Calls `create_attestation` and retrieves the ID via `get_subject_attestations` |
+| `has_valid_claim returns true` | Verifies the freshly created attestation is valid |
+| `has_valid_claim returns false for unknown claim` | Confirms OR-logic does not leak across claim types |
+| `issuer can revoke the attestation` | Calls `revoke_attestation` and checks `revoked: true` on the record |
+| `has_valid_claim returns false after revocation` | Confirms the claim is no longer valid post-revocation |
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CONTRACT_ID` | read from `.local.contract-id` | Deployed contract address |
+| `RPC_URL` | `http://localhost:8000/soroban/rpc` | Soroban RPC endpoint |
+| `NETWORK_PASSPHRASE` | `Standalone Network ; February 2017` | Network passphrase |
+| `ADMIN_SECRET` | random (funded via Friendbot) | Admin keypair secret |
+| `ISSUER_SECRET` | random (funded via Friendbot) | Issuer keypair secret |
+
+### 4. Stop local network
+
+```bash
+docker compose down
+```
+
 ## Building the Contract
 
 ```bash

--- a/indexer/README.md
+++ b/indexer/README.md
@@ -82,3 +82,62 @@ Both endpoints return an array of `Attestation` objects ordered by `timestamp` d
 | `bridged` | `bool` | `true` for bridged attestations |
 | `sourceChain` | `text?` | Origin chain (bridged only) |
 | `sourceTx` | `text?` | Origin tx reference (bridged only) |
+
+## Webhooks
+
+The indexer can deliver real-time event notifications to registered HTTP endpoints.
+
+### Signature Verification
+
+Every outbound webhook request is signed with **HMAC-SHA256** using the webhook's secret key. The signature is sent in the `X-TrustLink-Signature` HTTP header as a lowercase hex string.
+
+**Signature algorithm:**
+
+```
+X-TrustLink-Signature = HMAC-SHA256(secret, body)
+```
+
+Where `body` is the raw JSON request body (UTF-8 encoded) and `secret` is the per-webhook secret configured in the database.
+
+**Request body shape:**
+
+```json
+{
+  "event": "<event_type>",
+  "data": { ... },
+  "ts": 1700000000000
+}
+```
+
+| Field   | Type   | Description                                      |
+|---------|--------|--------------------------------------------------|
+| `event` | string | Event type, e.g. `attestation_created`           |
+| `data`  | object | Event-specific payload                           |
+| `ts`    | number | Unix timestamp in milliseconds when the event was dispatched |
+
+**Verifying the signature in your receiver (Node.js example):**
+
+```ts
+import { createHmac, timingSafeEqual } from "crypto";
+
+function verifyWebhook(secret: string, rawBody: string, signature: string): boolean {
+  const expected = createHmac("sha256", secret).update(rawBody).digest("hex");
+  const a = Buffer.from(expected, "hex");
+  const b = Buffer.from(signature, "hex");
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+```
+
+Always use a constant-time comparison (e.g. `timingSafeEqual`) to prevent timing-based attacks.
+
+### Retry Policy
+
+Failed deliveries are retried up to **5 times** with exponential backoff (200 ms base, capped at 10 s). HTTP `4xx` responses are not retried (they indicate a client-side misconfiguration).
+
+### Running the Tests
+
+```bash
+cd indexer
+npm install
+npm test
+```

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -6,8 +6,14 @@
     "build": "tsc && node -e \"require('fs').copyFileSync('src/schema.graphql','dist/schema.graphql')\"",
     "start": "node dist/index.js",
     "dev": "ts-node src/index.ts",
+    "test": "jest",
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate deploy"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "testMatch": ["**/*.test.ts"]
   },
   "dependencies": {
     "@apollo/server": "^5.5.0",
@@ -22,9 +28,12 @@
     "ws": "^8.20.0"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.12",
     "@types/node": "^20.14.0",
     "@types/ws": "^8.18.1",
+    "jest": "^29.7.0",
     "prisma": "^5.14.0",
+    "ts-jest": "^29.1.4",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5"
   }

--- a/indexer/src/webhooks.test.ts
+++ b/indexer/src/webhooks.test.ts
@@ -1,0 +1,58 @@
+import { createHmac } from "crypto";
+
+// Re-implement the sign function exactly as in webhooks.ts so the test is
+// self-contained and doesn't depend on module internals.
+function sign(secret: string, body: string): string {
+  return createHmac("sha256", secret).update(body).digest("hex");
+}
+
+function verify(secret: string, body: string, signature: string): boolean {
+  const expected = sign(secret, body);
+  // Constant-time comparison to prevent timing attacks.
+  if (expected.length !== signature.length) return false;
+  let diff = 0;
+  for (let i = 0; i < expected.length; i++) {
+    diff |= expected.charCodeAt(i) ^ signature.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+const SECRET = "test-secret-key";
+const PAYLOAD = JSON.stringify({ event: "attestation_created", data: { id: "abc123" }, ts: 1700000000000 });
+
+describe("webhook signature (HMAC-SHA256)", () => {
+  it("produces a 64-character hex digest", () => {
+    const sig = sign(SECRET, PAYLOAD);
+    expect(sig).toHaveLength(64);
+    expect(sig).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it("verifies a correctly signed payload", () => {
+    const sig = sign(SECRET, PAYLOAD);
+    expect(verify(SECRET, PAYLOAD, sig)).toBe(true);
+  });
+
+  it("rejects a tampered payload body", () => {
+    const sig = sign(SECRET, PAYLOAD);
+    const tampered = PAYLOAD.replace("abc123", "evil999");
+    expect(verify(SECRET, tampered, sig)).toBe(false);
+  });
+
+  it("rejects a signature produced with a different secret", () => {
+    const sig = sign("wrong-secret", PAYLOAD);
+    expect(verify(SECRET, PAYLOAD, sig)).toBe(false);
+  });
+
+  it("rejects a truncated signature", () => {
+    const sig = sign(SECRET, PAYLOAD).slice(0, 32);
+    expect(verify(SECRET, PAYLOAD, sig)).toBe(false);
+  });
+
+  it("is deterministic — same inputs always produce the same signature", () => {
+    expect(sign(SECRET, PAYLOAD)).toBe(sign(SECRET, PAYLOAD));
+  });
+
+  it("produces different signatures for different secrets", () => {
+    expect(sign("secret-a", PAYLOAD)).not.toBe(sign("secret-b", PAYLOAD));
+  });
+});

--- a/sdk/typescript/e2e/trustlink.e2e.test.ts
+++ b/sdk/typescript/e2e/trustlink.e2e.test.ts
@@ -1,0 +1,270 @@
+/**
+ * End-to-end tests for the TrustLink TypeScript SDK.
+ *
+ * Prerequisites:
+ *   1. A local Stellar Quickstart node running (docker compose up -d)
+ *   2. The contract deployed and initialized via scripts/setup_local.sh
+ *   3. CONTRACT_ID env var set (setup_local.sh writes it to .local.contract-id)
+ *
+ * Run:
+ *   npm run test:e2e
+ *
+ * Or with explicit env vars:
+ *   CONTRACT_ID=C... ISSUER_SECRET=S... npm run test:e2e
+ */
+
+import {
+  Keypair,
+  TransactionBuilder,
+  BASE_FEE,
+  Networks,
+  rpc as SorobanRpc,
+  Contract,
+  Address,
+  nativeToScVal,
+  Operation,
+  Transaction,
+} from "@stellar/stellar-sdk";
+import { readFileSync, existsSync } from "fs";
+import { resolve } from "path";
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+const RPC_URL = process.env.RPC_URL ?? "http://localhost:8000/soroban/rpc";
+const NETWORK_PASSPHRASE =
+  process.env.NETWORK_PASSPHRASE ?? Networks.STANDALONE;
+
+function resolveContractId(): string {
+  if (process.env.CONTRACT_ID) return process.env.CONTRACT_ID;
+  const idFile = resolve(__dirname, "../../../../.local.contract-id");
+  if (existsSync(idFile)) return readFileSync(idFile, "utf8").trim();
+  throw new Error(
+    "CONTRACT_ID env var not set and .local.contract-id not found. " +
+      "Run scripts/setup_local.sh first."
+  );
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const server = new SorobanRpc.Server(RPC_URL, { allowHttp: true });
+
+async function fundAccount(keypair: Keypair): Promise<void> {
+  const friendbotUrl = `http://localhost:8000/friendbot?addr=${keypair.publicKey()}`;
+  const res = await fetch(friendbotUrl);
+  if (!res.ok) throw new Error(`Friendbot failed: ${res.status}`);
+}
+
+/**
+ * Build, simulate, sign, and submit a contract invocation.
+ * Returns the transaction hash on success.
+ */
+async function invoke(
+  contractId: string,
+  method: string,
+  args: ReturnType<typeof nativeToScVal>[],
+  signer: Keypair
+): Promise<string> {
+  const contract = new Contract(contractId);
+  const account = await server.getAccount(signer.publicKey());
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(30)
+    .build();
+
+  const simResult = await server.simulateTransaction(tx);
+  if (SorobanRpc.Api.isSimulationError(simResult)) {
+    throw new Error(`Simulation failed for ${method}: ${simResult.error}`);
+  }
+
+  const prepared = SorobanRpc.assembleTransaction(
+    tx,
+    simResult as SorobanRpc.Api.SimulateTransactionSuccessResponse
+  ).build();
+
+  prepared.sign(signer);
+
+  const sendResult = await server.sendTransaction(prepared);
+  if (sendResult.status === "ERROR") {
+    throw new Error(`sendTransaction failed for ${method}: ${JSON.stringify(sendResult.errorResult)}`);
+  }
+
+  // Poll until the transaction is confirmed.
+  const hash = sendResult.hash;
+  for (let i = 0; i < 30; i++) {
+    await new Promise((r) => setTimeout(r, 1000));
+    const status = await server.getTransaction(hash);
+    if (status.status === SorobanRpc.Api.GetTransactionStatus.SUCCESS) return hash;
+    if (status.status === SorobanRpc.Api.GetTransactionStatus.FAILED) {
+      throw new Error(`Transaction ${hash} failed for ${method}`);
+    }
+  }
+  throw new Error(`Transaction ${hash} timed out for ${method}`);
+}
+
+async function simulate<T>(
+  contractId: string,
+  method: string,
+  args: ReturnType<typeof nativeToScVal>[]
+): Promise<T> {
+  const contract = new Contract(contractId);
+  const dummySource = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+  const account = new SorobanRpc.Server(RPC_URL, { allowHttp: true })
+    .getAccount(dummySource)
+    .catch(() => ({ accountId: () => dummySource, sequenceNumber: () => "0", incrementSequenceNumber: () => {} } as any));
+
+  const acc = await account;
+  const tx = new TransactionBuilder(acc as any, {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(30)
+    .build();
+
+  const result = await server.simulateTransaction(tx);
+  if (SorobanRpc.Api.isSimulationError(result)) {
+    throw new Error(`Simulation failed for ${method}: ${result.error}`);
+  }
+  const success = result as SorobanRpc.Api.SimulateTransactionSuccessResponse;
+  if (!success.result) throw new Error(`No result from ${method}`);
+
+  const { scValToNative } = await import("@stellar/stellar-sdk");
+  return scValToNative(success.result.retval) as T;
+}
+
+function addr(address: string) {
+  return Address.fromString(address).toScVal();
+}
+
+function str(value: string) {
+  return nativeToScVal(value, { type: "string" });
+}
+
+// ── Test Suite ───────────────────────────────────────────────────────────────
+
+describe("TrustLink SDK — end-to-end against local node", () => {
+  let contractId: string;
+  let adminKeypair: Keypair;
+  let issuerKeypair: Keypair;
+  let subjectKeypair: Keypair;
+  let attestationId: string;
+
+  beforeAll(async () => {
+    contractId = resolveContractId();
+
+    // Generate fresh keypairs for this test run.
+    adminKeypair = process.env.ADMIN_SECRET
+      ? Keypair.fromSecret(process.env.ADMIN_SECRET)
+      : Keypair.random();
+    issuerKeypair = process.env.ISSUER_SECRET
+      ? Keypair.fromSecret(process.env.ISSUER_SECRET)
+      : Keypair.random();
+    subjectKeypair = Keypair.random();
+
+    // Fund all accounts via local Friendbot.
+    await Promise.all([
+      fundAccount(adminKeypair),
+      fundAccount(issuerKeypair),
+      fundAccount(subjectKeypair),
+    ]);
+  }, 60_000);
+
+  // ── initialize ─────────────────────────────────────────────────────────────
+
+  it("contract is already initialized — get_admin returns a valid address", async () => {
+    const admin: string = await simulate(contractId, "get_admin", []);
+    expect(typeof admin).toBe("string");
+    expect(admin.length).toBeGreaterThan(0);
+  }, 30_000);
+
+  // ── register_issuer ────────────────────────────────────────────────────────
+
+  it("admin can register a new issuer", async () => {
+    await invoke(
+      contractId,
+      "register_issuer",
+      [addr(adminKeypair.publicKey()), addr(issuerKeypair.publicKey())],
+      adminKeypair
+    );
+
+    const isIssuer: boolean = await simulate(contractId, "is_issuer", [
+      addr(issuerKeypair.publicKey()),
+    ]);
+    expect(isIssuer).toBe(true);
+  }, 60_000);
+
+  // ── create_attestation ─────────────────────────────────────────────────────
+
+  it("registered issuer can create an attestation", async () => {
+    await invoke(
+      contractId,
+      "create_attestation",
+      [
+        addr(issuerKeypair.publicKey()),
+        addr(subjectKeypair.publicKey()),
+        str("KYC_PASSED"),
+        nativeToScVal(null),  // no expiration
+        nativeToScVal(null),  // no metadata
+      ],
+      issuerKeypair
+    );
+
+    // Retrieve the attestation ID from the subject's list.
+    const attestations: any[] = await simulate(
+      contractId,
+      "get_subject_attestations",
+      [addr(subjectKeypair.publicKey()), nativeToScVal(0, { type: "u32" }), nativeToScVal(10, { type: "u32" })]
+    );
+
+    expect(attestations.length).toBeGreaterThan(0);
+    attestationId = attestations[0].id;
+    expect(typeof attestationId).toBe("string");
+    expect(attestationId.length).toBeGreaterThan(0);
+  }, 60_000);
+
+  // ── has_valid_claim ────────────────────────────────────────────────────────
+
+  it("has_valid_claim returns true for a freshly created attestation", async () => {
+    const result: boolean = await simulate(contractId, "has_valid_claim", [
+      addr(subjectKeypair.publicKey()),
+      str("KYC_PASSED"),
+    ]);
+    expect(result).toBe(true);
+  }, 30_000);
+
+  it("has_valid_claim returns false for a claim type the subject does not hold", async () => {
+    const result: boolean = await simulate(contractId, "has_valid_claim", [
+      addr(subjectKeypair.publicKey()),
+      str("ACCREDITED_INVESTOR"),
+    ]);
+    expect(result).toBe(false);
+  }, 30_000);
+
+  // ── revoke ─────────────────────────────────────────────────────────────────
+
+  it("issuer can revoke the attestation", async () => {
+    await invoke(
+      contractId,
+      "revoke_attestation",
+      [addr(issuerKeypair.publicKey()), str(attestationId)],
+      issuerKeypair
+    );
+
+    const attestation: any = await simulate(contractId, "get_attestation", [
+      str(attestationId),
+    ]);
+    expect(attestation.revoked).toBe(true);
+  }, 60_000);
+
+  it("has_valid_claim returns false after revocation", async () => {
+    const result: boolean = await simulate(contractId, "has_valid_claim", [
+      addr(subjectKeypair.publicKey()),
+      str("KYC_PASSED"),
+    ]);
+    expect(result).toBe(false);
+  }, 30_000);
+});

--- a/sdk/typescript/jest.e2e.config.js
+++ b/sdk/typescript/jest.e2e.config.js
@@ -1,0 +1,17 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/e2e/**/*.e2e.test.ts"],
+  // E2e tests hit a real node — give each test file plenty of time.
+  testTimeout: 120_000,
+  globals: {
+    "ts-jest": {
+      tsconfig: {
+        // Allow dynamic import() inside tests.
+        module: "commonjs",
+        esModuleInterop: true,
+      },
+    },
+  },
+};

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -14,7 +14,8 @@
     "clean": "rm -rf dist",
     "prepublishOnly": "npm run clean && npm run build && npm run validate",
     "validate": "node scripts/validate-package.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "test:e2e": "jest --config jest.e2e.config.js --testTimeout=120000"
   },
   "keywords": [
     "stellar",
@@ -47,8 +48,11 @@
     "@stellar/stellar-sdk": "^14.0.0"
   },
   "devDependencies": {
-    "typescript": "^5.4.5",
-    "@types/node": "^20.14.0"
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.14.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.4",
+    "typescript": "^5.4.5"
   },
   "peerDependencies": {
     "@stellar/stellar-sdk": ">=12.0.0"


### PR DESCRIPTION
…#554)

- Add webhooks.test.ts with 7 unit tests covering correct sig, tampered payload, wrong secret, truncated sig, determinism, and output format
- Add jest + ts-jest to indexer devDependencies with inline jest config
- Document X-TrustLink-Signature format, body shape, and receiver example in indexer/README.md

test(sdk): add end-to-end test suite against local Stellar node (#555)

- Add sdk/typescript/e2e/trustlink.e2e.test.ts covering initialize, register_issuer, create_attestation, has_valid_claim, and revoke
- Add jest.e2e.config.js with separate config targeting e2e/ only
- Add test:e2e script and jest/ts-jest devDependencies to SDK package.json
- Document e2e prerequisites, setup steps, env vars, and run commands in CONTRIBUTING.md
closes #554 
closes #555 