### PR TITLE
ci: add cargo-deny, WASM size check, testnet smoke test, and pin action SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Rust toolchain
         run: rustup show
@@ -19,18 +19,34 @@ jobs:
       - name: Run cargo audit
         run: cargo audit --deny warnings
 
+  deny:
+    name: Dependency Licenses and Advisories
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+
+      - name: Run cargo deny check
+        run: cargo deny check
+
   ci:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Rust toolchain
         run: rustup show
 
       - name: Cache cargo registry and build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry
@@ -64,7 +80,7 @@ jobs:
         run: cargo llvm-cov --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
         with:
           files: ./lcov.info
           fail_ci_if_error: true
@@ -87,13 +103,13 @@ jobs:
       size_bytes: ${{ steps.measure.outputs.size_bytes }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Rust toolchain
         run: rustup show
 
       - name: Cache cargo registry and build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry
@@ -137,7 +153,7 @@ jobs:
           echo "OK: optimized binary is within the 100 KB limit."
 
       - name: Upload size artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: wasm-size-${{ github.sha }}
           path: wasm-size.txt
@@ -153,7 +169,7 @@ jobs:
       actions: read
     steps:
       - name: Download current size artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           name: wasm-size-${{ github.sha }}
           path: current
@@ -175,7 +191,7 @@ jobs:
           fi
 
       - name: Post PR comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const fs = require('fs');
@@ -222,13 +238,13 @@ jobs:
     needs: ci
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Rust toolchain
         run: rustup show
 
       - name: Cache cargo registry and build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/deploy-dapp.yml
+++ b/.github/workflows/deploy-dapp.yml
@@ -13,9 +13,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
           node-version: '20'
           cache: 'npm'
@@ -33,7 +33,7 @@ jobs:
         run: npm run build
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: examples/react-app/dist

--- a/.github/workflows/docs-sdk.yml
+++ b/.github/workflows/docs-sdk.yml
@@ -19,9 +19,9 @@ jobs:
     name: Generate TypeDoc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -36,7 +36,7 @@ jobs:
         run: npm run docs
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: sdk/typescript/docs/api
 
@@ -50,4 +50,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/publish-indexer.yml
+++ b/.github/workflows/publish-indexer.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -25,7 +25,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ghcr.io/${{ github.repository }}/indexer
           tags: |
@@ -34,7 +34,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ./indexer
           push: true

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
@@ -52,6 +52,6 @@ jobs:
           "
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: bindings/python/dist/

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.ref }}
 
@@ -25,7 +25,7 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
 
       - name: Cache cargo registry and build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry
@@ -63,7 +63,7 @@ jobs:
           file target/wasm32-unknown-unknown/release/trustlink.optimized.wasm
 
       - name: Upload WASM artifact to release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           files: |
             target/wasm32-unknown-unknown/release/trustlink.wasm
@@ -94,12 +94,12 @@ jobs:
     needs: build-and-publish
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.ref }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,1 +1,161 @@
-name: Publish TypeScript SDK\n\non:\n  release:\n    types: [published]\n  workflow_dispatch:\n    inputs:\n      version:\n        description: 'Version to publish (e.g., 1.2.3)'\n        required: true\n        type: string\n      tag:\n        description: 'npm tag (latest, beta, alpha)'\n        required: false\n        default: 'latest'\n        type: choice\n        options:\n          - latest\n          - beta\n          - alpha\n\npermissions:\n  contents: read\n  id-token: write # Required for npm provenance\n\njobs:\n  publish-sdk:\n    name: Build and Publish TypeScript SDK\n    runs-on: ubuntu-latest\n    \n    steps:\n      - name: Checkout repository\n        uses: actions/checkout@v4\n\n      - name: Setup Node.js\n        uses: actions/setup-node@v4\n        with:\n          node-version: '20'\n          registry-url: 'https://registry.npmjs.org'\n          cache: 'npm'\n          cache-dependency-path: 'sdk/typescript/package-lock.json'\n\n      - name: Install dependencies\n        working-directory: sdk/typescript\n        run: npm ci\n\n      - name: Determine version\n        id: version\n        run: |\n          if [ \"${{ github.event_name }}\" = \"release\" ]; then\n            # Extract version from git tag (e.g., v1.2.3 -> 1.2.3)\n            VERSION=${GITHUB_REF#refs/tags/v}\n            TAG=\"latest\"\n          else\n            # Use manual input\n            VERSION=\"${{ github.event.inputs.version }}\"\n            TAG=\"${{ github.event.inputs.tag }}\"\n          fi\n          echo \"version=$VERSION\" >> $GITHUB_OUTPUT\n          echo \"tag=$TAG\" >> $GITHUB_OUTPUT\n          echo \"Publishing version: $VERSION with tag: $TAG\"\n\n      - name: Update package.json version\n        working-directory: sdk/typescript\n        run: |\n          npm version ${{ steps.version.outputs.version }} --no-git-tag-version\n          echo \"Updated package.json to version ${{ steps.version.outputs.version }}\"\n\n      - name: Build TypeScript SDK\n        working-directory: sdk/typescript\n        run: npm run build\n\n      - name: Run type check\n        working-directory: sdk/typescript\n        run: npx tsc --noEmit\n\n      - name: Verify build output\n        working-directory: sdk/typescript\n        run: |\n          echo \"Build output:\"\n          ls -la dist/\n          echo \"\"\n          echo \"Package contents (dry run):\"\n          npm pack --dry-run\n          echo \"\"\n          echo \"Package size:\"\n          npm pack --silent | xargs ls -lh\n\n      - name: Check if version already exists on npm\n        id: check-version\n        working-directory: sdk/typescript\n        run: |\n          if npm view @trustlink/sdk@${{ steps.version.outputs.version }} version 2>/dev/null; then\n            echo \"exists=true\" >> $GITHUB_OUTPUT\n            echo \"Version ${{ steps.version.outputs.version }} already exists on npm\"\n          else\n            echo \"exists=false\" >> $GITHUB_OUTPUT\n            echo \"Version ${{ steps.version.outputs.version }} does not exist on npm\"\n          fi\n\n      - name: Publish to npm\n        if: steps.check-version.outputs.exists == 'false'\n        working-directory: sdk/typescript\n        run: |\n          npm publish --tag ${{ steps.version.outputs.tag }} --provenance --access public\n          echo \"Successfully published @trustlink/sdk@${{ steps.version.outputs.version }}\"\n        env:\n          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}\n\n      - name: Skip publishing (version exists)\n        if: steps.check-version.outputs.exists == 'true'\n        run: |\n          echo \"⚠️ Skipping publish: @trustlink/sdk@${{ steps.version.outputs.version }} already exists on npm\"\n          echo \"If you need to republish, increment the version number.\"\n\n      - name: Create job summary\n        run: |\n          echo \"## TypeScript SDK Publication\" >> $GITHUB_STEP_SUMMARY\n          echo \"\" >> $GITHUB_STEP_SUMMARY\n          if [ \"${{ steps.check-version.outputs.exists }}\" = \"false\" ]; then\n            echo \"✅ **Successfully published @trustlink/sdk@${{ steps.version.outputs.version }}**\" >> $GITHUB_STEP_SUMMARY\n            echo \"\" >> $GITHUB_STEP_SUMMARY\n            echo \"### Installation\" >> $GITHUB_STEP_SUMMARY\n            echo \"\\`\\`\\`bash\" >> $GITHUB_STEP_SUMMARY\n            echo \"npm install @trustlink/sdk@${{ steps.version.outputs.version }}\" >> $GITHUB_STEP_SUMMARY\n            echo \"\\`\\`\\`\" >> $GITHUB_STEP_SUMMARY\n            echo \"\" >> $GITHUB_STEP_SUMMARY\n            echo \"### Links\" >> $GITHUB_STEP_SUMMARY\n            echo \"- [View on npm](https://www.npmjs.com/package/@trustlink/sdk/v/${{ steps.version.outputs.version }})\" >> $GITHUB_STEP_SUMMARY\n            echo \"- [Documentation](https://github.com/${{ github.repository }}/tree/main/sdk/typescript)\" >> $GITHUB_STEP_SUMMARY\n          else\n            echo \"⚠️ **Version ${{ steps.version.outputs.version }} already exists on npm**\" >> $GITHUB_STEP_SUMMARY\n            echo \"\" >> $GITHUB_STEP_SUMMARY\n            echo \"Publication was skipped. To publish a new version:\" >> $GITHUB_STEP_SUMMARY\n            echo \"1. Increment the version number\" >> $GITHUB_STEP_SUMMARY\n            echo \"2. Create a new release or run this workflow again\" >> $GITHUB_STEP_SUMMARY\n          fi\n\n      - name: Post to Slack (on success)\n        if: success() && steps.check-version.outputs.exists == 'false' && env.SLACK_WEBHOOK_URL != ''\n        uses: 8398a7/action-slack@v3\n        with:\n          status: success\n          text: |\n            🚀 TypeScript SDK published!\n            📦 @trustlink/sdk@${{ steps.version.outputs.version }}\n            🔗 https://www.npmjs.com/package/@trustlink/sdk\n        env:\n          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}\n\n      - name: Post to Slack (on failure)\n        if: failure() && env.SLACK_WEBHOOK_URL != ''\n        uses: 8398a7/action-slack@v3\n        with:\n          status: failure\n          text: |\n            ❌ TypeScript SDK publication failed!\n            Version: ${{ steps.version.outputs.version }}\n            Check the workflow logs for details.\n        env:\n          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}\n
+name: Publish TypeScript SDK
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 1.2.3)'
+        required: true
+        type: string
+      tag:
+        description: 'npm tag (latest, beta, alpha)'
+        required: false
+        default: 'latest'
+        type: choice
+        options:
+          - latest
+          - beta
+          - alpha
+
+permissions:
+  contents: read
+  id-token: write # Required for npm provenance
+
+jobs:
+  publish-sdk:
+    name: Build and Publish TypeScript SDK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: 'sdk/typescript/package-lock.json'
+
+      - name: Install dependencies
+        working-directory: sdk/typescript
+        run: npm ci
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            # Extract version from git tag (e.g., v1.2.3 -> 1.2.3)
+            VERSION=${GITHUB_REF#refs/tags/v}
+            TAG="latest"
+          else
+            # Use manual input
+            VERSION="${{ github.event.inputs.version }}"
+            TAG="${{ github.event.inputs.tag }}"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "Publishing version: $VERSION with tag: $TAG"
+
+      - name: Update package.json version
+        working-directory: sdk/typescript
+        run: |
+          npm version ${{ steps.version.outputs.version }} --no-git-tag-version
+          echo "Updated package.json to version ${{ steps.version.outputs.version }}"
+
+      - name: Build TypeScript SDK
+        working-directory: sdk/typescript
+        run: npm run build
+
+      - name: Run type check
+        working-directory: sdk/typescript
+        run: npx tsc --noEmit
+
+      - name: Verify build output
+        working-directory: sdk/typescript
+        run: |
+          echo "Build output:"
+          ls -la dist/
+          echo ""
+          echo "Package contents (dry run):"
+          npm pack --dry-run
+          echo ""
+          echo "Package size:"
+          npm pack --silent | xargs ls -lh
+
+      - name: Check if version already exists on npm
+        id: check-version
+        working-directory: sdk/typescript
+        run: |
+          if npm view @trustlink/sdk@${{ steps.version.outputs.version }} version 2>/dev/null; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Version ${{ steps.version.outputs.version }} already exists on npm"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Version ${{ steps.version.outputs.version }} does not exist on npm"
+          fi
+
+      - name: Publish to npm
+        if: steps.check-version.outputs.exists == 'false'
+        working-directory: sdk/typescript
+        run: |
+          npm publish --tag ${{ steps.version.outputs.tag }} --provenance --access public
+          echo "Successfully published @trustlink/sdk@${{ steps.version.outputs.version }}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Skip publishing (version exists)
+        if: steps.check-version.outputs.exists == 'true'
+        run: |
+          echo "Skipping publish: @trustlink/sdk@${{ steps.version.outputs.version }} already exists on npm"
+          echo "If you need to republish, increment the version number."
+
+      - name: Create job summary
+        run: |
+          echo "## TypeScript SDK Publication" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.check-version.outputs.exists }}" = "false" ]; then
+            echo "Published @trustlink/sdk@${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Installation" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+            echo "npm install @trustlink/sdk@${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Links" >> $GITHUB_STEP_SUMMARY
+            echo "- [View on npm](https://www.npmjs.com/package/@trustlink/sdk/v/${{ steps.version.outputs.version }})" >> $GITHUB_STEP_SUMMARY
+            echo "- [Documentation](https://github.com/${{ github.repository }}/tree/main/sdk/typescript)" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Version ${{ steps.version.outputs.version }} already exists on npm — publication skipped." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "To publish a new version:" >> $GITHUB_STEP_SUMMARY
+            echo "1. Increment the version number" >> $GITHUB_STEP_SUMMARY
+            echo "2. Create a new release or run this workflow again" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Post to Slack (on success)
+        if: success() && steps.check-version.outputs.exists == 'false' && env.SLACK_WEBHOOK_URL != ''
+        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
+        with:
+          status: success
+          text: |
+            TypeScript SDK published!
+            @trustlink/sdk@${{ steps.version.outputs.version }}
+            https://www.npmjs.com/package/@trustlink/sdk
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Post to Slack (on failure)
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
+        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
+        with:
+          status: failure
+          text: |
+            TypeScript SDK publication failed!
+            Version: ${{ steps.version.outputs.version }}
+            Check the workflow logs for details.
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - name: Create Release PR
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -12,20 +12,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Rust toolchain
         run: rustup show
 
       - name: Cache cargo registry
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
 
       - name: Run cargo audit
         run: cargo audit --deny warnings
 
       - name: Create issue on audit failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const title = '🔒 Security Audit Failed - New Vulnerabilities Detected';

--- a/.github/workflows/testnet-smoke.yml
+++ b/.github/workflows/testnet-smoke.yml
@@ -1,0 +1,135 @@
+name: Testnet Smoke Test
+
+on:
+  push:
+    branches:
+      - 'release/**'
+  workflow_dispatch:
+
+jobs:
+  smoke-test:
+    name: Deploy and smoke-test on Stellar testnet
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      NETWORK: testnet
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Cache cargo registry and build artifacts
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-smoke-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install binaryen (wasm-opt)
+        run: sudo apt-get install -y binaryen
+
+      - name: Build optimized WASM
+        run: |
+          cargo build --target wasm32-unknown-unknown --release
+          wasm-opt -Oz --enable-bulk-memory --strip-debug \
+            target/wasm32-unknown-unknown/release/trustlink.wasm \
+            -o target/wasm32-unknown-unknown/release/trustlink.optimized.wasm
+          echo "Optimized WASM size: $(stat -c%s target/wasm32-unknown-unknown/release/trustlink.optimized.wasm) bytes"
+
+      - name: Install Stellar CLI
+        run: cargo install --locked stellar-cli --features opt
+
+      - name: Generate ephemeral admin key and fund via Friendbot
+        run: |
+          stellar keys generate smoke-admin --network testnet
+          ADMIN_ADDRESS=$(stellar keys address smoke-admin)
+          echo "ADMIN_ADDRESS=${ADMIN_ADDRESS}" >> "$GITHUB_ENV"
+          curl -sf "https://friendbot.stellar.org/?addr=${ADMIN_ADDRESS}" -o /dev/null
+          echo "Admin funded: ${ADMIN_ADDRESS}"
+
+      - name: Deploy contract to testnet
+        run: |
+          CONTRACT_ID=$(stellar contract deploy \
+            --wasm target/wasm32-unknown-unknown/release/trustlink.optimized.wasm \
+            --source smoke-admin \
+            --network testnet)
+          echo "CONTRACT_ID=${CONTRACT_ID}" >> "$GITHUB_ENV"
+          echo "Contract deployed: ${CONTRACT_ID}"
+
+      - name: Smoke test — initialize
+        run: |
+          stellar contract invoke \
+            --id "$CONTRACT_ID" \
+            --source smoke-admin \
+            --network testnet \
+            -- initialize \
+            --admin "$ADMIN_ADDRESS" \
+            --ttl_days null
+          echo "initialize: OK"
+
+      - name: Smoke test — register_issuer
+        run: |
+          stellar keys generate smoke-issuer --network testnet
+          ISSUER_ADDRESS=$(stellar keys address smoke-issuer)
+          echo "ISSUER_ADDRESS=${ISSUER_ADDRESS}" >> "$GITHUB_ENV"
+          curl -sf "https://friendbot.stellar.org/?addr=${ISSUER_ADDRESS}" -o /dev/null
+          stellar contract invoke \
+            --id "$CONTRACT_ID" \
+            --source smoke-admin \
+            --network testnet \
+            -- register_issuer \
+            --admin "$ADMIN_ADDRESS" \
+            --issuer "$ISSUER_ADDRESS"
+          echo "register_issuer: OK — issuer: ${ISSUER_ADDRESS}"
+
+      - name: Smoke test — create_attestation
+        run: |
+          stellar keys generate smoke-subject --network testnet
+          SUBJECT_ADDRESS=$(stellar keys address smoke-subject)
+          echo "SUBJECT_ADDRESS=${SUBJECT_ADDRESS}" >> "$GITHUB_ENV"
+          ATTESTATION_ID=$(stellar contract invoke \
+            --id "$CONTRACT_ID" \
+            --source smoke-issuer \
+            --network testnet \
+            -- create_attestation \
+            --issuer "$ISSUER_ADDRESS" \
+            --subject "$SUBJECT_ADDRESS" \
+            --claim_type '"SMOKE_TEST"' \
+            --expiration null \
+            --metadata null \
+            --tags null | tr -d '"')
+          echo "ATTESTATION_ID=${ATTESTATION_ID}" >> "$GITHUB_ENV"
+          echo "create_attestation: OK — id: ${ATTESTATION_ID}"
+
+      - name: Smoke test — has_valid_claim
+        run: |
+          RESULT=$(stellar contract invoke \
+            --id "$CONTRACT_ID" \
+            --source smoke-admin \
+            --network testnet \
+            -- has_valid_claim \
+            --subject "$SUBJECT_ADDRESS" \
+            --claim_type '"SMOKE_TEST"')
+          echo "has_valid_claim returned: ${RESULT}"
+          if [ "$RESULT" != "true" ]; then
+            echo "ERROR: has_valid_claim returned '${RESULT}', expected 'true'"
+            exit 1
+          fi
+          echo "has_valid_claim: OK"
+
+      - name: Cleanup ephemeral keys
+        if: always()
+        run: |
+          stellar keys rm smoke-admin   2>/dev/null || true
+          stellar keys rm smoke-issuer  2>/dev/null || true
+          stellar keys rm smoke-subject 2>/dev/null || true

--- a/.github/workflows/validate-commits.yml
+++ b/.github/workflows/validate-commits.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Validate commit messages
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         with:
           types: |
             feat
@@ -28,6 +28,6 @@ jobs:
           requireScope: false
           subjectPattern: ^(?![A-Z]).+[^.]$
           subjectPatternError: |
-            The subject "{subject}" found in the pull request title "{title}" doesn't match the configured pattern. 
+            The subject "{subject}" found in the pull request title "{title}" doesn't match the configured pattern.
             Please ensure the subject starts with a lowercase letter and doesn't end with a period.
           validateSingleCommit: false

--- a/deny.toml
+++ b/deny.toml
@@ -32,6 +32,7 @@ version = 2
 allow = [
     "MIT",
     "Apache-2.0",
+    "ISC",
     "BSD-2-Clause",
     "BSD-3-Clause",
     # Additional identifiers required by the current dependency tree:


### PR DESCRIPTION


Resolves four CI hardening issues:

### #371 — cargo-deny for license and vulnerability scanning
- Added ISC to the allowed license list in deny.toml (MIT, Apache-2.0, ISC were the three specified in the issue).
- Added a dedicated `deny` job to ci.yml that installs cargo-deny and runs `cargo deny check` on every push/PR. Runs in parallel with the existing `audit` job. The deny.toml already covered advisories, license compliance, banned crates, and source restrictions.

### #370 — WASM size regression check
- The `wasm-size` job (builds optimized WASM, fails if > 100 KB) and `pr-size-comment` job (posts delta vs main as a PR comment) were already present in ci.yml. This PR closes the tracking issue.

### #372 — Testnet deployment smoke test
- Added .github/workflows/testnet-smoke.yml triggered on push to release/** branches and via workflow_dispatch.
- Builds and optimizes the WASM binary, then deploys an ephemeral contract instance to the Stellar testnet using a Friendbot-funded throwaway key.
- Smoke-tests the four contract entry points in order: initialize → register_issuer → create_attestation → has_valid_claim
- Cleans up all ephemeral key aliases on exit (always runs).

### #373 — Pin all GitHub Actions to immutable commit SHAs
- Every `uses:` line across all ten workflow files now references a specific commit SHA with the human-readable version tag as a comment, e.g. actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
- Also fixed publish-sdk.yml which was stored with literal \n escape sequences instead of real newlines; rewritten with correct YAML formatting plus SHA-pinned actions.

Pinned versions:
  actions/checkout          11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
  actions/cache             0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
  actions/upload-artifact   ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
  actions/download-artifact 95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
  actions/github-script     60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
  actions/setup-node        49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
  actions/setup-node        1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
  actions/setup-python      a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
  actions/deploy-pages      d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
  actions/upload-pages-artifact 56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
  Swatinem/rust-cache       9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
  codecov/codecov-action    ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
  docker/login-action       74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
  docker/metadata-action    902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
  docker/build-push-action  263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
  softprops/action-gh-release de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
  googleapis/release-please-action 7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
  amannn/action-semantic-pull-request 0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
  peaceiris/actions-gh-pages 4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
  pypa/gh-action-pypi-publish cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
  8398a7/action-slack       77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0

Closes #371
Closes #370
Closes #372
Closes #373

