### PR TITLE
feat: add ADR-008, ADR-009 and expand compliance.md for rate limiting, delegation, rectification, and data retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -1031,6 +1031,9 @@ Key design choices are documented as ADRs in [docs/adr/](docs/adr/):
 | [ADR-002](docs/adr/ADR-002-persistent-storage.md) | Persistent storage instead of temporary storage  |
 | [ADR-003](docs/adr/ADR-003-immutable-history.md)  | Immutable attestation history (no delete)        |
 | [ADR-004](docs/adr/ADR-004-dual-indexes.md)       | Separate issuer and subject indexes              |
+| [ADR-007](docs/adr/ADR-007-attestation-requests.md) | Pull-based attestation request workflow        |
+| [ADR-008](docs/adr/ADR-008-rate-limiting.md)      | Rate limiting design and known limitations       |
+| [ADR-009](docs/adr/ADR-009-delegation-model.md)   | Delegation model and trust chain implications    |
 
 A blank [template](docs/adr/ADR-000-template.md) is available for new decisions.
 

--- a/docs/adr/ADR-008-rate-limiting.md
+++ b/docs/adr/ADR-008-rate-limiting.md
@@ -1,0 +1,115 @@
+# ADR-008: Rate Limiting Design — Per-Issuer Last-Issuance Timestamp
+
+- **Status**: Accepted
+- **Date**: 2026-05-29
+
+## Context
+
+TrustLink needs to protect against high-frequency attestation spam from a single
+issuer. Without rate limiting, a registered issuer could flood the contract with
+thousands of attestations per ledger close, exhausting storage quotas and
+degrading availability for other issuers.
+
+The rate limiting mechanism must satisfy three constraints:
+
+1. **On-chain enforceability** — The limit must be checked and enforced inside
+   the contract without relying on off-chain intermediaries.
+2. **Low storage overhead** — Each registered issuer should require at most one
+   additional storage entry for rate limit state.
+3. **Configurable by the admin** — The admin must be able to set a global default
+   and per-claim-type overrides without a contract upgrade.
+
+## Decision
+
+### Chosen approach: per-issuer last-issuance timestamp
+
+The contract stores a single `LastIssuanceTime(Address)` entry per issuer in
+persistent storage. On every attestation creation call, `check_rate_limit`
+compares the current ledger timestamp against this stored value:
+
+```rust
+if current_time.saturating_sub(last) < interval {
+    return Err(Error::RateLimited);
+}
+```
+
+After a successful issuance, `set_last_issuance_time` overwrites the stored
+value with the current timestamp.
+
+The effective interval is resolved in this priority order:
+
+1. Per-claim-type override (`set_rate_limit_for_claim_type(admin, claim_type, interval_secs)`)
+2. Global default (`set_rate_limit(admin, min_issuance_interval)`)
+3. No limit (if neither is configured)
+
+An interval of `0` disables the rate limit entirely for that claim type.
+
+### Why not token bucket?
+
+A token bucket allows bursting up to a configured capacity and then refills at
+a fixed rate. While more expressive, it requires storing both a token count and
+a last-refill timestamp per issuer, doubling the storage reads and writes per
+attestation. Token buckets also introduce parameter complexity (capacity,
+refill rate) that is difficult to reason about in a governance context. Given
+that the primary concern is sustained spam rather than short bursts from
+legitimate issuers, a simple interval check is sufficient.
+
+### Why not sliding window?
+
+A sliding window counter tracks the number of issuances within a rolling time
+window, enabling accurate rate enforcement regardless of where in the window
+issuances cluster. However, it requires storing a sorted list of recent
+timestamps per issuer, which is expensive on Soroban where every storage entry
+has a per-byte cost. For TrustLink's use case — preventing sustained abuse
+rather than enforcing precise throughput — the simpler interval approach is
+preferred.
+
+### Why not per (issuer, claim_type) timestamps?
+
+Tracking a separate last-issuance timestamp for each `(issuer, claim_type)`
+pair would allow independent rate limiting for each claim type. The cost is
+O(claim types) storage entries per issuer. Given that per-claim-type rate
+limits are already the exception rather than the rule, a single shared timer
+per issuer is a reasonable simplification for the common case.
+
+## Consequences
+
+### Positive
+
+- One storage entry per issuer — minimal overhead.
+- Straightforward to reason about: one ledger call per interval, no complex
+  state machine.
+- Per-claim-type overrides allow fine-grained control for high-value or
+  high-risk claim types without altering the global policy.
+- `RateLimited` errors are deterministic and auditable on-chain.
+
+### Negative
+
+- **Shared timer across claim types**: The `LastIssuanceTime(Address)` key is
+  keyed on issuer address alone. Issuing any claim type resets the timer for
+  all claim types. An issuer with two claim types that legitimately require
+  independent high-frequency issuance may be inadvertently throttled.
+- **Delegates bypass rate limiting**: `create_attestation_as_delegate` does not
+  call `check_rate_limit` and does not update `LastIssuanceTime`. A delegate
+  key can therefore issue attestations on behalf of the delegating issuer at an
+  unconstrained rate. Operators who rely on rate limiting for spam prevention
+  should apply off-chain controls on delegate key distribution.
+- **Batch issuance counts as one**: `create_attestations_batch` applies a
+  single `check_rate_limit` call and a single `set_last_issuance_time` update
+  regardless of the number of subjects in the batch. An issuer can issue N
+  attestations in one call after waiting one interval, effectively achieving
+  burst throughput of N per interval.
+- **Ledger timestamp granularity**: The Soroban ledger timestamp advances in
+  approximately 5-second increments. Rate limit intervals shorter than ~10
+  seconds may not behave as configured due to timestamp resolution.
+- **No cross-issuer coordination**: Each issuer's timer is independent. If an
+  issuer operates multiple registered addresses, the combined issuance rate is
+  a multiple of the configured per-issuer limit.
+
+### Neutral
+
+- Rate limit configuration is stored separately from issuer registration; an
+  issuer can be registered without any rate limit in effect.
+- The rate limit applies to `create_attestation` and `create_attestations_batch`
+  but not to multi-sig proposal creation (`propose_attestation`) — the proposal
+  workflow has its own TTL-based throttle via the 7-day expiry window.

--- a/docs/adr/ADR-009-delegation-model.md
+++ b/docs/adr/ADR-009-delegation-model.md
@@ -1,0 +1,166 @@
+# ADR-009: Delegation Model and Trust Chain Implications
+
+- **Status**: Accepted
+- **Date**: 2026-05-29
+
+## Context
+
+TrustLink's initial design assumed that only directly registered issuers would
+create attestations. In practice, enterprise deployments require a hub-and-spoke
+model: a single trusted issuer (the root) wants to authorise subsidiary
+agents — KYC vendors, branch offices, automated services — to issue a specific
+subset of claim types on its behalf.
+
+Without a delegation mechanism, every authorised agent must be independently
+registered as a root issuer, granting it unbounded authority to issue any claim
+type. This creates two problems:
+
+1. **Overpermissioning** — a subsidiary that only handles `KYC_PASSED` checks
+   gains the same authority as the root issuer over all claim types.
+2. **Attribution loss** — attestations appear to come from a vendor address
+   rather than the root issuer address, breaking relying-party trust policies
+   that are keyed on the root issuer.
+
+## Decision
+
+### Delegation mechanism
+
+The admin grants an issuer the ability to call `delegate_claim_type`:
+
+```rust
+delegate_claim_type(issuer, delegate, claim_type, expiration: Option<u64>)
+```
+
+This stores a `Delegation` record keyed on `(delegator, delegate, claim_type)`:
+
+```rust
+pub struct Delegation {
+    pub delegator: Address,
+    pub delegate: Address,
+    pub claim_type: String,
+    pub expiration: Option<u64>,
+}
+```
+
+Delegations are **per-claim-type**: a delegate authorised for `KYC_PASSED`
+cannot issue `AML_CLEARED` on the delegator's behalf without a separate
+delegation record.
+
+The delegate invokes:
+
+```rust
+create_attestation_as_delegate(delegate, delegator, subject, claim_type, ...)
+```
+
+The contract verifies the delegation record exists and has not expired before
+proceeding. The resulting attestation is stored with `issuer = delegator`,
+making the attestation indistinguishable from one the delegator issued
+directly. The `actor` field in the audit log is set to the delegate address,
+preserving a complete audit trail.
+
+### Trust chain model
+
+```
+Admin
+  └─ registers Issuer A  (root issuer)
+         └─ delegates claim_type=KYC_PASSED to Agent X
+                └─ Agent X creates attestations for subjects
+                       └─ attestation.issuer = Issuer A
+                          attestation.audit_actor = Agent X
+```
+
+Relying parties that trust Issuer A therefore implicitly trust every
+attestation created by any current or past delegate of Issuer A for the
+delegated claim type.
+
+### Revocation
+
+An issuer may revoke a delegation at any time:
+
+```rust
+revoke_delegation(issuer, delegate, claim_type)
+```
+
+Revocation removes the delegation record immediately. Delegate calls after
+revocation return `Error::Unauthorized`. Existing attestations previously
+created by the delegate are not affected — they remain valid under the
+delegator's identity unless separately revoked.
+
+### Why not a capability token model?
+
+An alternative design would issue the delegate a capability token (an NFT or
+signed capability struct) that the contract verifies on each call. This avoids
+a storage entry per delegation but requires the delegate to present the token
+on every call, which complicates key rotation and token revocation — a revoked
+token must be tracked on-chain anyway, negating the storage advantage. The
+storage-keyed model chosen here is simpler and allows instant revocation without
+a token blocklist.
+
+### Why not inherit the delegator's rate limit?
+
+`create_attestation_as_delegate` does not call `check_rate_limit` and does not
+update `LastIssuanceTime`. See ADR-008 for the rate limiting design. The
+interaction between delegation and rate limiting is a known gap: operators who
+need rate limiting on delegate paths must enforce this off-chain or at the
+delegate key management layer.
+
+## Consequences
+
+### Positive
+
+- Claim-type-scoped authority limits blast radius: a compromised delegate key
+  can only issue the specific claim types it was delegated.
+- Attestations retain the root issuer identity, preserving relying-party trust
+  policies without modification.
+- The audit log records the actual actor (delegate address), enabling forensic
+  attribution of every attestation to the specific key that created it.
+- Optional expiration on delegations supports time-bounded vendor contracts
+  without requiring explicit revocation.
+- Delegations are revocable immediately, with no grace period.
+
+### Negative
+
+- **Compromised delegate = compromised issuer for delegated claim types**: A
+  delegate key that is stolen or misused can issue arbitrary attestations of
+  the delegated claim type under the trusted root issuer's identity. Relying
+  parties cannot distinguish a legitimate attestation from a fraudulent one
+  issued by a compromised delegate.
+- **No rate limiting on delegate path**: Delegates bypass the per-issuer rate
+  limit (see ADR-008). A compromised or malicious delegate can issue at
+  unrestricted volume.
+- **Revocation does not invalidate past attestations**: Revoking a delegation
+  prevents future issuance but does not revoke attestations already created by
+  the delegate. Operators must separately audit and revoke individual
+  attestations if delegate compromise is suspected.
+- **No multi-level delegation**: A delegate cannot further sub-delegate. The
+  `create_attestation_as_delegate` function verifies that `delegator` is a
+  registered issuer but does not support chained delegation. Attempts to build
+  deeper delegation chains require root-issuer involvement for each level.
+- **Attribution is in the audit log, not the attestation**: The attestation
+  struct records `issuer = delegator`. The delegate's identity is only
+  recoverable from the audit log. Off-chain systems that do not index audit
+  entries will see all delegated attestations as if directly issued by the root.
+
+### Neutral
+
+- Delegation records are stored in persistent Soroban storage with the same
+  TTL extension logic as attestations; they will not be archived while active.
+- `list_delegations_by_delegator` returns only non-expired delegations; expired
+  records remain in storage until TTL-based archival.
+- The `DelegationCreated` and `DelegationRevoked` events enable off-chain
+  indexers to maintain an up-to-date delegation graph.
+
+## Recommended Mitigations for Operators
+
+1. **Minimise delegate key lifetime** — prefer short-lived delegations with an
+   explicit `expiration` rather than indefinite authority.
+2. **Rotate delegate keys frequently** — treat delegate keys as operational
+   credentials, not long-lived secrets.
+3. **Monitor `DelegationCreated` events** — flag unexpected new delegations as
+   a potential indicator of account compromise at the root issuer level.
+4. **Audit after suspected compromise** — if a delegate key is compromised,
+   query the audit log for all attestations where `actor = delegate_address`
+   and revoke any that cannot be verified as legitimate.
+5. **Apply off-chain rate limiting** — because the contract does not rate-limit
+   delegate issuance, deploy an off-chain proxy or key-management service that
+   enforces per-delegate issuance quotas.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,6 +13,8 @@ the trade-offs accepted as a result.
 | [ADR-003](ADR-003-immutable-history.md) | Immutable attestation history (no delete) | Accepted |
 | [ADR-004](ADR-004-dual-indexes.md) | Separate issuer and subject indexes | Accepted |
 | [ADR-007](ADR-007-attestation-requests.md) | Pull-based attestation request workflow (subject-initiated, 7-day TTL, optional rejection reason) | Accepted |
+| [ADR-008](ADR-008-rate-limiting.md) | Rate limiting design — per-issuer last-issuance timestamp, known limitations | Accepted |
+| [ADR-009](ADR-009-delegation-model.md) | Delegation model and trust chain implications | Accepted |
 
 ## Template
 

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -62,6 +62,77 @@ topics: ["del_req", subject_address]
 data:   (attestation_id, timestamp)
 ```
 
+## Right to Rectification — GDPR Article 16
+
+GDPR Article 16 grants data subjects the right to have inaccurate personal data
+corrected. TrustLink attestations are immutable by design (see
+[ADR-003](adr/ADR-003-immutable-history.md)): once an attestation is written to
+the ledger it cannot be edited in place. Rectification is therefore achieved
+through a **revoke-and-reissue** workflow.
+
+### Why immutability applies here
+
+An attestation record is a verifiable claim made by an issuer at a point in
+time. Allowing silent in-place edits would undermine the non-repudiation
+property that makes attestations trustworthy. The historical record of what was
+claimed, and when, must remain intact. Rectification replaces the incorrect
+claim with a new, correct one while preserving the full audit trail.
+
+### Recommended revoke-and-reissue workflow
+
+When a subject requests correction of inaccurate attestation metadata or claim
+data, the operator should follow these steps:
+
+1. **Validate the rectification request** — confirm the subject's identity and
+   document the nature of the inaccuracy and the corrected data.
+
+2. **Revoke the incorrect attestation**:
+   ```rust
+   contract.revoke_attestation(&issuer, &attestation_id, Some("Rectification: data corrected on subject request"));
+   ```
+   This sets `revoked: true` on the record and emits a `RevocationEvent`, which
+   off-chain systems must honour. The revocation reason should reference the
+   rectification request for audit purposes.
+
+3. **Issue a corrected attestation**:
+   ```rust
+   contract.create_attestation(&issuer, &subject, &claim_type, expiration, Some(corrected_metadata));
+   ```
+   The new attestation receives a new deterministic ID and timestamp.
+
+4. **Notify the subject** — provide the new attestation ID so relying parties
+   the subject interacts with can update their records.
+
+5. **Update off-chain indexes** — any indexer or dApp that cached the original
+   attestation must subscribe to `RevocationEvent` (`topics[0] == "revoke"`) and
+   replace cached records with the new attestation.
+
+### Limitations
+
+- **Historical ledger data**: The original (incorrect) attestation record
+  remains visible in Soroban ledger history to anyone who already holds the
+  attestation ID. This is an inherent property of public blockchains and does
+  not affect functional correctness — the revoked attestation is rejected by all
+  validity-checking functions.
+- **Metadata scope**: Rectification via reissue only applies to data stored in
+  the `metadata` field or claim type. The subject and issuer addresses are
+  structural identifiers and cannot be changed; if either needs to change, a new
+  attestation to a new address is the only option.
+- **Off-chain data**: Operators who stored personal data in off-chain systems
+  and used TrustLink only as a reference anchor must independently apply
+  rectification to those systems. TrustLink does not propagate corrections to
+  external data stores.
+
+### Operator workflow checklist
+
+| Step | Action | Contract call |
+|------|--------|---------------|
+| 1 | Verify subject identity and document the inaccuracy | — |
+| 2 | Revoke the incorrect attestation with a descriptive reason | `revoke_attestation(issuer, id, reason)` |
+| 3 | Issue the corrected attestation | `create_attestation(issuer, subject, claim_type, ...)` |
+| 4 | Record the old and new attestation IDs in your compliance log | — |
+| 5 | Notify the subject of the new attestation ID | — |
+
 ## Data Minimisation
 
 TrustLink stores only the data necessary for attestation verification:
@@ -93,19 +164,105 @@ EU/EEA data subjects.
 
 ## Data Retention
 
-Attestations support optional expiration (`expiration` field). Issuers should
-set appropriate expiration times aligned with their data retention policy rather
-than creating indefinite attestations.
+TrustLink provides two distinct mechanisms that govern how long attestation data
+persists. Operators must understand both to comply with their jurisdiction's data
+retention laws.
 
-Recommended retention periods by claim type:
+### Mechanism 1 — Attestation expiration (`expiration` field)
 
-| Claim Type           | Suggested Expiration |
-|----------------------|----------------------|
-| `KYC_PASSED`         | 1–2 years            |
-| `ACCREDITED_INVESTOR`| 1 year               |
-| `AML_CLEARED`        | 6–12 months          |
-| `SANCTIONS_CHECKED`  | 3–6 months           |
-| `MERCHANT_VERIFIED`  | 1–2 years            |
+Every attestation may carry an optional `expiration` Unix timestamp. Once that
+timestamp passes, the attestation is treated as invalid by all claim-checking
+functions (`has_valid_claim`, `get_valid_claims`, etc.) even though the record
+remains in storage. This is a **logical** expiry: the data is still present on
+the ledger but no longer surfaced to relying parties.
+
+Set expiration at issuance time:
+
+```rust
+let expiration_unix = env.ledger().timestamp() + (365 * 24 * 60 * 60); // 1 year
+contract.create_attestation(&issuer, &subject, &claim_type, Some(expiration_unix), metadata);
+```
+
+After expiry, if a subject also wants the record removed from queries,
+`request_deletion` should be called to set the `deleted` flag (see
+Right to Erasure section above).
+
+### Mechanism 2 — Soroban ledger TTL (`TtlConfig`)
+
+Soroban persistent storage entries are archived to off-chain cold storage when
+they have not been accessed for longer than their configured TTL (time-to-live).
+TrustLink uses a contract-level `TtlConfig { ttl_days: u32 }` to set the ledger
+entry TTL for all attestation records. The contract automatically extends the
+TTL of any record it reads or writes, resetting the archival countdown.
+
+The admin configures this at initialisation:
+
+```rust
+contract.initialize(&admin, Some(ttl_days));
+```
+
+The default is **30 days**. Ledger archival is **not** the same as deletion —
+archived entries can be restored via Stellar's state-archival mechanism. For
+compliance purposes, ledger TTL should be treated as a cache lifetime, not a
+deletion policy. True functional expiry is controlled by the `expiration` field
+(Mechanism 1) and the `deleted` flag (right-to-erasure).
+
+### Recommended retention periods by claim type
+
+The following periods reflect common regulatory and business requirements.
+Operators should review their specific jurisdictional obligations before
+deploying.
+
+| Claim Type           | Suggested Expiration | Rationale                                      |
+|----------------------|----------------------|------------------------------------------------|
+| `KYC_PASSED`         | 1–2 years            | FATF guidance; most KYC regimes require refresh |
+| `ACCREDITED_INVESTOR`| 1 year               | SEC Rule 506(c); annual re-verification common  |
+| `AML_CLEARED`        | 6–12 months          | Risk-based AML policies; sanctions lists update |
+| `SANCTIONS_CHECKED`  | 3–6 months           | Sanctions lists change frequently               |
+| `MERCHANT_VERIFIED`  | 1–2 years            | PCI/merchant agreements typically annual        |
+
+### Configuring TTL for jurisdictional compliance
+
+Different jurisdictions impose different maximum and minimum retention periods.
+Operators should configure the attestation `expiration` field — not the ledger
+TTL — as their primary retention control, since ledger TTL only affects cold
+storage archival, not data validity.
+
+**GDPR (EU/EEA)** — GDPR's storage limitation principle (Article 5(1)(e))
+requires that personal data not be retained longer than necessary. Set
+`expiration` to the shortest period consistent with the lawful basis for
+processing. For KYC attestations backed by consent, re-obtain consent and
+reissue before expiry rather than issuing indefinitely-valid attestations.
+
+**CCPA (California)** — No mandated retention period, but data must be
+retained no longer than disclosed in the privacy notice. Align `expiration`
+with the retention period stated in your privacy disclosure.
+
+**FATF / Travel Rule jurisdictions** — Most financial-intelligence frameworks
+require retaining transaction records for 5 years. Because TrustLink stores
+claim status (not the underlying transaction), the attestation expiration should
+outlive the underlying transaction if the attestation itself is part of the
+compliance record.
+
+**Operator workflow for TTL compliance**
+
+1. Determine the maximum retention period required by the applicable regulation.
+2. Set the `expiration` field on new attestations to that maximum period.
+3. Subscribe to `DeletionRequested` events and delete off-chain copies promptly.
+4. After an attestation expires, call `request_deletion` to suppress it from
+   all on-chain queries (completing the functional erasure).
+5. Review and refresh attestations for subjects with ongoing relationships before
+   their `expiration` passes to avoid service interruption.
+
+### Ledger TTL vs. attestation expiration — summary
+
+| Property           | Attestation `expiration` field         | Soroban ledger TTL (`ttl_days`)         |
+|--------------------|----------------------------------------|-----------------------------------------|
+| Controls           | Logical validity of the attestation    | When the entry is archived to cold store |
+| Set by             | Issuer at creation time                | Admin at contract initialisation         |
+| Effect on queries  | Expired = invalid in all query fns     | No effect on validity; entry is archived |
+| Compliance role    | Primary retention policy control       | Infrastructure cache-lifetime only       |
+| Default            | None (no expiry unless set)            | 30 days                                  |
 
 ## Summary of GDPR-Relevant Contract Functions
 


### PR DESCRIPTION
## Summary

This PR resolves four documentation issues in a single pass:

### ADR-008 — Rate limiting design (`docs/adr/ADR-008-rate-limiting.md`)

- Documents the per-issuer last-issuance timestamp approach and why token bucket and sliding window alternatives were not chosen.
- Explains the interval resolution priority: per-claim-type override → global default → no limit.
- Records all known limitations:
  - Single timer shared across all claim types per issuer (one issuance resets the timer for all).
  - `create_attestation_as_delegate` bypasses `check_rate_limit` entirely — delegates are unconstrained.
  - `create_attestations_batch` counts the whole batch as a single rate-limit check.
  - Ledger timestamp granularity (~5 s) makes sub-10 s intervals unreliable.
  - No cross-issuer coordination (multiple registered addresses multiply effective throughput).

### ADR-009 — Delegation model and trust chain implications (`docs/adr/ADR-009-delegation-model.md`)

- Documents the per-claim-type delegation mechanism (`Delegation { delegator, delegate, claim_type, expiration }`).
- Analyses the trust chain: all attestations created by a delegate appear with `issuer = delegator`; the delegate's identity is only recoverable from the audit log.
- Calls out the key security implication: a compromised delegate key can issue attestations under the root issuer's trusted identity for delegated claim types.
- Cross-references ADR-008 for the rate-limiting bypass on the delegate path.
- Provides concrete operator mitigations: short-lived delegations, frequent key rotation, monitoring `DelegationCreated` events, post-compromise audit procedure, and off-chain rate limiting.

### `docs/compliance.md` — Right to Rectification (GDPR Article 16)

- New section explaining that attestation immutability (ADR-003) means rectification is achieved via **revoke-and-reissue**.
- Five-step operator workflow with contract call examples for `revoke_attestation` and `create_attestation`.
- Documents limitations: historical ledger data, metadata-only scope, off-chain data not propagated.
- Operator workflow checklist table for quick reference.

### `docs/compliance.md` — Data Retention (expanded)

- Replaces the previous stub section with a full treatment of both TTL mechanisms:
  - **Attestation `expiration` field** — logical validity control; the primary retention policy lever.
  - **Soroban ledger TTL (`TtlConfig`)** — infrastructure archival; not a legal deletion mechanism.
- Adds jurisdiction-specific guidance for GDPR, CCPA, and FATF/Travel Rule deployments.
- Per-claim-type recommended retention periods with regulatory rationale.
- Operator workflow checklist for TTL compliance.
- Summary comparison table: expiration field vs. ledger TTL.

### README and ADR index updates

- Added ADR-007, ADR-008, and ADR-009 rows to the ADR table in `README.md`.
- Added ADR-008 and ADR-009 rows to `docs/adr/README.md`.

## Test plan

- [ ] Verify `docs/adr/ADR-008-rate-limiting.md` exists and follows the ADR-000 template structure.
- [ ] Verify `docs/adr/ADR-009-delegation-model.md` exists and follows the ADR-000 template structure.
- [ ] Verify `docs/adr/README.md` index table includes ADR-008 and ADR-009 with correct links.
- [ ] Verify `README.md` ADR table includes ADR-007, ADR-008, and ADR-009 with correct links.
- [ ] Verify `docs/compliance.md` contains a 'Right to Rectification' section with the revoke-and-reissue workflow.
- [ ] Verify `docs/compliance.md` 'Data Retention' section covers both expiration and ledger TTL mechanisms with jurisdiction guidance.
- [ ] Confirm all cross-references between ADRs and compliance.md resolve correctly.

Closes #580
Closes #581
Closes #582
Closes #583