### PR TITLE
devcontainer: pin Stellar CLI to 21.x and print version; consolidate config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,10 +2,6 @@
   "name": "TrustLink — Rust + Soroban",
   "image": "mcr.microsoft.com/devcontainers/rust:1-bullseye",
   "postCreateCommand": "bash .devcontainer/post-create.sh",
-  "remoteEnv": {
-    "SOROBAN_NETWORK": "testnet"
-  },
-  "postCreateCommand": "rustup target add wasm32-unknown-unknown && cargo install --locked soroban-cli",
   "postStartCommand": "bash -lc 'docker compose up -d stellar || docker-compose up -d stellar'",
   "forwardPorts": [8000],
   "portsAttributes": {
@@ -15,6 +11,7 @@
     }
   },
   "remoteEnv": {
+    "SOROBAN_NETWORK": "testnet",
     "STELLAR_RPC_URL": "http://localhost:8000/soroban/rpc",
     "STELLAR_NETWORK": "local"
   }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -15,5 +15,13 @@ cargo install cargo-watch
 
 echo "→ pre-building project (warms up the cargo cache)"
 cargo build
+echo "→ ensuring stellar CLI (pinned 21.x) is installed"
+if command -v stellar >/dev/null 2>&1; then
+	echo "stellar already installed: $(stellar --version || echo 'unknown version') — skipping install"
+else
+	echo "→ installing stellar-cli (locked, pinned 21.x, features: opt)"
+	cargo install --locked stellar-cli --version "^21" --features opt
+	echo "→ installed: $(stellar --version || echo 'stellar binary not found')"
+fi
 
 echo "✓ devcontainer ready — run: cargo test"


### PR DESCRIPTION
Closes #575

---

## Summary
Pin `stellar-cli` to the 21.x series in the devcontainer setup and explicitly print the installed version. Consolidate `devcontainer.json` environment and single `postCreateCommand` so the setup is deterministic and idempotent.

## Changes
- `.devcontainer/post-create.sh`
  - If `stellar` is already present, skip install to avoid duplicate installs or overwrites.
  - Install `stellar-cli` with `cargo install --locked stellar-cli --version "^21" --features opt` when missing.
  - Print the installed `stellar --version` after install.
- `.devcontainer/devcontainer.json`
  - Removed duplicate `postCreateCommand` and used the shell script as single source of truth.
  - Merged `remoteEnv` entries for clarity.

## Rationale
- Pinning to `^21` yields deterministic builds while allowing safe patch/minor updates in the 21.x series.
- Printing the version makes CI/devcontainer logs show a clear success indicator and helps debug silent breakages.
- Idempotent install avoids conflicts if an official devcontainer feature or the base image already provides `stellar`.

## Testing / Validation
1. Rebuild devcontainer in VS Code (Command Palette → "Dev Containers: Rebuild Container").
2. Or run locally inside the container:

```bash
bash .devcontainer/post-create.sh
stellar --version
```

Expected: script exits successfully and prints `stellar --version` (e.g. `stellar 21.x.y`).

## Notes
- The script intentionally skips installing `stellar` if `stellar` exists. If you prefer the script to always reinstall (overwrite), I can change it to force-install.
- I did not add a devcontainer feature entry because I couldn't reliably discover an authoritative registry feature here; the script is guarded so adding a feature later will not duplicate work. If you want, I can add a feature entry once you provide the exact feature identifier.

## CI Safety
- Uses `--locked` and a pinned `--version` to reduce unexpected changes across environments.
- The change is low-risk and limited to devcontainer setup; it does not impact production code paths.
