### PR TITLE
fix(makefile): integrate verify_deployment.sh as make verify target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ else
 endif
 
 .PHONY: build test optimize clean install fmt clippy \
-        deploy invoke \
+        deploy invoke verify \
         testnet mainnet local \
         bindings check-bindings \
         check-size \
@@ -82,6 +82,13 @@ help:
 	@echo "make local-deploy   - Deploy and initialize contract on local Stellar network"
 	@echo "make bindings       - Generate TypeScript bindings from compiled WASM"
 	@echo "make check-bindings - Fail if committed bindings are out of date"
+	@echo "make deploy         - Build, optimize, and deploy to NETWORK (default: testnet)"
+	@echo "                      Requires: ADMIN_SECRET=<secret>  SOURCE=<key-alias>"
+	@echo "                      Example:  make deploy NETWORK=testnet SOURCE=deployer"
+	@echo "make verify         - Run post-deployment verification against a live contract"
+	@echo "                      Requires: CONTRACT_ID=<id>  SOURCE=<key-alias>"
+	@echo "                      Optional: NETWORK=testnet|mainnet (default: testnet)"
+	@echo "                      Example:  make verify CONTRACT_ID=C... SOURCE=deployer NETWORK=testnet"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Build & test
@@ -164,3 +171,65 @@ check-bindings: bindings
 	@echo "Checking bindings are up to date..."
 	git diff --exit-code bindings/typescript/ || \
 		(echo "ERROR: TypeScript bindings are out of date. Run 'make bindings' and commit the result." && exit 1)
+
+# ── Signing key alias (used by deploy and verify) ─────────────────────────────
+# SOURCE is the stellar key alias (not the raw secret) passed to stellar CLI.
+# For deploy, ADMIN_SECRET must also be exported so the CLI can sign.
+SOURCE ?= deployer
+
+## Build, optimize, and deploy the contract to NETWORK.
+## Requires: ADMIN_SECRET exported in the environment; SOURCE set to a key alias.
+## After deploy, note the printed CONTRACT_ID and run: make verify CONTRACT_ID=... SOURCE=...
+deploy: optimize
+ifeq ($(NETWORK),mainnet)
+	@echo "⚠  WARNING: Deploying to MAINNET. Press Ctrl-C within 5 seconds to abort."
+	@sleep 5
+endif
+	@echo "Deploying TrustLink to $(NETWORK)..."
+	stellar contract deploy \
+		--wasm $(WASM_OPT) \
+		--source $(SOURCE) \
+		--network $(NETWORK)
+	@echo ""
+	@echo "════════════════════════════════════════════════════════════════"
+	@echo "  Deployment complete."
+	@echo "  ⚠  Run post-deployment verification before considering this done:"
+	@echo "     make verify CONTRACT_ID=<printed-above> SOURCE=$(SOURCE) NETWORK=$(NETWORK)"
+	@echo "════════════════════════════════════════════════════════════════"
+
+## Invoke any contract function on NETWORK.
+## Usage: make invoke ARGS="-- <function> [--param value ...]"
+invoke:
+	@test -n "$(CONTRACT_ID)" || (echo "Error: CONTRACT_ID is required. Export it or pass CONTRACT_ID=C..."; exit 1)
+	stellar contract invoke \
+		--id $(CONTRACT_ID) \
+		--source $(SOURCE) \
+		--network $(NETWORK) \
+		$(ARGS)
+
+testnet:
+	$(MAKE) deploy NETWORK=testnet
+
+mainnet:
+	$(MAKE) deploy NETWORK=mainnet
+
+local:
+	$(MAKE) deploy NETWORK=local
+
+## Run post-deployment verification against a live TrustLink contract.
+## Executes scripts/verify_deployment.sh which creates a temporary issuer,
+## issues a test attestation, verifies it, revokes it, and cleans up.
+##
+## Required: CONTRACT_ID=<contract-id>  SOURCE=<stellar-key-alias>
+## Optional: NETWORK=testnet|mainnet    (default: testnet)
+##
+## Example:
+##   make verify CONTRACT_ID=CABC...XYZ SOURCE=deployer NETWORK=testnet
+verify:
+	@test -n "$(CONTRACT_ID)" || (echo "Error: CONTRACT_ID is required.  Usage: make verify CONTRACT_ID=C... SOURCE=<alias> [NETWORK=testnet|mainnet]"; exit 1)
+	@test -n "$(SOURCE)"      || (echo "Error: SOURCE is required.  Usage: make verify CONTRACT_ID=C... SOURCE=<alias> [NETWORK=testnet|mainnet]"; exit 1)
+	@echo "Running deployment verification for $(CONTRACT_ID) on $(NETWORK)..."
+	bash scripts/verify_deployment.sh \
+		--contract $(CONTRACT_ID) \
+		--source   $(SOURCE) \
+		--network  $(NETWORK)


### PR DESCRIPTION
## Summary

Closes #569

Integrates `scripts/verify_deployment.sh` into the standard Makefile workflow by adding a `verify` target, a proper `deploy` target with a post-deployment reminder, and filling in the previously-declared-but-undefined `invoke`, `testnet`, `mainnet`, and `local` targets.

---

## Changes — `Makefile`

### New variable
```makefile
SOURCE ?= deployer   # stellar key alias passed to --source
```

### New `deploy` target
- Depends on `optimize` (build → wasm-opt)
- Prompts a 5-second abort window when `NETWORK=mainnet`
- Calls `stellar contract deploy --wasm ... --source $(SOURCE) --network $(NETWORK)`
- After success, prints a clearly-boxed reminder:
  ```
  ⚠  Run post-deployment verification before considering this done:
     make verify CONTRACT_ID=<printed-above> SOURCE=deployer NETWORK=testnet
  ```

### New `verify` target
- Guards against missing `CONTRACT_ID` and `SOURCE` with actionable error messages
- Delegates to `scripts/verify_deployment.sh --contract ... --source ... --network ...`
- Safe on both testnet and mainnet (the script itself handles Friendbot funding only on testnet)
- Usage:
  ```bash
  make verify CONTRACT_ID=CABC...XYZ SOURCE=deployer NETWORK=testnet
  ```

### New `invoke` target
- Guards against missing `CONTRACT_ID`
- Passes `$(ARGS)` through to `stellar contract invoke`
- Usage: `make invoke ARGS="-- get_admin"`

### New `testnet` / `mainnet` / `local` aliases
- Were listed in `.PHONY` but never defined; now delegate to `make deploy NETWORK=<net>`

### Updated `.PHONY`
- Added `verify`

### Updated `make help`
- Documents `deploy` and `verify` with required/optional parameters and examples

---

## Verification

```bash
# Dry-run — confirms argument passing and script invocation
make -n verify CONTRACT_ID=CTEST SOURCE=deployer
# bash scripts/verify_deployment.sh --contract CTEST --source deployer --network testnet

# Missing CONTRACT_ID guard
make verify SOURCE=deployer
# Error: CONTRACT_ID is required. ...

# Help output
make help
# ... includes deploy and verify entries with examples
```

---

## Compatibility

- No existing targets were modified or removed
- `local-deploy` (setup_local.sh path) is unchanged
- CI workflows that call `make build`, `make test`, `make optimize` are unaffected
- `ADMIN_SECRET` env-var convention is preserved and documented