### PR TITLE
docs: add Fee Estimation section to integration guide

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -659,4 +659,168 @@ Use this table to map error codes directly to UI copy:
 
 ---
 
+## 7. Fee Estimation
+
+TrustLink involves two distinct fees that integrators should surface to users before submitting a transaction:
+
+| Fee type | What it is | How to obtain it |
+|---|---|---|
+| **Stellar network fee** | XLM paid to validators for transaction inclusion | Returned by `simulateTransaction` |
+| **Attestation fee** | Token amount charged by the TrustLink contract (if configured by admin) | Returned by `get_fee_config` |
+
+### Stellar Network Fee via `simulateTransaction`
+
+Call `simulateTransaction` before submitting. The simulation result contains the minimum resource fee the network will accept.
+
+```typescript
+import {
+  Contract,
+  Networks,
+  TransactionBuilder,
+  SorobanRpc,
+  nativeToScVal,
+} from "@stellar/stellar-sdk";
+
+const server = new SorobanRpc.Server("https://soroban-testnet.stellar.org");
+const CONTRACT_ID = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCN8";
+
+async function estimateNetworkFee(
+  issuerPublicKey: string,
+  subjectAddress: string,
+  claimType: string
+): Promise<{ networkFeeLumens: string; minResourceFee: string }> {
+  const contract = new Contract(CONTRACT_ID);
+
+  const operation = contract.call(
+    "create_attestation",
+    nativeToScVal(issuerPublicKey, { type: "address" }),
+    nativeToScVal(subjectAddress, { type: "address" }),
+    nativeToScVal(claimType, { type: "string" }),
+    nativeToScVal(null, { type: "void" }), // no expiration
+    nativeToScVal(null, { type: "void" })  // no metadata
+  );
+
+  const account = await server.getAccount(issuerPublicKey);
+  const tx = new TransactionBuilder(account, {
+    fee: "100", // base fee in stroops — will be replaced by simulation result
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(operation)
+    .setTimeout(30)
+    .build();
+
+  const simResult = await server.simulateTransaction(tx);
+
+  if (SorobanRpc.Api.isSimulationError(simResult)) {
+    throw new Error(`Simulation failed: ${simResult.error}`);
+  }
+
+  // minResourceFee is in stroops (1 XLM = 10_000_000 stroops)
+  const minResourceFee = simResult.minResourceFee ?? "0";
+  const networkFeeLumens = (parseInt(minResourceFee, 10) / 1e7).toFixed(7);
+
+  return { networkFeeLumens, minResourceFee };
+}
+
+// Usage
+const { networkFeeLumens } = await estimateNetworkFee(
+  issuerKeypair.publicKey(),
+  "GABC...XYZ",
+  "KYC_PASSED"
+);
+console.log(`Estimated network fee: ${networkFeeLumens} XLM`);
+```
+
+### Attestation Fee (Contract-Level)
+
+If the admin has configured an attestation fee, `create_attestation` will transfer tokens from the issuer to the fee collector. Fetch the current fee config before prompting the user:
+
+```typescript
+async function getAttestationFee(callerPublicKey: string): Promise<{
+  feeEnabled: boolean;
+  amount: bigint;
+  tokenAddress: string | null;
+  collectorAddress: string;
+} | null> {
+  const contract = new Contract(CONTRACT_ID);
+
+  const operation = contract.call("get_fee_config");
+
+  const account = await server.getAccount(callerPublicKey);
+  const tx = new TransactionBuilder(account, {
+    fee: "100",
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(operation)
+    .setTimeout(30)
+    .build();
+
+  const simResult = await server.simulateTransaction(tx);
+
+  if (SorobanRpc.Api.isSimulationError(simResult)) {
+    throw new Error(`Simulation failed: ${simResult.error}`);
+  }
+
+  const retval = simResult.result?.retval;
+  if (!retval) return null;
+
+  const config = scValToNative(retval) as {
+    attestation_fee: bigint;
+    fee_collector: string;
+    fee_token: string | null;
+  };
+
+  return {
+    feeEnabled: config.attestation_fee > 0n,
+    amount: config.attestation_fee,
+    tokenAddress: config.fee_token,
+    collectorAddress: config.fee_collector,
+  };
+}
+
+// Usage
+const attestationFee = await getAttestationFee(issuerKeypair.publicKey());
+
+if (attestationFee?.feeEnabled) {
+  console.log(
+    `Attestation fee: ${attestationFee.amount} token units`,
+    `(token: ${attestationFee.tokenAddress})`
+  );
+} else {
+  console.log("No attestation fee configured.");
+}
+```
+
+### Displaying Both Fees to Users
+
+Combine both estimates before asking the user to sign:
+
+```typescript
+async function estimateCreateAttestationCost(
+  issuerPublicKey: string,
+  subjectAddress: string,
+  claimType: string
+) {
+  const [networkFee, attestationFee] = await Promise.all([
+    estimateNetworkFee(issuerPublicKey, subjectAddress, claimType),
+    getAttestationFee(issuerPublicKey),
+  ]);
+
+  console.log(`Network fee:     ~${networkFee.networkFeeLumens} XLM`);
+
+  if (attestationFee?.feeEnabled) {
+    console.log(
+      `Attestation fee: ${attestationFee.amount} token units`,
+      `→ paid to ${attestationFee.collectorAddress}`
+    );
+  } else {
+    console.log("Attestation fee: none");
+  }
+}
+```
+
+> **Note:** `simulateTransaction` reflects the fee at simulation time. Network congestion can cause the actual fee to differ slightly. Use `SorobanRpc.assembleTransaction` to apply the simulation's recommended fee before signing.
+
+---
+
 For the full API reference, see the [README](../README.md). For error definitions and type details, see [`src/types.rs`](../src/types.rs).


### PR DESCRIPTION
## Summary

Adds a new **Section 7: Fee Estimation** to `docs/integration-guide.md` so integrators can display fee estimates to users before submitting transactions.

## Changes

- Explains the two distinct fees: Stellar network fee and TrustLink attestation fee
- TypeScript example using `simulateTransaction` to extract `minResourceFee`
- TypeScript example using `get_fee_config` to read the contract-level attestation fee
- Combined helper that fetches both estimates in parallel before prompting the user to sign

## Acceptance Criteria

- [x] Fee Estimation section added explaining how to use `simulate` for fee estimates
- [x] TypeScript code example using the SDK's `simulateTransaction` method
- [x] Attestation fee documented separately from the Stellar network fee

Closes #588