### PR TITLE
feat: add wallet disconnect button

### DIFF
--- a/examples/react-app/src/App.tsx
+++ b/examples/react-app/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { connectWallet, getWalletAddress } from "./wallet";
+import { connectWallet, getWalletAddress, disconnectWallet } from "./wallet";
 import AdminPanel from "./panels/AdminPanel";
 import IssuerPanel from "./panels/IssuerPanel";
 import UserPanel from "./panels/UserPanel";
@@ -31,6 +31,13 @@ export default function App() {
     } finally {
       setConnecting(false);
     }
+  }
+
+  async function handleDisconnect() {
+    await disconnectWallet();
+    setAddress(null);
+    setTab("user");
+    setError(null);
   }
 
   const short = address ? `${address.slice(0, 6)}…${address.slice(-4)}` : "";
@@ -69,7 +76,7 @@ export default function App() {
         <h1>TrustLink</h1>
         <div className="wallet-info">
           <span className="addr">{short}</span>
-          <button className="btn btn-outline" style={{ fontSize: "0.8rem", padding: "0.3rem 0.75rem" }} onClick={() => setAddress(null)}>
+          <button className="btn btn-outline" style={{ fontSize: "0.8rem", padding: "0.3rem 0.75rem" }} onClick={handleDisconnect}>
             Disconnect
           </button>
         </div>

--- a/examples/react-app/src/contract.ts
+++ b/examples/react-app/src/contract.ts
@@ -277,3 +277,16 @@ export async function getExpiringAttestations(
     nativeToScVal(50, { type: "u32" })
   );
 }
+
+export async function getIssuerAttestations(
+  issuer: string,
+  start: number,
+  limit: number
+): Promise<Attestation[]> {
+  return simulate(
+    "get_issuer_attestations",
+    addr(issuer),
+    nativeToScVal(start, { type: "u32" }),
+    nativeToScVal(limit, { type: "u32" })
+  );
+}

--- a/examples/react-app/src/wallet.ts
+++ b/examples/react-app/src/wallet.ts
@@ -16,19 +16,29 @@ export async function connectWallet(): Promise<string> {
   }
   const result = await getAddress();
   if (result.error) throw new Error(result.error.message);
+  localStorage.setItem("wallet_address", result.address);
   return result.address;
 }
 
 export async function getWalletAddress(): Promise<string | null> {
+  const stored = localStorage.getItem("wallet_address");
+  if (!stored) return null;
   try {
     const connected = await isConnected();
     if (!connected) return null;
     const result = await getAddress();
     if (result.error) return null;
+    if (result.address !== stored) {
+      localStorage.setItem("wallet_address", result.address);
+    }
     return result.address;
   } catch {
     return null;
   }
+}
+
+export async function disconnectWallet(): Promise<void> {
+  localStorage.removeItem("wallet_address");
 }
 
 export async function sign(xdr: string, network: string): Promise<string> {


### PR DESCRIPTION
Closes #563

---


#563 

Summary of Changes
Wallet State Management & Persistent Tracking (

wallet.ts
):

Implemented disconnectWallet() which removes "wallet_address" from localStorage.
Updated connectWallet() to store the wallet address in localStorage once connected.
Modified getWalletAddress() (used for auto-reconnection) to first check localStorage for the connected address. If it's not found (indicating the user has explicitly disconnected), it returns null instead of automatically reconnecting.
UI & State Reset (

App.tsx
):

Imported disconnectWallet from ./wallet.
Implemented handleDisconnect() to clear the local address state, reset the tab selection back to "user", and clear any pending wallet errors.
Connected the "Disconnect" button in the header component to trigger handleDisconnect().
Compiler Build Resolution (

contract.ts
):

Added the missing getIssuerAttestations export to resolve a pre-existing TypeScript build blocker in IssuerDashboard.tsx (which imports it).