### PR TITLE
fix(react-app): add error boundaries to prevent full app unmount

### DIFF
--- a/examples/react-app/src/App.tsx
+++ b/examples/react-app/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { connectWallet, getWalletAddress } from "./wallet";
+import { ErrorBoundary } from "./ErrorBoundary";
 import AdminPanel from "./panels/AdminPanel";
 import IssuerPanel from "./panels/IssuerPanel";
 import UserPanel from "./panels/UserPanel";
@@ -83,12 +84,12 @@ export default function App() {
         ))}
       </nav>
 
-      {tab === "user" && <UserPanel address={address} />}
-      {tab === "requests" && <AttestationRequestPanel address={address} />}
-      {tab === "multisig" && <MultiSigPanel address={address} />}
-      {tab === "issuer" && <IssuerPanel address={address} />}
-      {tab === "verifier" && <VerifierPanel />}
-      {tab === "admin" && <AdminPanel address={address} />}
+      {tab === "user" && <ErrorBoundary><UserPanel address={address} /></ErrorBoundary>}
+      {tab === "requests" && <ErrorBoundary><AttestationRequestPanel address={address} /></ErrorBoundary>}
+      {tab === "multisig" && <ErrorBoundary><MultiSigPanel address={address} /></ErrorBoundary>}
+      {tab === "issuer" && <ErrorBoundary><IssuerPanel address={address} /></ErrorBoundary>}
+      {tab === "verifier" && <ErrorBoundary><VerifierPanel /></ErrorBoundary>}
+      {tab === "admin" && <ErrorBoundary><AdminPanel address={address} /></ErrorBoundary>}
     </>
   );
 }

--- a/examples/react-app/src/ErrorBoundary.tsx
+++ b/examples/react-app/src/ErrorBoundary.tsx
@@ -1,0 +1,44 @@
+import { Component, ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+      return (
+        <div className="error-boundary">
+          <h3>Something went wrong</h3>
+          <p>{this.state.error?.message || "An unexpected error occurred"}</p>
+          <button className="btn btn-primary" onClick={this.handleRetry}>
+            Try Again
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/examples/react-app/src/index.css
+++ b/examples/react-app/src/index.css
@@ -141,3 +141,18 @@ body {
 .connect-screen p { color: #64748b; max-width: 360px; }
 
 .empty { color: #64748b; font-size: 0.875rem; padding: 1rem 0; }
+/* Error Boundary */
+.error-boundary {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 2rem;
+  text-align: center;
+  background: #1a1d27;
+  border: 1px solid #7f1d1d;
+  border-radius: 0.75rem;
+  margin: 1rem;
+}
+.error-boundary h3 { color: #fca5a5; font-size: 1.1rem; margin-bottom: 0.5rem; }
+.error-boundary p { color: #94a3b8; font-size: 0.9rem; margin-bottom: 1rem; }

--- a/examples/react-app/src/main.tsx
+++ b/examples/react-app/src/main.tsx
@@ -3,8 +3,12 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
 
+import { ErrorBoundary } from "./ErrorBoundary";
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>
 );


### PR DESCRIPTION
Closes #560

---

Adds ErrorBoundary component to catch render errors in panels, preventing the entire app from unmounting on panel failures.