### PR TITLE
docs: add error handling guide (#587) and Grafana dashboard (#586)

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -527,4 +527,136 @@ pub enum Error {
 
 ---
 
+---
+
+## 6. Error Handling
+
+TrustLink errors are returned as `Error(Contract, #N)` values. This section covers every error code, whether it is retryable, and how to surface it to end users.
+
+### Error Code Reference
+
+| Code | Name                  | Meaning                                                        | Retryable? |
+|------|-----------------------|----------------------------------------------------------------|------------|
+| `#1` | `AlreadyInitialized`  | `initialize()` was called on an already-initialized contract   | No         |
+| `#2` | `NotInitialized`      | Contract has not been initialized yet                          | No         |
+| `#3` | `Unauthorized`        | Caller is not the admin, a registered issuer, or the subject   | No         |
+| `#4` | `NotFound`            | Attestation ID does not exist                                  | No         |
+| `#5` | `DuplicateAttestation`| An attestation with the same deterministic hash already exists | No         |
+| `#6` | `AlreadyRevoked`      | The attestation has already been revoked                       | No         |
+| `#7` | `Expired`             | The attestation's expiration timestamp has passed              | No         |
+| `#8` | `InvalidThreshold`    | Multi-sig threshold is 0 or exceeds the number of signers      | No         |
+| `#9` | `NotRequiredSigner`   | Cosigner address is not in the proposal's required-signers list| No         |
+| `#10`| `LimitExceeded`       | Issuer or subject has reached the configured attestation limit | No†        |
+| `#11`| `AlreadySigned`       | This issuer has already co-signed the proposal                 | No         |
+| `#12`| `ProposalFinalized`   | The multi-sig proposal has already been activated              | No         |
+| `#13`| `ProposalExpired`     | The 7-day co-signing window elapsed without reaching threshold | No         |
+
+> † `LimitExceeded` is not retryable for the same issuer/subject until the admin raises the limit or stale attestations are revoked.
+
+### TypeScript: Catching and Handling TrustLinkError
+
+```typescript
+/** All TrustLink contract error codes mapped to structured metadata. */
+const TRUSTLINK_ERRORS: Record<
+  number,
+  { name: string; retryable: boolean; userMessage: string }
+> = {
+  1:  { name: "AlreadyInitialized",   retryable: false, userMessage: "The contract is already set up." },
+  2:  { name: "NotInitialized",       retryable: false, userMessage: "The contract is not yet available. Please try again later." },
+  3:  { name: "Unauthorized",         retryable: false, userMessage: "You do not have permission to perform this action." },
+  4:  { name: "NotFound",             retryable: false, userMessage: "The requested attestation could not be found." },
+  5:  { name: "DuplicateAttestation", retryable: false, userMessage: "This attestation already exists." },
+  6:  { name: "AlreadyRevoked",       retryable: false, userMessage: "This attestation has already been revoked." },
+  7:  { name: "Expired",              retryable: false, userMessage: "This attestation has expired. Please renew your verification." },
+  8:  { name: "InvalidThreshold",     retryable: false, userMessage: "The approval threshold is invalid." },
+  9:  { name: "NotRequiredSigner",    retryable: false, userMessage: "Your account is not authorised to co-sign this proposal." },
+  10: { name: "LimitExceeded",        retryable: false, userMessage: "The attestation limit has been reached. Please contact support." },
+  11: { name: "AlreadySigned",        retryable: false, userMessage: "You have already signed this proposal." },
+  12: { name: "ProposalFinalized",    retryable: false, userMessage: "This proposal has already been completed." },
+  13: { name: "ProposalExpired",      retryable: false, userMessage: "The signing window for this proposal has closed." },
+};
+
+interface TrustLinkErrorInfo {
+  code: number;
+  name: string;
+  retryable: boolean;
+  userMessage: string;
+}
+
+/**
+ * Parse a raw error thrown by the Stellar SDK into structured TrustLink error info.
+ * Returns null if the error is not a TrustLink contract error.
+ */
+function parseTrustLinkError(error: unknown): TrustLinkErrorInfo | null {
+  const msg = String(error);
+  const match = msg.match(/Error\(Contract,\s*#(\d+)\)/);
+  if (!match) return null;
+
+  const code = parseInt(match[1], 10);
+  const meta = TRUSTLINK_ERRORS[code];
+  return {
+    code,
+    name: meta?.name ?? "UnknownError",
+    retryable: meta?.retryable ?? false,
+    userMessage: meta?.userMessage ?? `Unexpected error (code ${code}). Please contact support.`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Usage example
+// ---------------------------------------------------------------------------
+async function verifyAndAttest(
+  issuerKeypair: Keypair,
+  subjectAddress: string,
+  claimType: string
+): Promise<void> {
+  try {
+    await createAttestation(issuerKeypair, subjectAddress, claimType);
+    console.log("Attestation created successfully.");
+  } catch (err) {
+    const tlError = parseTrustLinkError(err);
+
+    if (tlError) {
+      console.error(`TrustLink error [${tlError.name}]:`, tlError.userMessage);
+
+      if (tlError.retryable) {
+        // Safe to retry after a short delay
+        console.warn("This error is transient — retrying in 2 s…");
+        await new Promise((r) => setTimeout(r, 2000));
+        await createAttestation(issuerKeypair, subjectAddress, claimType);
+      } else {
+        // Surface the user-facing message in your UI
+        throw new Error(tlError.userMessage);
+      }
+    } else {
+      // Non-contract error (network, RPC, etc.) — may be retryable
+      console.error("Unexpected error:", err);
+      throw err;
+    }
+  }
+}
+```
+
+### User-Facing Message Reference
+
+Use this table to map error codes directly to UI copy:
+
+| Code | Recommended user-facing message                                              |
+|------|------------------------------------------------------------------------------|
+| `#1` | "The contract is already set up."                                            |
+| `#2` | "The contract is not yet available. Please try again later."                 |
+| `#3` | "You do not have permission to perform this action."                         |
+| `#4` | "The requested attestation could not be found."                              |
+| `#5` | "This attestation already exists."                                           |
+| `#6` | "This attestation has already been revoked."                                 |
+| `#7` | "This attestation has expired. Please renew your verification."              |
+| `#8` | "The approval threshold is invalid."                                         |
+| `#9` | "Your account is not authorised to co-sign this proposal."                   |
+| `#10`| "The attestation limit has been reached. Please contact support."            |
+| `#11`| "You have already signed this proposal."                                     |
+| `#12`| "This proposal has already been completed."                                  |
+| `#13`| "The signing window for this proposal has closed."                           |
+
+---
+
 For the full API reference, see the [README](../README.md). For error definitions and type details, see [`src/types.rs`](../src/types.rs).

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -731,7 +731,77 @@ curl -s ... | jq '[.result.events[].topic[1]] | unique'
 
 ---
 
-## 9. Detecting and Responding to Storage Exhaustion
+## 9. Grafana Dashboard
+
+A pre-built Grafana dashboard is provided at [`monitoring/grafana-dashboard.json`](../monitoring/grafana-dashboard.json). It includes five panels:
+
+| Panel | Type | What it shows |
+|---|---|---|
+| **Total Attestations Over Time** | Time series | Cumulative `trustlink_attestations_total` counter |
+| **Revocation Rate** | Time series | `rate(trustlink_revocations_total[$__rate_interval])` — spikes indicate bulk revocations |
+| **Active Issuers** | Stat | Current value of `trustlink_active_issuers` |
+| **Indexer Lag** | Gauge | `trustlink_indexer_lag_ledgers` — ledgers the indexer is behind the chain tip |
+| **Webhook Delivery Success Rate** | Time series | Ratio of `trustlink_webhook_deliveries_success_total` to total deliveries |
+
+### Prerequisites
+
+- Grafana 10.0+ with a **Prometheus** datasource configured and named `Prometheus`.
+- Your TrustLink indexer exposes the metrics listed above on a `/metrics` endpoint that Prometheus scrapes.
+
+### Importing the dashboard
+
+**Via the Grafana UI:**
+
+1. Open Grafana and go to **Dashboards → Import** (or navigate to `/dashboard/import`).
+2. Click **Upload dashboard JSON file** and select `monitoring/grafana-dashboard.json`.
+3. In the **Prometheus** dropdown, select your Prometheus datasource.
+4. Click **Import**.
+
+**Via the Grafana HTTP API:**
+
+```bash
+# Replace <GRAFANA_URL>, <USER>, and <PASSWORD> with your values
+curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -u "<USER>:<PASSWORD>" \
+  --data-binary @monitoring/grafana-dashboard.json \
+  "<GRAFANA_URL>/api/dashboards/import"
+```
+
+**Via Grafana provisioning (GitOps):**
+
+Copy the file into your Grafana provisioning directory and add a provider config:
+
+```yaml
+# grafana/provisioning/dashboards/trustlink.yaml
+apiVersion: 1
+providers:
+  - name: TrustLink
+    folder: TrustLink
+    type: file
+    options:
+      path: /etc/grafana/dashboards/trustlink
+```
+
+```bash
+cp monitoring/grafana-dashboard.json /etc/grafana/dashboards/trustlink/
+# Grafana picks up the file automatically on the next provisioning cycle (default: 10 s)
+```
+
+### Metric names reference
+
+| Metric | Type | Description |
+|---|---|---|
+| `trustlink_attestations_total` | Counter | All attestations ever created |
+| `trustlink_revocations_total` | Counter | All revocations ever performed |
+| `trustlink_active_issuers` | Gauge | Current registered issuer count |
+| `trustlink_indexer_lag_ledgers` | Gauge | Ledgers the indexer is behind the chain tip |
+| `trustlink_webhook_deliveries_success_total` | Counter | Webhook calls that returned HTTP 2xx |
+| `trustlink_webhook_deliveries_failure_total` | Counter | Webhook calls that failed or timed out |
+
+---
+
+## 10. Detecting and Responding to Storage Exhaustion
 
 TrustLink enforces per-issuer and per-subject attestation limits
 (`max_attestations_per_issuer`, `max_attestations_per_subject`). When a limit

--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -1,0 +1,262 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource scraping the TrustLink indexer metrics endpoint",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
+    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
+    { "type": "panel", "id": "stat", "name": "Stat", "version": "" },
+    { "type": "panel", "id": "gauge", "name": "Gauge", "version": "" }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "TrustLink on-chain attestation metrics — total attestations, revocation rate, active issuers, indexer lag, and webhook delivery success rate.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "id": 1,
+      "title": "Total Attestations Over Time",
+      "description": "Cumulative count of all attestations created (native, imported, bridged, multi-sig).",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Attestations",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": ["last", "max"], "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trustlink_attestations_total",
+          "legendFormat": "Total attestations",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Revocation Rate",
+      "description": "Rate of attestation revocations per minute, averaged over the selected time range.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "red" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "reqps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.1 },
+              { "color": "red", "value": 0.5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(trustlink_revocations_total[$__rate_interval])",
+          "legendFormat": "Revocations / s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Active Issuers",
+      "description": "Current number of registered issuers (live count, not cumulative).",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "green", "value": 3 }
+            ]
+          },
+          "unit": "short",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trustlink_active_issuers",
+          "legendFormat": "Active issuers",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Indexer Lag",
+      "description": "Number of ledgers the TrustLink event indexer is behind the chain tip. Values above 10 indicate the indexer is falling behind.",
+      "type": "gauge",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 30 }
+            ]
+          },
+          "unit": "short",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "trustlink_indexer_lag_ledgers",
+          "legendFormat": "Lag (ledgers)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Webhook Delivery Success Rate",
+      "description": "Percentage of webhook deliveries that succeeded (HTTP 2xx) over the selected time window.",
+      "type": "timeseries",
+      "gridPos": { "h": 4, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "green" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "min": 0,
+          "max": 100,
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 90 },
+              { "color": "green", "value": 99 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": ["mean", "min"], "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "100 * rate(trustlink_webhook_deliveries_success_total[$__rate_interval]) / (rate(trustlink_webhook_deliveries_success_total[$__rate_interval]) + rate(trustlink_webhook_deliveries_failure_total[$__rate_interval]) + 1e-9)",
+          "legendFormat": "Success rate %",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["trustlink", "soroban", "stellar", "attestations"],
+  "templating": {
+    "list": []
+  },
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "TrustLink Metrics",
+  "uid": "trustlink-metrics-v1",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Summary

This PR resolves two documentation issues in a single change.

---

### Issue #587 — Error Handling section in `docs/integration-guide.md`

**Problem:** The integration guide showed how to call contract functions but gave no guidance on which errors are retryable vs. permanent, or how to map contract error codes to user-facing messages.

**Changes:**
- Added **`## 6. Error Handling`** section to `docs/integration-guide.md`.
- Full error code table covering all 13 TrustLink error codes (`#1`–`#13`) with name, meaning, and retryable classification.
- TypeScript `parseTrustLinkError` helper that parses `Error(Contract, #N)` strings into structured metadata (code, name, retryable flag, user message).
- Usage example showing retry logic for transient errors and UI-safe message surfacing for permanent errors.
- User-facing message reference table for direct use in UI copy.

---

### Issue #586 — Grafana dashboard for TrustLink metrics

**Problem:** `docs/monitoring.md` described available metrics but provided no Grafana dashboard, forcing operators to build their own.

**Changes:**
- Added **`monitoring/grafana-dashboard.json`** — a Grafana 10+ compatible dashboard with 5 panels:
  - **Total Attestations Over Time** (time series) — `trustlink_attestations_total`
  - **Revocation Rate** (time series) — `rate(trustlink_revocations_total[...])`
  - **Active Issuers** (stat) — `trustlink_active_issuers`
  - **Indexer Lag** (gauge) — `trustlink_indexer_lag_ledgers`
  - **Webhook Delivery Success Rate** (time series) — success / (success + failure)
- Added **`## 9. Grafana Dashboard`** section to `docs/monitoring.md` covering:
  - UI import (upload JSON file)
  - HTTP API import (`curl` one-liner)
  - Grafana provisioning via file provider (GitOps)
  - Metric names reference table
- Renumbered old section 9 (Storage Exhaustion) → section 10.

---

### Testing
- Verified all three files are well-formed (JSON valid, Markdown renders correctly).
- No source code changes; documentation only.

close #586 
close #587 