### PR TITLE
feat(react-app): add expiring attestations section with renewal to Is…

### DIFF
--- a/examples/react-app/src/contract.ts
+++ b/examples/react-app/src/contract.ts
@@ -265,6 +265,20 @@ export async function getIssuerStats(issuer: string): Promise<IssuerStats> {
   return simulate("get_issuer_stats", addr(issuer));
 }
 
+export async function getIssuerAttestations(
+  issuer: string,
+  start: number,
+  limit: number
+): Promise<Attestation[]> {
+  const ids: string[] = await simulate(
+    "get_issuer_attestations",
+    addr(issuer),
+    nativeToScVal(start, { type: "u32" }),
+    nativeToScVal(limit, { type: "u32" })
+  );
+  return Promise.all(ids.map((id) => simulate<Attestation>("get_attestation", str(id))));
+}
+
 export async function getExpiringAttestations(
   issuer: string,
   daysWindow: number
@@ -275,5 +289,19 @@ export async function getExpiringAttestations(
     nativeToScVal(daysWindow, { type: "u32" }),
     nativeToScVal(0, { type: "u32" }),
     nativeToScVal(50, { type: "u32" })
+  );
+}
+
+export async function renewAttestation(
+  issuer: string,
+  attestationId: string,
+  newExpiration: bigint | null
+): Promise<void> {
+  return invoke(
+    issuer,
+    "renew_attestation",
+    addr(issuer),
+    str(attestationId),
+    optU64(newExpiration)
   );
 }

--- a/examples/react-app/src/panels/IssuerDashboard.tsx
+++ b/examples/react-app/src/panels/IssuerDashboard.tsx
@@ -3,6 +3,7 @@ import {
   getIssuerStats,
   getIssuerAttestations,
   getExpiringAttestations,
+  renewAttestation,
   Attestation,
   IssuerStats,
 } from "../contract";
@@ -15,6 +16,7 @@ export default function IssuerDashboard({ address }: Props) {
   const [expiring, setExpiring] = useState<Attestation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [renewing, setRenewing] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     loadDashboard();
@@ -36,6 +38,24 @@ export default function IssuerDashboard({ address }: Props) {
       setError((err as Error).message);
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function handleRenew(attestationId: string, currentExpiration: bigint) {
+    setRenewing((prev) => new Set(prev).add(attestationId));
+    try {
+      const oneYear = BigInt(365 * 24 * 60 * 60);
+      const newExpiration = currentExpiration + oneYear;
+      await renewAttestation(address, attestationId, newExpiration);
+      await loadDashboard();
+    } catch (err: unknown) {
+      alert(`Failed to renew: ${(err as Error).message}`);
+    } finally {
+      setRenewing((prev) => {
+        const next = new Set(prev);
+        next.delete(attestationId);
+        return next;
+      });
     }
   }
 
@@ -143,6 +163,14 @@ export default function IssuerDashboard({ address }: Props) {
                       (Number(a.expiration || 0) - Math.floor(Date.now() / 1000)) / 86400
                     )}
                   </span>
+                  <button
+                    className="btn btn-primary"
+                    style={{ marginTop: "0.5rem", width: "100%" }}
+                    onClick={() => handleRenew(a.id, a.expiration!)}
+                    disabled={renewing.has(a.id)}
+                  >
+                    {renewing.has(a.id) ? "Renewing..." : "Renew"}
+                  </button>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
…suerDashboard

- Add getIssuerAttestations and renewAttestation functions to contract.ts
- Display expiring attestations with subject, claim type, and days until expiry
- Add Renew button that extends expiration by 1 year
- Show loading state during renewal and auto-refresh on success

Closes #562