### PR TITLE
feat(build): add check-wasm-size target with configurable size limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-.PHONY: build test optimize clean install help local-deploy check-size
-
 # ─────────────────────────────────────────────────────────────────────────────
 # TrustLink Makefile
 # ─────────────────────────────────────────────────────────────────────────────
@@ -35,6 +33,7 @@
 NETWORK      ?= testnet
 WASM          = target/wasm32-unknown-unknown/release/trustlink.wasm
 WASM_OPT      = target/wasm32-unknown-unknown/release/trustlink.optimized.wasm
+WASM_SIZE_LIMIT ?= 102400
 
 # ── RPC URLs (overridable via environment) ────────────────────────────────────
 TESTNET_RPC_URL  ?= https://soroban-testnet.stellar.org
@@ -64,7 +63,7 @@ endif
         deploy invoke \
         testnet mainnet local \
         bindings check-bindings \
-        check-size \
+        check-size check-wasm-size \
         help
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -77,6 +76,8 @@ help:
 	@echo "make test           - Run all unit tests"
 	@echo "make optimize       - Build release WASM and run wasm-opt -Oz"
 	@echo "make check-size     - Verify optimized WASM is under 100 KB"
+	@echo "make check-wasm-size - Verify optimized WASM is under WASM_SIZE_LIMIT (default: 100 KB)"
+	@echo "                       Override: make check-wasm-size WASM_SIZE_LIMIT=<bytes>"
 	@echo "make clean          - Clean build artifacts"
 	@echo "make install        - Install required dependencies"
 	@echo "make local-deploy   - Deploy and initialize contract on local Stellar network"
@@ -119,16 +120,20 @@ optimize: build
 		$$(( $$(stat -c%s $(WASM)) - $$(stat -c%s $(WASM_OPT)) ))
 	@echo "Optimized artifact: $(WASM_OPT)"
 
-## Verify the optimized WASM binary is under the 100 KB ledger-storage threshold.
-check-size: optimize
+## Verify the optimized WASM binary is under the configurable size limit.
+## Default limit: 100 KB. Override: make check-wasm-size WASM_SIZE_LIMIT=<bytes>
+check-wasm-size: optimize
 	@SIZE=$$(stat -c%s $(WASM_OPT)); \
-	MAX=$$((100 * 1024)); \
-	echo "Optimized WASM size: $${SIZE} bytes ($$(( SIZE / 1024 )) KB) / limit 100 KB"; \
+	MAX=$(WASM_SIZE_LIMIT); \
+	echo "Optimized WASM size: $${SIZE} bytes ($$(( SIZE / 1024 )) KB) / limit $$(( MAX / 1024 )) KB ($(WASM_SIZE_LIMIT) bytes)"; \
 	if [ "$$SIZE" -gt "$$MAX" ]; then \
-		echo "ERROR: $(WASM_OPT) is $${SIZE} bytes — exceeds 100 KB threshold."; \
+		echo "ERROR: $(WASM_OPT) is $${SIZE} bytes — exceeds limit of $(WASM_SIZE_LIMIT) bytes ($$(( MAX / 1024 )) KB)."; \
 		exit 1; \
 	fi; \
-	echo "OK: binary is within the 100 KB limit."
+	echo "OK: binary is within the $(WASM_SIZE_LIMIT)-byte limit."
+
+## Backwards-compatible alias for check-wasm-size
+check-size: check-wasm-size
 
 ## Clean build artifacts and compiled outputs
 clean:


### PR DESCRIPTION
Closes #572

---

## Summary

Adds a `check-wasm-size` Makefile target that builds the optimized WASM artifact and enforces a configurable maximum file-size limit. This gives CI/CD pipelines a deterministic gate to catch binary bloat before it reaches mainnet.

---

## Changes

### `Makefile`

| Change | Detail |
|--------|--------|
| New variable `WASM_SIZE_LIMIT` | Defaults to `102400` (100 KB). Overridable via CLI or CI env var: `make check-wasm-size WASM_SIZE_LIMIT=81920` |
| New target `check-wasm-size` | Depends on `optimize` → always checks a freshly built artifact. Prints a size report, exits 0 on pass, exits 1 with a clear error on failure. |
| `check-size` kept as alias | Existing CI steps using `make check-size` continue to work without modification. |
| Updated `.PHONY` | `check-wasm-size` added to the phony list. |
| Updated `help` output | Documents the new target and the override syntax. |
| Removed stale `.PHONY` | Duplicate declaration at the top of the file removed. |

---

## Usage

```bash
# Default 100 KB limit
make check-wasm-size

# Custom limit (e.g. 80 KB)
make check-wasm-size WASM_SIZE_LIMIT=81920

# Backwards-compatible alias
make check-size
```

**Example output (pass):**
```
Optimized WASM size: 68432 bytes (66 KB) / limit 100 KB (102400 bytes)
OK: binary is within the 102400-byte limit.
```

**Example output (fail):**
```
Optimized WASM size: 110592 bytes (108 KB) / limit 100 KB (102400 bytes)
ERROR: target/.../trustlink.optimized.wasm is 110592 bytes — exceeds limit of 102400 bytes (100 KB).
make: *** [check-wasm-size] Error 1
```

---

## CI/CD Integration

```yaml
- name: Check WASM size
  run: make check-wasm-size
```

---

## What was tested

- `make -n check-wasm-size` — dry-run confirms correct command expansion
- `make -n check-wasm-size WASM_SIZE_LIMIT=200000` — confirms variable override propagates
- `make -n check-size` — confirms alias resolves to the same command chain
- `make -n build test optimize clean fmt clippy help` — all existing targets unaffected

---

## No-impact guarantee

- Zero changes to contract source (`src/`), tests, or any runtime behaviour
- No new dependencies introduced
- `check-size` alias preserves full backwards compatibility