### PR TITLE
feat: add bridge contract trust model and Prometheus alerting rules

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -537,6 +537,74 @@ RPC_URL=https://soroban-testnet.stellar.org \
 }
 ```
 
+### Prometheus Alerting Rules
+
+Ready-to-use Prometheus alerting rules are provided in
+[`monitoring/alerts.yml`](../monitoring/alerts.yml). Load the file into your
+Prometheus configuration:
+
+```yaml
+# prometheus.yml
+rule_files:
+  - "monitoring/alerts.yml"
+```
+
+The file defines one alert group (`trustlink`) with four rules. Each rule
+requires the following metrics to be exported by your TrustLink event indexer:
+
+| Metric | Type | Description |
+|---|---|---|
+| `trustlink_contract_paused` | Gauge | `1` when the contract is paused, `0` otherwise |
+| `trustlink_issuer_removed_total` | Counter | Cumulative count of `iss_rem` events |
+| `trustlink_attestation_revoked_total` | Counter | Cumulative count of `revoked` events |
+| `trustlink_latest_ledger` | Gauge | Current chain tip ledger sequence |
+| `trustlink_indexer_last_processed_ledger` | Gauge | Last ledger processed by the indexer |
+
+#### `TrustLinkContractPaused`
+
+**Severity:** Critical  
+**Condition:** `trustlink_contract_paused == 1`
+
+Fires immediately when the contract is paused via `pause()`. All attestation
+write operations are halted while the contract is paused. Verify the pause was
+an intentional admin action (e.g. incident response) and call `unpause()` once
+the threat is contained.
+
+#### `TrustLinkIssuerRemoved`
+
+**Severity:** Critical  
+**Condition:** Any `iss_rem` event in the last 5 minutes
+
+Fires when an issuer is removed from the registry. Existing attestations from
+the removed issuer remain valid but no new ones can be created, and the issuer
+can no longer revoke their own attestations. Confirm the removal was intentional
+and assess whether affected attestations need to be transferred to a successor
+issuer via `transfer_attestation`.
+
+#### `TrustLinkHighRevocationRate`
+
+**Severity:** High  
+**Condition:** More than 10 `revoked` events in any 5-minute window
+
+A revocation spike may indicate a compromised issuer key, a bulk compliance
+action (e.g. sanctions list update), or a bug in issuer automation. Follow the
+runbook in [Section 8](#8-investigating-a-spike-in-revocations) to determine
+the root cause. Adjust the threshold (`> 10`) to match your expected baseline
+traffic after one week of observation.
+
+#### `TrustLinkIndexerLag`
+
+**Severity:** High  
+**Condition:** Indexer more than 100 ledgers behind the chain tip for 2 minutes
+
+When the indexer lags, all event-based alerts become unreliable — revocation
+spikes, issuer removals, and bridge anomalies may go undetected. Check that the
+indexer process is running, verify RPC connectivity (see the
+[`no_events_received` runbook](#no_events_received--monitor-silence)), and
+switch to a backup RPC endpoint if needed.
+
+---
+
 ### Dashboard Metrics to Track
 
 - **Attestations created per hour** — baseline for normal activity

--- a/docs/security.md
+++ b/docs/security.md
@@ -243,6 +243,83 @@ See the [Known Limitations](#known-limitations) section below.
 
 ---
 
+## Bridge Contract Trust Model
+
+Bridge contracts occupy a privileged position in TrustLink's trust hierarchy.
+Understanding their trust assumptions is essential before registering one.
+
+### What a Bridge Contract Can Do
+
+A registered bridge contract can call `bridge_attestation` to create an
+attestation for **any subject** with **any claim type**. The bridge address
+becomes the on-chain `issuer` of the resulting attestation. There is no
+per-bridge restriction on which subjects or claim types it may attest.
+
+This is intentionally broad — bridges are expected to mirror verified
+attestations from another chain, and the contract cannot independently verify
+the source-chain state.
+
+### Trust Assumptions
+
+Registering a bridge contract means trusting that:
+
+1. **The source-chain verification logic is correct.** The bridge must only
+   relay attestations that were legitimately issued on the source chain. The
+   TrustLink contract has no way to verify this on-chain.
+2. **The bridge contract itself is not compromised.** A compromised bridge key
+   or a bug in the bridge contract can create arbitrary attestations for any
+   subject with any claim type.
+3. **The `source_chain` and `source_tx` fields are accurate.** These are
+   supplied by the bridge and stored verbatim. They are informational only —
+   the contract does not validate them.
+
+### Vetting Process Before Registering a Bridge
+
+Before calling `register_bridge`, the admin should:
+
+1. **Audit the bridge contract source code.** Review the source-chain
+   verification logic, key management, and upgrade mechanism. Confirm the
+   bridge cannot be unilaterally upgraded by a single key.
+2. **Verify the bridge contract address on-chain.** Confirm the address matches
+   the audited bytecode and has not been replaced.
+3. **Confirm the bridge operator's key management.** The bridge operator should
+   use a hardware wallet or multisig account to control the bridge contract.
+4. **Agree on a supported claim type allowlist.** Document which claim types
+   the bridge is authorised to relay. Even though the contract does not enforce
+   this on-chain, the bridge implementation should enforce it internally.
+5. **Establish an incident contact.** Have a direct escalation path to the
+   bridge operator so the admin can call `remove_bridge` quickly if a
+   compromise is suspected.
+6. **Test on testnet first.** Run the bridge against a testnet deployment and
+   verify that only expected attestations are created before enabling on
+   mainnet.
+
+### Blast Radius of a Compromised Bridge
+
+If a bridge contract or its controlling key is compromised, an attacker can:
+
+- Create attestations for **any subject** with **any claim type** — including
+  high-value types such as `KYC_PASSED` or `ACCREDITED_INVESTOR`.
+- Fabricate `source_chain` and `source_tx` values that appear legitimate.
+- Issue attestations at high volume until the admin calls `remove_bridge`.
+
+Unlike a compromised issuer, a compromised bridge is not limited to the claim
+types that issuer was expected to use. The blast radius is therefore equivalent
+to a compromised admin for the purposes of attestation creation.
+
+### Recommended Mitigations
+
+| Mitigation | Description |
+|---|---|
+| Limit registered bridges | Register only bridges you have audited. Prefer zero bridges unless cross-chain support is required. |
+| Monitor `bridged` events | Alert immediately on any `bridged` event from an unexpected `source_chain` or at abnormal volume (see [monitoring/alerts.yml](../monitoring/alerts.yml)). |
+| Enforce claim type restrictions in the bridge | The bridge contract should maintain its own allowlist of claim types it is permitted to relay, even though TrustLink does not enforce this on-chain. |
+| Use a multisig bridge operator key | Require M-of-N signatures to authorise bridge transactions, reducing single-key compromise risk. |
+| Have a `remove_bridge` runbook | Document and rehearse the steps to call `remove_bridge` quickly. The admin should be able to execute this within minutes of a suspected compromise. |
+| Separate bridge registries per source chain | Register a distinct bridge contract per source chain rather than one bridge for all chains. This limits the blast radius to a single chain if one bridge is compromised. |
+
+---
+
 ## Known Limitations
 
 These are honest assessments of what the contract does not protect against.

--- a/monitoring/alerts.yml
+++ b/monitoring/alerts.yml
@@ -1,0 +1,61 @@
+groups:
+  - name: trustlink
+    rules:
+      # Fires when the contract is paused via the admin pause() function.
+      # All attestation write operations are halted while this is active.
+      - alert: TrustLinkContractPaused
+        expr: trustlink_contract_paused == 1
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "TrustLink contract is paused"
+          description: >
+            The TrustLink contract has been paused. All attestation creation
+            and revocation is halted. Verify this was an intentional admin
+            action and unpause once the incident is resolved.
+
+      # Fires when an issuer is removed from the registry.
+      # Existing attestations from the removed issuer remain valid but no new
+      # ones can be created, and the issuer can no longer revoke their own attestations.
+      - alert: TrustLinkIssuerRemoved
+        expr: increase(trustlink_issuer_removed_total[5m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "TrustLink issuer removed"
+          description: >
+            An issuer has been removed from the TrustLink registry in the last
+            5 minutes. Confirm the removal was intentional. Check whether
+            affected attestations need to be transferred to a successor issuer.
+
+      # Fires when the revocation rate spikes above 10 revocations in 5 minutes.
+      # This may indicate a compromised issuer key, a bulk compliance action,
+      # or a bug in issuer automation.
+      - alert: TrustLinkHighRevocationRate
+        expr: increase(trustlink_attestation_revoked_total[5m]) > 10
+        for: 0m
+        labels:
+          severity: high
+        annotations:
+          summary: "High attestation revocation rate"
+          description: >
+            More than 10 attestations have been revoked in the last 5 minutes
+            (current: {{ $value }}). Investigate whether this is a planned
+            compliance sweep, an automation bug, or a compromised issuer key.
+
+      # Fires when the event indexer falls more than 100 ledgers behind the
+      # latest ledger. This means monitoring data is stale and alerts based on
+      # event counts may be unreliable.
+      - alert: TrustLinkIndexerLag
+        expr: (trustlink_latest_ledger - trustlink_indexer_last_processed_ledger) > 100
+        for: 2m
+        labels:
+          severity: high
+        annotations:
+          summary: "TrustLink indexer is lagging"
+          description: >
+            The TrustLink event indexer is {{ $value }} ledgers behind the
+            chain tip (threshold: 100). Event-based alerts may be delayed or
+            missing. Check the indexer process and RPC connectivity.


### PR DESCRIPTION
- docs/security.md: add 'Bridge Contract Trust Model' section before Known Limitations. Documents what a bridge contract can do, the trust assumptions operators must accept before registering one, the recommended vetting process (audit source-chain logic, verify on-chain address, confirm operator key management, agree on a claim-type allowlist, establish an incident contact, test on testnet), the full blast radius of a compromised bridge (arbitrary attestations for any subject/claim type), and recommended mitigations (limit registered bridges, monitor bridged events, enforce claim-type restrictions inside the bridge, use multisig operator keys, maintain a remove_bridge runbook, use per-chain bridge registries).

- monitoring/alerts.yml: new file with a Prometheus 'trustlink' alert group containing four rules:
    * TrustLinkContractPaused   – fires immediately when the contract is paused
    * TrustLinkIssuerRemoved    – fires on any iss_rem event in a 5-min window
    * TrustLinkHighRevocationRate – fires when revocations exceed 10 in 5 min
    * TrustLinkIndexerLag       – fires when the indexer is >100 ledgers behind
                                   the chain tip for 2+ minutes

- docs/monitoring.md: add 'Prometheus Alerting Rules' subsection inside Section 4 (Alerting Recommendations). References monitoring/alerts.yml, lists the five required indexer metrics, and explains the trigger condition, severity, and response guidance for each of the four alert rules.

Closes #584
Closes #585