### PR TITLE
feat(release): add make changelog-preview dry-run command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ endif
         testnet mainnet local \
         bindings check-bindings \
         check-size rollback \
+        changelog-preview test-changelog-preview \
         help
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -97,6 +98,9 @@ help:
 	@echo "                      Requires: CONTRACT_ID=<id>  SOURCE=<key-alias>"
 	@echo "                      Optional: NETWORK=testnet|mainnet (default: testnet)"
 	@echo "                      Example:  make verify CONTRACT_ID=C... SOURCE=deployer NETWORK=testnet"
+	@echo "make changelog-preview - Preview the next version and changelog entry Release Please"
+	@echo "                      would generate, without creating a PR or modifying any files."
+	@echo "                      Example:  make changelog-preview"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Build & test
@@ -291,3 +295,16 @@ verify:
 		--contract $(CONTRACT_ID) \
 		--source   $(SOURCE) \
 		--network  $(NETWORK)
+
+## Preview the next version and changelog entry that Release Please would generate.
+## Parses conventional commits since the last release tag and prints the expected
+## version bump and formatted changelog section without modifying any files.
+##
+## Example:
+##   make changelog-preview
+changelog-preview:
+	@bash scripts/changelog-preview.sh
+
+## Run automated tests for the changelog-preview script.
+test-changelog-preview:
+	@bash tests/test_changelog_preview.sh

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -144,6 +144,81 @@ Closes #42
 2. Ensures commit messages are properly formatted
 3. Blocks merge if validation fails
 
+## Changelog Preview (Local Dry-Run)
+
+Before merging to `main`, you can preview the next version and the changelog entry that Release Please would generate — without creating a PR or modifying any files.
+
+```bash
+make changelog-preview
+```
+
+The command parses conventional commits since the last release tag, determines the version bump, and prints the formatted changelog section to stdout.
+
+### Sample Output
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Changelog Preview  since v0.1.0
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  Current version : 0.1.0
+  Next version    : 0.2.0  (minor bump)
+  Version bump    : minor
+
+────────────────────────────────────────────────────────────
+  CHANGELOG.md entry that Release Please would generate:
+────────────────────────────────────────────────────────────
+
+## [0.2.0](../../compare/v0.1.0...v0.2.0) (2026-06-01)
+
+### Features
+
+* **storage:** add dual indexing for subject and issuer ([a1b2c3d](../../commit/a1b2c3d...))
+* **api:** add has_any_claim and has_all_claims ([e4f5a6b](../../commit/e4f5a6b...))
+
+### Bug Fixes
+
+* **validation:** reject attestations with valid_from in past ([7c8d9e0](../../commit/7c8d9e0...))
+
+────────────────────────────────────────────────────────────
+  NOTE: This is a local preview only. No files were changed.
+  Release Please may produce slightly different output when
+  it runs against the GitHub repository.
+────────────────────────────────────────────────────────────
+```
+
+### How It Works
+
+- Reads the current version from `Cargo.toml`.
+- Finds the last release tag (`git describe --tags`). If no tag exists, scans all commits.
+- Parses non-merge commits matching the [Conventional Commits](https://www.conventionalcommits.org/) format.
+- Applies the same bump rules and section visibility as `release-please-config.json`:
+  - `feat` → minor bump, shown in **Features**
+  - `fix` → patch bump, shown in **Bug Fixes**
+  - `perf` → patch bump, shown in **Performance**
+  - `docs` → shown in **Documentation** (no bump)
+  - `refactor` → shown in **Refactoring** (no bump)
+  - `test`, `chore` → hidden (no bump)
+  - `BREAKING CHANGE` footer or `!` suffix → major bump
+- Prints the preview and exits with code `0`. No files are written.
+
+### When No Release Would Be Created
+
+If there are no releasable commits (only `chore`, `test`, `docs`, etc.), the command prints:
+
+```
+  No releasable commits found since v0.1.0.
+  Release Please would not create a release PR.
+```
+
+### Running the Tests
+
+```bash
+make test-changelog-preview
+```
+
+This runs `tests/test_changelog_preview.sh`, which exercises the script in isolated temporary git repositories covering version bumping, section visibility, tag-based scoping, and idempotency.
+
 ## Manual Release (if needed)
 
 If you need to manually trigger a release:

--- a/scripts/changelog-preview.sh
+++ b/scripts/changelog-preview.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# changelog-preview.sh — Preview the next Release Please changelog entry and version.
+#
+# Parses conventional commits since the last release tag (or all commits if no
+# tag exists) and prints the expected next version and changelog section that
+# Release Please would generate, without creating a PR or modifying any files.
+#
+# Sections mirror release-please-config.json:
+#   feat  → Features   (minor bump)
+#   fix   → Bug Fixes  (patch bump)
+#   perf  → Performance (patch bump)
+#   docs  → Documentation
+#   refactor → Refactoring
+#   test, chore → hidden (not shown)
+#
+# Usage: bash scripts/changelog-preview.sh
+#        make changelog-preview
+
+set -euo pipefail
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+# Read current version from Cargo.toml
+current_version() {
+    grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/'
+}
+
+# Bump semver: bump_version <major> <minor> <patch> <bump_type>
+bump_version() {
+    local major=$1 minor=$2 patch=$3 bump=$4
+    case "$bump" in
+        major) echo "$((major + 1)).0.0" ;;
+        minor) echo "${major}.$((minor + 1)).0" ;;
+        patch) echo "${major}.${minor}.$((patch + 1))" ;;
+        *)     echo "${major}.${minor}.${patch}" ;;
+    esac
+}
+
+# ── Determine commit range ────────────────────────────────────────────────────
+
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+if [ -n "$LAST_TAG" ]; then
+    RANGE="${LAST_TAG}..HEAD"
+    SINCE_MSG="since ${LAST_TAG}"
+else
+    RANGE="HEAD"
+    SINCE_MSG="(no previous release tag found — scanning all commits)"
+fi
+
+# ── Collect conventional commits ─────────────────────────────────────────────
+
+# Format: <hash> <subject>
+mapfile -t COMMITS < <(git log "$RANGE" --format="%H %s" --no-merges 2>/dev/null || true)
+
+declare -a FEAT_LINES=() FIX_LINES=() PERF_LINES=() DOCS_LINES=() REFACTOR_LINES=()
+BUMP_TYPE="none"
+
+for entry in "${COMMITS[@]}"; do
+    hash="${entry%% *}"
+    subject="${entry#* }"
+    short="${hash:0:7}"
+
+    # Parse: type(scope): description  OR  type!: description (breaking)
+    if [[ "$subject" =~ ^([a-z]+)(\([^\)]*\))?(!)?:\ (.+)$ ]]; then
+        type="${BASH_REMATCH[1]}"
+        scope="${BASH_REMATCH[2]}"
+        breaking="${BASH_REMATCH[3]}"
+        desc="${BASH_REMATCH[4]}"
+
+        # Check for BREAKING CHANGE in commit body
+        body=$(git log -1 --format="%b" "$hash" 2>/dev/null || true)
+        if [[ -n "$breaking" ]] || echo "$body" | grep -q "^BREAKING CHANGE:"; then
+            BUMP_TYPE="major"
+        fi
+
+        # Format scope for display
+        scope_display=""
+        if [ -n "$scope" ]; then
+            # scope is like "(storage)" — strip parens for display
+            scope_inner="${scope:1:${#scope}-2}"
+            scope_display="**${scope_inner}:** "
+        fi
+        line="* ${scope_display}${desc} ([${short}](../../commit/${hash}))"
+
+        case "$type" in
+            feat)
+                FEAT_LINES+=("$line")
+                [ "$BUMP_TYPE" != "major" ] && BUMP_TYPE="minor"
+                ;;
+            fix)
+                FIX_LINES+=("$line")
+                [ "$BUMP_TYPE" = "none" ] && BUMP_TYPE="patch"
+                ;;
+            perf)
+                PERF_LINES+=("$line")
+                [ "$BUMP_TYPE" = "none" ] && BUMP_TYPE="patch"
+                ;;
+            docs)
+                DOCS_LINES+=("$line")
+                ;;
+            refactor)
+                REFACTOR_LINES+=("$line")
+                ;;
+            # test, chore, ci, build → hidden per release-please-config.json
+        esac
+    fi
+done
+
+# ── Compute next version ──────────────────────────────────────────────────────
+
+VERSION=$(current_version)
+IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+if [ "$BUMP_TYPE" = "none" ]; then
+    NEXT_VERSION="$VERSION"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "  Changelog Preview  ${SINCE_MSG}"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+    echo "  No releasable commits found since ${LAST_TAG:-the beginning}."
+    echo "  Release Please would not create a release PR."
+    echo ""
+    echo "  Current version: ${VERSION}"
+    echo ""
+    exit 0
+fi
+
+NEXT_VERSION=$(bump_version "$MAJOR" "$MINOR" "$PATCH" "$BUMP_TYPE")
+TODAY=$(date +%Y-%m-%d)
+
+# ── Print preview ─────────────────────────────────────────────────────────────
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Changelog Preview  ${SINCE_MSG}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "  Current version : ${VERSION}"
+echo "  Next version    : ${NEXT_VERSION}  (${BUMP_TYPE} bump)"
+echo "  Version bump    : ${BUMP_TYPE}"
+echo ""
+echo "────────────────────────────────────────────────────────────"
+echo "  CHANGELOG.md entry that Release Please would generate:"
+echo "────────────────────────────────────────────────────────────"
+echo ""
+echo "## [${NEXT_VERSION}](../../compare/v${VERSION}...v${NEXT_VERSION}) (${TODAY})"
+echo ""
+
+if [ ${#FEAT_LINES[@]} -gt 0 ]; then
+    echo "### Features"
+    echo ""
+    for line in "${FEAT_LINES[@]}"; do echo "$line"; done
+    echo ""
+fi
+
+if [ ${#FIX_LINES[@]} -gt 0 ]; then
+    echo "### Bug Fixes"
+    echo ""
+    for line in "${FIX_LINES[@]}"; do echo "$line"; done
+    echo ""
+fi
+
+if [ ${#PERF_LINES[@]} -gt 0 ]; then
+    echo "### Performance"
+    echo ""
+    for line in "${PERF_LINES[@]}"; do echo "$line"; done
+    echo ""
+fi
+
+if [ ${#DOCS_LINES[@]} -gt 0 ]; then
+    echo "### Documentation"
+    echo ""
+    for line in "${DOCS_LINES[@]}"; do echo "$line"; done
+    echo ""
+fi
+
+if [ ${#REFACTOR_LINES[@]} -gt 0 ]; then
+    echo "### Refactoring"
+    echo ""
+    for line in "${REFACTOR_LINES[@]}"; do echo "$line"; done
+    echo ""
+fi
+
+echo "────────────────────────────────────────────────────────────"
+echo "  NOTE: This is a local preview only. No files were changed."
+echo "  Release Please may produce slightly different output when"
+echo "  it runs against the GitHub repository."
+echo "────────────────────────────────────────────────────────────"

--- a/tests/test_changelog_preview.sh
+++ b/tests/test_changelog_preview.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# tests/test_changelog_preview.sh — Tests for scripts/changelog-preview.sh
+#
+# Runs in a temporary git repository to isolate from the real repo state.
+# Each test creates a minimal git history and verifies the script output.
+#
+# Usage: bash tests/test_changelog_preview.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PREVIEW_SCRIPT="${SCRIPT_DIR}/../scripts/changelog-preview.sh"
+
+PASS=0
+FAIL=0
+
+# ── Test harness ──────────────────────────────────────────────────────────────
+
+run_test() {
+    local name="$1"
+    local fn="$2"
+    if "$fn"; then
+        echo "  PASS  $name"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL  $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Create a temp git repo with a Cargo.toml at the given version.
+setup_repo() {
+    local version="${1:-0.1.0}"
+    TMPDIR_REPO=$(mktemp -d)
+    cd "$TMPDIR_REPO"
+    git init -q
+    git config user.email "test@test.com"
+    git config user.name "Test"
+    printf '[package]\nname = "test"\nversion = "%s"\nedition = "2021"\n' "$version" > Cargo.toml
+    git add Cargo.toml
+    git commit -q -m "chore: initial commit"
+}
+
+cleanup_repo() {
+    cd /
+    rm -rf "$TMPDIR_REPO"
+}
+
+add_commit() {
+    local msg="$1"
+    echo "$msg" >> changes.txt
+    git add changes.txt
+    git commit -q -m "$msg"
+}
+
+add_tag() {
+    git tag "$1"
+}
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+test_no_releasable_commits() {
+    setup_repo "0.1.0"
+    add_commit "chore: update ci"
+    add_commit "test: add unit tests"
+    local out
+    out=$(bash "$PREVIEW_SCRIPT")
+    cleanup_repo
+    echo "$out" | grep -q "No releasable commits"
+}
+
+test_feat_produces_minor_bump() {
+    setup_repo "0.1.0"
+    add_commit "feat(storage): add dual indexing"
+    local out
+    out=$(bash "$PREVIEW_SCRIPT")
+    cleanup_repo
+    echo "$out" | grep -q "0.2.0"
+    echo "$out" | grep -q "minor"
+}
+
+test_fix_produces_patch_bump() {
+    setup_repo "0.1.0"
+    add_commit "fix(validation): reject past expiration"
+    local out
+    out=$(bash "$PREVIEW_SCRIPT")
+    cleanup_repo
+    echo "$out" | grep -q "0.1.1"
+    echo "$out" | grep -q "patch"
+}
+
+test_feat_and_fix_produces_minor_bump() {
+    setup_repo "0.1.0"
+    add_commit "fix(auth): fix auth check"
+    add_commit "feat(api): add new endpoint"
+    local out
+    out=$(bash "$PREVIEW_SCRIPT")
+    cleanup_repo
+    echo "$out" | grep -q "0.2.0"
+    echo "$out" | grep -q "minor"
+}
+
+test_feat_appears_in_features_section() {
+    setup_repo "0.1.0"
+    add_commit "feat(storage): add dual indexing"
+    local out
+    out=$(bash "$PREVIEW_SCRIPT")
+    cleanup_repo
+    echo "$out" | grep -q "### Features"
+    echo "$out" | grep -q "add dual indexing"
+}
+
+test_fix_appears_in_bug_fixes_section() {
+    setup_repo "0.1.0"
+    add_commit "fix(validation): reject past expiration"
+    local out
+    out=$(bash "$PREVIEW_SCRIPT")
+    cleanup_repo
+    echo "$out" | grep -q "### Bug Fixes"
+    echo "$out" | grep -q "reject past expiration"
+}
+
+test_docs_appears_in_documentation_section() {
+    setup_repo "0.1.0"
+    add_commit "docs(readme): update usage examples"
+    local out
+    out=$(bash "$PREVIEW_SCRIPT")
+    cleanup_repo
+    # docs alone don't trigger a release bump, but should appear in output
+    # (no version bump, so "No releasable commits" is expected)
+    echo "$out" | grep -q "No releasable commits"
+}
+
+test_chore_is_hidden() {
+    setup_repo "0.1.0"
+    add_commit "chore(deps): bump soroban-sdk"
+    local out
+    out=$(bash "$PREVIEW_SCRIPT")
+    cleanup_repo
+    echo "$out" | grep -q "No releasable commits"
+}
+
+test_since_last_tag_only() {
+    setup_repo "0.1.0"
+    add_commit "feat(old): old feature before tag"
+    add_tag "v0.1.0"
+    add_commit "fix(new): new fix after tag"
+    local out
+    out=$(bash "$PREVIEW_SCRIPT")
+    cleanup_repo
+    # Should show 0.1.1 (patch), not 0.2.0 (minor from old feat)
+    echo "$out" | grep -q "0.1.1"
+    # Old feat should NOT appear
+    ! echo "$out" | grep -q "old feature before tag"
+}
+
+test_no_files_modified() {
+    setup_repo "0.1.0"
+    add_commit "feat(api): add endpoint"
+    local before
+    before=$(find . -newer Cargo.toml -not -path './.git/*' 2>/dev/null | sort)
+    bash "$PREVIEW_SCRIPT" > /dev/null
+    local after
+    after=$(find . -newer Cargo.toml -not -path './.git/*' 2>/dev/null | sort)
+    cleanup_repo
+    [ "$before" = "$after" ]
+}
+
+test_exit_code_zero_on_success() {
+    setup_repo "0.1.0"
+    add_commit "feat(api): add endpoint"
+    bash "$PREVIEW_SCRIPT" > /dev/null
+    local code=$?
+    cleanup_repo
+    [ "$code" -eq 0 ]
+}
+
+test_exit_code_zero_no_releasable() {
+    setup_repo "0.1.0"
+    add_commit "chore: update ci"
+    bash "$PREVIEW_SCRIPT" > /dev/null
+    local code=$?
+    cleanup_repo
+    [ "$code" -eq 0 ]
+}
+
+test_current_version_shown() {
+    setup_repo "1.2.3"
+    add_commit "fix(auth): fix token check"
+    local out
+    out=$(bash "$PREVIEW_SCRIPT")
+    cleanup_repo
+    echo "$out" | grep -q "1.2.3"
+    echo "$out" | grep -q "1.2.4"
+}
+
+test_scope_formatted_in_output() {
+    setup_repo "0.1.0"
+    add_commit "feat(storage): add indexing"
+    local out
+    out=$(bash "$PREVIEW_SCRIPT")
+    cleanup_repo
+    echo "$out" | grep -q "storage"
+}
+
+test_perf_produces_patch_bump() {
+    setup_repo "0.1.0"
+    add_commit "perf(query): optimize attestation lookup"
+    local out
+    out=$(bash "$PREVIEW_SCRIPT")
+    cleanup_repo
+    echo "$out" | grep -q "0.1.1"
+    echo "$out" | grep -q "patch"
+}
+
+# ── Run all tests ─────────────────────────────────────────────────────────────
+
+echo ""
+echo "Running changelog-preview tests..."
+echo ""
+
+run_test "no releasable commits → no release message" test_no_releasable_commits
+run_test "feat commit → minor bump (0.1.0 → 0.2.0)" test_feat_produces_minor_bump
+run_test "fix commit → patch bump (0.1.0 → 0.1.1)" test_fix_produces_patch_bump
+run_test "feat + fix → minor bump wins" test_feat_and_fix_produces_minor_bump
+run_test "feat appears in Features section" test_feat_appears_in_features_section
+run_test "fix appears in Bug Fixes section" test_fix_appears_in_bug_fixes_section
+run_test "docs alone → no release" test_docs_appears_in_documentation_section
+run_test "chore is hidden (no release)" test_chore_is_hidden
+run_test "only commits since last tag are included" test_since_last_tag_only
+run_test "no files are modified by the script" test_no_files_modified
+run_test "exit code 0 on success" test_exit_code_zero_on_success
+run_test "exit code 0 when no releasable commits" test_exit_code_zero_no_releasable
+run_test "current and next version shown correctly" test_current_version_shown
+run_test "scope is formatted in output" test_scope_formatted_in_output
+run_test "perf commit → patch bump" test_perf_produces_patch_bump
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+echo ""
+
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Closes #577

Implements `make changelog-preview` — a local dry-run command that parses conventional commits since the last release tag and prints the expected next version and formatted `CHANGELOG.md` entry that Release Please would generate, without creating a PR or modifying any files.

## Changes

### `scripts/changelog-preview.sh` (new)
- Reads current version from `Cargo.toml`
- Finds the last release tag via `git describe --tags`; falls back to all commits if no tag exists
- Parses non-merge commits matching the Conventional Commits format
- Applies the same bump rules and section visibility as `release-please-config.json`:
  - `feat` → minor bump → **Features** section
  - `fix` → patch bump → **Bug Fixes** section
  - `perf` → patch bump → **Performance** section
  - `docs` → **Documentation** section (no bump)
  - `refactor` → **Refactoring** section (no bump)
  - `test`, `chore` → hidden (no bump, not shown)
  - `BREAKING CHANGE` footer or `!` suffix → major bump
- Prints the preview to stdout and exits `0`; **no files are written**

### `Makefile`
- `make changelog-preview` — runs the preview script
- `make test-changelog-preview` — runs the test suite
- Both added to `.PHONY` and `help`

### `tests/test_changelog_preview.sh` (new)
15 isolated tests running in temporary git repositories:
- `feat` → minor bump (0.1.0 → 0.2.0)
- `fix` → patch bump (0.1.0 → 0.1.1)
- `perf` → patch bump
- `feat` + `fix` → minor wins
- `feat` appears in Features section
- `fix` appears in Bug Fixes section
- `docs` alone → no release
- `chore` is hidden
- Only commits since last tag are included
- No files are modified by the script
- Exit code 0 on success and on no-releasable-commits
- Current and next version shown correctly
- Scope formatted in output

### `RELEASE.md`
New **"Changelog Preview (Local Dry-Run)"** section documenting:
- Usage (`make changelog-preview`)
- Sample output
- How-it-works explanation
- When no release would be created
- How to run the tests

## Sample Output

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Changelog Preview  since v0.1.0
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  Current version : 0.1.0
  Next version    : 0.2.0  (minor bump)
  Version bump    : minor

────────────────────────────────────────────────────────────
  CHANGELOG.md entry that Release Please would generate:
────────────────────────────────────────────────────────────

## [0.2.0](../../compare/v0.1.0...v0.2.0) (2026-06-01)

### Features

* **storage:** add dual indexing for subject and issuer ([a1b2c3d](../../commit/a1b2c3d...))

### Bug Fixes

* **validation:** reject attestations with valid_from in past ([7c8d9e0](../../commit/7c8d9e0...))

────────────────────────────────────────────────────────────
  NOTE: This is a local preview only. No files were changed.
  Release Please may produce slightly different output when
  it runs against the GitHub repository.
────────────────────────────────────────────────────────────
```

## Testing

```bash
# Run the preview
make changelog-preview

# Run the test suite (15 tests, all passing)
make test-changelog-preview
```

## Acceptance Criteria

- [x] `make changelog-preview` runs and prints expected next version and changelog entry
- [x] No files are modified (idempotent, safe to run anytime)
- [x] Works with or without a prior release tag
- [x] Mirrors `release-please-config.json` bump rules and section visibility exactly
- [x] `RELEASE.md` documents the command with usage and sample output
- [x] 15 automated tests cover all bump rules, section visibility, tag scoping, and idempotency
- [x] No new dependencies introduced (pure bash + git)