### PR TITLE
feat(sdk): ResilienceConfig, pagination docs, npm provenance, TypeDoc — closes #534 #535 #536 #537

### DIFF
--- a/.github/workflows/docs-sdk.yml
+++ b/.github/workflows/docs-sdk.yml
@@ -1,0 +1,53 @@
+name: Publish SDK Docs to GitHub Pages
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build-docs:
+    name: Generate TypeDoc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: sdk/typescript/package-lock.json
+
+      - name: Install dependencies
+        working-directory: sdk/typescript
+        run: npm ci
+
+      - name: Generate docs
+        working-directory: sdk/typescript
+        run: npm run docs
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: sdk/typescript/docs/api
+
+  deploy-docs:
+    name: Deploy to GitHub Pages
+    needs: build-docs
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -11,6 +11,8 @@ TypeScript SDK for the [TrustLink](https://github.com/afurious/TrustLink) on-cha
 npm install @trustlink/sdk @stellar/stellar-sdk
 ```
 
+The package is published to npm as [`@trustlink/sdk`](https://www.npmjs.com/package/@trustlink/sdk) with npm provenance attestation enabled.
+
 **Requirements:**
 - Node.js 16.0.0 or higher
 - @stellar/stellar-sdk 12.0.0 or higher
@@ -133,6 +135,15 @@ how many attestations are fetched per RPC call:
 for await (const a of client.iterateSubjectAttestations(subject, 50)) {
   // fetches 50 at a time
 }
+```
+
+Iteration stops as soon as a page returns fewer items than `pageSize` (not only
+when it returns zero). This means the generator handles mid-iteration deletions
+gracefully — it will not hang waiting for a page that will never be full.
+
+```typescript
+// iterateSubjectAttestations(subject: string, pageSize?: number): AsyncGenerator<Attestation>
+// iterateIssuerAttestations(issuer: string, pageSize?: number): AsyncGenerator<Attestation>
 ```
 
 ### Count Queries

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -14,7 +14,8 @@
     "clean": "rm -rf dist",
     "prepublishOnly": "npm run clean && npm run build && npm run validate",
     "validate": "node scripts/validate-package.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "docs": "typedoc --out docs/api src/index.ts"
   },
   "keywords": [
     "stellar",
@@ -38,7 +39,8 @@
     "url": "https://github.com/afurious/TrustLink/issues"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "engines": {
     "node": ">=16.0.0"
@@ -48,7 +50,8 @@
   },
   "devDependencies": {
     "typescript": "^5.4.5",
-    "@types/node": "^20.14.0"
+    "@types/node": "^20.14.0",
+    "typedoc": "^0.26.0"
   },
   "peerDependencies": {
     "@stellar/stellar-sdk": ">=12.0.0"

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -78,8 +78,14 @@ export class TrustLinkClient {
 
     this.server = new SorobanRpc.Server(this.rpcUrl, { allowHttp: true });
     this.contract = new Contract(contractId);
-    this.retryOptions = options.retry ?? {};
-    this.breaker = new CircuitBreaker(options.circuitBreaker ?? {});
+    const res = options.resilience ?? {};
+    this.retryOptions = options.retry ?? {
+      maxAttempts: res.maxRetries,
+      initialDelayMs: res.backoffMs,
+    };
+    this.breaker = new CircuitBreaker(options.circuitBreaker ?? {
+      failureThreshold: res.circuitBreakerThreshold,
+    });
   }
 
   // ── Helpers ────────────────────────────────────────────────────────────────

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,4 +1,4 @@
 export { TrustLinkClient } from "./client";
 export * from "./types";
 export { CircuitBreaker, withRetry } from "./resilience";
-export type { RetryOptions, CircuitBreakerOptions } from "./resilience";
+export type { RetryOptions, CircuitBreakerOptions, ResilienceConfig } from "./resilience";

--- a/sdk/typescript/src/resilience.ts
+++ b/sdk/typescript/src/resilience.ts
@@ -2,6 +2,16 @@
  * Resilience utilities: exponential backoff retry and circuit breaker.
  */
 
+/** Simplified resilience config accepted by TrustLinkClient constructor. */
+export interface ResilienceConfig {
+  /** Maximum number of retry attempts (default: 3) */
+  maxRetries?: number;
+  /** Initial backoff delay in ms (default: 200) */
+  backoffMs?: number;
+  /** Failure count before opening the circuit breaker (default: 5) */
+  circuitBreakerThreshold?: number;
+}
+
 export interface RetryOptions {
   /** Maximum number of attempts (default: 3) */
   maxAttempts?: number;

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -295,4 +295,6 @@ export interface TrustLinkClientOptions {
   retry?: import("./resilience").RetryOptions;
   /** Optional: circuit breaker configuration. */
   circuitBreaker?: import("./resilience").CircuitBreakerOptions;
+  /** Optional: simplified resilience config (maxRetries, backoffMs, circuitBreakerThreshold). */
+  resilience?: import("./resilience").ResilienceConfig;
 }

--- a/sdk/typescript/typedoc.json
+++ b/sdk/typescript/typedoc.json
@@ -1,0 +1,10 @@
+{
+  "entryPoints": ["src/index.ts"],
+  "out": "docs/api",
+  "name": "@trustlink/sdk",
+  "includeVersion": true,
+  "readme": "README.md",
+  "excludePrivate": true,
+  "excludeProtected": true,
+  "plugin": []
+}


### PR DESCRIPTION
## Summary

- **#534** — Add `ResilienceConfig` interface (`maxRetries`, `backoffMs`, `circuitBreakerThreshold`) to `resilience.ts`; `TrustLinkClient` constructor now accepts `resilience?` option alongside the existing `retry`/`circuitBreaker` options and maps the simplified fields through. Export `ResilienceConfig` from package index.
- **#535** — Document `iterateSubjectAttestations` / `iterateIssuerAttestations` stopping condition in `README.md`: iteration ends when a page returns fewer items than `pageSize`, handling mid-iteration deletions gracefully.
- **#536** — Add `"provenance": true` to `publishConfig` in `package.json` to enable npm provenance attestation on publish; add npm badge note in README.
- **#537** — Add `typedoc` as a dev dependency, `npm run docs` script, `typedoc.json` config, and a `docs-sdk.yml` GitHub Actions workflow that generates and deploys API docs to GitHub Pages on every release.

## Test plan
- [ ] `npm run build` passes in `sdk/typescript`
- [ ] `npm run docs` generates `docs/api/` locally
- [ ] Constructor accepts `resilience: { maxRetries: 5, backoffMs: 100, circuitBreakerThreshold: 3 }` without TypeScript errors
- [ ] `docs-sdk.yml` workflow runs on release and deploys to GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #534
Closes #535
Closes #536
Closes #537