### PR TITLE
feat(indexer): add indexer-dev, indexer-build, indexer-logs Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ endif
         testnet mainnet local \
         bindings check-bindings \
         check-size rollback \
+        indexer-dev indexer-build indexer-logs \
         help
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -97,6 +98,9 @@ help:
 	@echo "                      Requires: CONTRACT_ID=<id>  SOURCE=<key-alias>"
 	@echo "                      Optional: NETWORK=testnet|mainnet (default: testnet)"
 	@echo "                      Example:  make verify CONTRACT_ID=C... SOURCE=deployer NETWORK=testnet"
+	@echo "make indexer-dev    - Start the indexer stack (db + indexer) via docker compose"
+	@echo "make indexer-build  - Build the indexer Docker image"
+	@echo "make indexer-logs   - Tail logs from the running indexer container"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Build & test
@@ -291,3 +295,23 @@ verify:
 		--contract $(CONTRACT_ID) \
 		--source   $(SOURCE) \
 		--network  $(NETWORK)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Indexer
+# ─────────────────────────────────────────────────────────────────────────────
+
+## Start the indexer stack (db + indexer) in the foreground.
+## Press Ctrl-C to stop. Requires CONTRACT_ID and RPC_URL to be set.
+## Example:
+##   CONTRACT_ID=C... RPC_URL=https://soroban-testnet.stellar.org make indexer-dev
+indexer-dev:
+	docker compose -f indexer/docker-compose.yml up
+
+## Build the indexer Docker image without starting any containers.
+indexer-build:
+	docker compose -f indexer/docker-compose.yml build indexer
+
+## Tail logs from the running indexer container.
+## Follows output until interrupted with Ctrl-C.
+indexer-logs:
+	docker compose -f indexer/docker-compose.yml logs -f indexer


### PR DESCRIPTION
## Summary

Closes #576

Adds three Makefile targets for indexer workflows. Developers no longer need to `cd indexer` and run docker commands manually — all indexer operations are now available from the project root.

## Changes

### `Makefile`

Three new targets added under a new `# Indexer` section, all delegating to `indexer/docker-compose.yml`:

| Target | Command | Description |
|---|---|---|
| `make indexer-dev` | `docker compose -f indexer/docker-compose.yml up` | Start the full indexer stack (db + indexer) in the foreground |
| `make indexer-build` | `docker compose -f indexer/docker-compose.yml build indexer` | Build the indexer Docker image without starting containers |
| `make indexer-logs` | `docker compose -f indexer/docker-compose.yml logs -f indexer` | Tail logs from the running indexer container |

All three targets are added to `.PHONY` and documented in `make help`.

## Usage

```bash
# Start the indexer stack (requires CONTRACT_ID and RPC_URL)
CONTRACT_ID=C... RPC_URL=https://soroban-testnet.stellar.org make indexer-dev

# Build the Docker image only
make indexer-build

# Tail logs from a running indexer
make indexer-logs
```

## Design Notes

- Uses `docker compose` (v2 CLI) consistent with the existing `docker-compose.yml` at the project root
- Targets delegate entirely to `indexer/docker-compose.yml` — no changes to the indexer source, Dockerfile, or compose config
- `indexer-dev` starts only the `db` and `indexer` services (the `seed` service has `restart: "no"` and runs independently)
- `indexer-logs` follows the `indexer` service specifically, not the full stack
- No new dependencies introduced

## Acceptance Criteria

- [x] `make indexer-dev` starts the indexer with `docker compose up`
- [x] `make indexer-build` builds the indexer Docker image
- [x] `make indexer-logs` tails the indexer container logs
- [x] All targets follow existing Makefile conventions (`.PHONY`, `help`, inline comments)
- [x] No changes to indexer source, Dockerfile, or docker-compose config
- [x] No breaking changes to existing targets