### PR TITLE
chore: add pre-commit hooks for Rust fmt & Clippy; document install

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,14 +19,14 @@ repos:
     hooks:
       - id: cargo-fmt
         name: cargo fmt
-        entry: bash -c 'source "$HOME/.cargo/env" 2>/dev/null; cargo fmt --all -- --check'
+        entry: cargo fmt --all -- --check
         language: system
         types: [rust]
         pass_filenames: false
 
       - id: cargo-clippy
         name: cargo clippy
-        entry: bash -c 'source "$HOME/.cargo/env" 2>/dev/null; cargo clippy --all-targets --all-features -- -D warnings'
+        entry: cargo clippy --all-targets --all-features -- -D warnings
         language: system
         types: [rust]
         pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,17 @@ TrustLink uses [pre-commit](https://pre-commit.com) to enforce formatting and li
 **Install the hooks once after cloning:**
 
 ```bash
-pip install pre-commit   # or: brew install pre-commit
-pre-commit install
+# Install pre-commit (choose one method):
+pip install --user pre-commit   # or: brew install pre-commit
+
+# Ensure Rust tooling is available for the hooks:
+rustup component add rustfmt clippy
+
+# Install the git hooks (and fetch any hook dependencies):
+pre-commit install --install-hooks
+
+# Verify hooks run cleanly now:
+pre-commit run --all-files
 ```
 
 After that, every `git commit` automatically runs:


### PR DESCRIPTION
Closes #573

---

This PR adds pre-commit hooks and documentation to enforce Rust formatting and linting.

Changes:

- Adds local pre-commit hooks in `.pre-commit-config.yaml`:
  - `cargo fmt --all -- --check` (blocks commits if formatting fails)
  - `cargo clippy --all-targets --all-features -- -D warnings` (blocks commits on warnings)
- Uses `language: system` so `cargo` is invoked directly (CI-friendly).
- Updates `CONTRIBUTING.md` with minimal steps to install `pre-commit`, add `rustfmt`/`clippy`, install hooks, and verify with `pre-commit run --all-files`.

Notes:
- The branch was pushed to the fork `mohadon0/TrustLink` as `precommit/rust-fmt-clippy`.
- To test locally: install `pre-commit`, run `rustup component add rustfmt clippy`, run `pre-commit install --install-hooks`, then `pre-commit run --all-files`.