### PR TITLE
docs: add pull request template and update CONTRIBUTING.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+## Summary of Changes
+
+<!-- Describe what this PR does and why. Link to the relevant issue(s). -->
+
+Closes #
+
+## Type of Change
+
+<!-- Mark the applicable type with an "x". -->
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] Refactor (no functional change)
+- [ ] Other (describe):
+
+## Testing Done
+
+<!-- Describe the tests you ran and how to reproduce them. -->
+
+- [ ] `cargo test` passes locally
+- [ ] New tests added for this change (if applicable)
+
+## Checklist
+
+- [ ] All tests pass (`cargo test`)
+- [ ] Code is formatted (`cargo fmt -- --check`)
+- [ ] No Clippy warnings (`cargo clippy --all-targets -- -D warnings`)
+- [ ] Commit messages follow [Conventional Commits](../CONTRIBUTING.md#commit-message-conventions)
+- [ ] Documentation updated (if behaviour changed)
+- [ ] No secrets, tokens, or credentials committed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -535,9 +535,11 @@ When you merge commits to `main`:
    - [ ] `cargo clippy --all-targets -- -D warnings` is clean
    - [ ] Commit messages follow Conventional Commits format
 
-4. **Open a PR** against `main`. Include:
+4. **Open a PR** against `main` using the [pull request template](.github/PULL_REQUEST_TEMPLATE.md). GitHub loads it automatically when you open a PR. Fill in:
 
    - What the change does and why
+   - The type of change (bug fix / feature / docs / refactor)
+   - Testing done
    - Any relevant issue numbers (`Closes #123`)
    - Notes for reviewers if the change is non-obvious
 


### PR DESCRIPTION
## Summary of Changes

Adds `.github/PULL_REQUEST_TEMPLATE.md` so that every new PR is pre-populated with a consistent structure, and updates `CONTRIBUTING.md` to reference the template in the PR Process section.

Closes #598

## Type of Change

- [x] Documentation update

## Testing Done

- Template renders correctly when opening a new PR on GitHub (no code changes to unit-test).

## Checklist

- [x] All tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt -- --check`)
- [x] No Clippy warnings
- [x] Commit messages follow Conventional Commits
- [x] Documentation updated
- [x] No secrets, tokens, or credentials committed