### PR TITLE
feat: React app — CSV export, attestation timeline, toast notifications, and template management

### DIFF
--- a/examples/react-app/src/App.tsx
+++ b/examples/react-app/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { connectWallet, getWalletAddress } from "./wallet";
+import { connectWallet, getWalletAddress, disconnectWallet } from "./wallet";
 import { ErrorBoundary } from "./ErrorBoundary";
 import AdminPanel from "./panels/AdminPanel";
 import IssuerPanel from "./panels/IssuerPanel";
@@ -7,6 +7,8 @@ import UserPanel from "./panels/UserPanel";
 import VerifierPanel from "./panels/VerifierPanel";
 import AttestationRequestPanel from "./panels/AttestationRequestPanel";
 import MultiSigPanel from "./panels/MultiSigPanel";
+import { useAttestationSubscription } from "./hooks/useAttestationSubscription";
+import { useToasts, ToastContainer } from "./Toast";
 
 type Tab = "admin" | "issuer" | "user" | "verifier" | "requests" | "multisig";
 
@@ -49,6 +51,9 @@ export default function App() {
     setTab("user");
     setError(null);
   }
+
+  const { toasts, push: pushToast, dismiss: dismissToast } = useToasts();
+  useAttestationSubscription(address, pushToast);
 
   const short = address ? `${address.slice(0, 6)}…${address.slice(-4)}` : "";
 
@@ -109,6 +114,7 @@ export default function App() {
       {tab === "issuer" && <ErrorBoundary><IssuerPanel address={address} /></ErrorBoundary>}
       {tab === "verifier" && <ErrorBoundary><VerifierPanel /></ErrorBoundary>}
       {tab === "admin" && <ErrorBoundary><AdminPanel address={address} /></ErrorBoundary>}
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
     </>
   );
 }

--- a/examples/react-app/src/Toast.tsx
+++ b/examples/react-app/src/Toast.tsx
@@ -1,0 +1,82 @@
+import { useState, useCallback, useEffect, useRef } from "react";
+import { AttestationEvent } from "./hooks/useAttestationSubscription";
+
+export interface Toast {
+  id: number;
+  message: string;
+  type: "created" | "revoked";
+}
+
+let _nextId = 0;
+
+export function useToasts() {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const timers = useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map());
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+    const timer = timers.current.get(id);
+    if (timer) { clearTimeout(timer); timers.current.delete(id); }
+  }, []);
+
+  const push = useCallback((event: AttestationEvent) => {
+    const id = _nextId++;
+    const type = event.type === "attestation_created" ? "created" : "revoked";
+    const action = type === "created" ? "created" : "revoked";
+    const message = `Attestation ${action}: ${event.claim_type} (${event.id.slice(0, 8)}…)`;
+    setToasts((prev) => [...prev.slice(-4), { id, message, type }]);
+    const timer = setTimeout(() => dismiss(id), 5000);
+    timers.current.set(id, timer);
+  }, [dismiss]);
+
+  useEffect(() => {
+    const map = timers.current;
+    return () => { map.forEach(clearTimeout); };
+  }, []);
+
+  return { toasts, push, dismiss };
+}
+
+export function ToastContainer({ toasts, onDismiss }: { toasts: Toast[]; onDismiss: (id: number) => void }) {
+  return (
+    <div style={{
+      position: "fixed",
+      bottom: "1.5rem",
+      right: "1.5rem",
+      display: "flex",
+      flexDirection: "column",
+      gap: "0.5rem",
+      zIndex: 1000,
+      pointerEvents: "none",
+    }}>
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          style={{
+            background: t.type === "created" ? "#052e16" : "#450a0a",
+            border: `1px solid ${t.type === "created" ? "#16a34a" : "#dc2626"}`,
+            borderRadius: "0.5rem",
+            padding: "0.75rem 1rem",
+            color: "#e2e8f0",
+            fontSize: "0.875rem",
+            display: "flex",
+            alignItems: "center",
+            gap: "0.75rem",
+            pointerEvents: "all",
+            minWidth: "280px",
+            maxWidth: "360px",
+          }}
+        >
+          <span style={{ flex: 1 }}>{t.message}</span>
+          <button
+            onClick={() => onDismiss(t.id)}
+            style={{ background: "none", border: "none", color: "#94a3b8", cursor: "pointer", fontSize: "1rem", lineHeight: 1 }}
+            aria-label="Dismiss"
+          >
+            ×
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/examples/react-app/src/contract.ts
+++ b/examples/react-app/src/contract.ts
@@ -322,6 +322,19 @@ export async function getExpiringAttestations(
   );
 }
 
+export type AuditAction = "Created" | "Revoked" | "Renewed" | "Updated" | "Transferred";
+
+export interface AuditEntry {
+  action: AuditAction;
+  actor: string;
+  timestamp: bigint;
+  details: string | null;
+}
+
+export async function getAuditLog(attestationId: string): Promise<AuditEntry[]> {
+  return simulate("get_audit_log", str(attestationId));
+}
+
 export async function renewAttestation(
   issuer: string,
   attestationId: string,
@@ -333,5 +346,66 @@ export async function renewAttestation(
     addr(issuer),
     str(attestationId),
     optU64(newExpiration)
+  );
+}
+
+// ── attestation templates ─────────────────────────────────────────────────────
+
+export interface AttestationTemplate {
+  issuer: string;
+  template_id: string;
+  claim_type: string;
+  metadata: string | null;
+}
+
+export async function createTemplate(
+  issuer: string,
+  templateId: string,
+  claimType: string,
+  metadata: string | null
+): Promise<void> {
+  return invoke(
+    issuer,
+    "create_template",
+    addr(issuer),
+    str(templateId),
+    str(claimType),
+    optStr(metadata)
+  );
+}
+
+export async function deleteTemplate(
+  issuer: string,
+  templateId: string
+): Promise<void> {
+  return invoke(issuer, "delete_template", addr(issuer), str(templateId));
+}
+
+export async function getTemplate(
+  issuer: string,
+  templateId: string
+): Promise<AttestationTemplate> {
+  return simulate("get_template", addr(issuer), str(templateId));
+}
+
+export async function listTemplates(
+  issuer: string
+): Promise<AttestationTemplate[]> {
+  return simulate("list_templates", addr(issuer));
+}
+
+export async function createAttestationFromTemplate(
+  issuer: string,
+  templateId: string,
+  subject: string,
+  expiration: bigint | null
+): Promise<void> {
+  return invoke(
+    issuer,
+    "create_attestation_from_template",
+    addr(issuer),
+    str(templateId),
+    addr(subject),
+    optU64(expiration)
   );
 }

--- a/examples/react-app/src/hooks/useAttestationSubscription.ts
+++ b/examples/react-app/src/hooks/useAttestationSubscription.ts
@@ -1,0 +1,92 @@
+import { useEffect, useRef } from "react";
+
+export interface AttestationEvent {
+  type: "attestation_created" | "attestation_revoked";
+  id: string;
+  subject: string;
+  issuer: string;
+  claim_type: string;
+}
+
+const GQL_SUBSCRIPTION_CREATED = (address: string) => JSON.stringify({
+  id: "sub_created",
+  type: "subscribe",
+  payload: {
+    query: `subscription { onAttestationCreated(subject: "${address}") { id subject issuer claimType } }`,
+  },
+});
+
+const GQL_SUBSCRIPTION_REVOKED = (address: string) => JSON.stringify({
+  id: "sub_revoked",
+  type: "subscribe",
+  payload: {
+    query: `subscription { onAttestationRevoked(subject: "${address}") { id subject issuer claimType } }`,
+  },
+});
+
+export function useAttestationSubscription(
+  address: string | null,
+  onEvent: (event: AttestationEvent) => void
+) {
+  const onEventRef = useRef(onEvent);
+  onEventRef.current = onEvent;
+
+  useEffect(() => {
+    if (!address) return;
+    const indexerUrl = (import.meta as { env: Record<string, string> }).env.VITE_INDEXER_WS_URL;
+    if (!indexerUrl) return;
+
+    const ws = new WebSocket(indexerUrl, "graphql-transport-ws");
+
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ type: "connection_init", payload: {} }));
+    };
+
+    ws.onmessage = (msg: MessageEvent) => {
+      let data: { type: string; id?: string; payload?: { data?: Record<string, unknown> } };
+      try {
+        data = JSON.parse(msg.data as string) as typeof data;
+      } catch {
+        return;
+      }
+
+      if (data.type === "connection_ack") {
+        ws.send(GQL_SUBSCRIPTION_CREATED(address));
+        ws.send(GQL_SUBSCRIPTION_REVOKED(address));
+        return;
+      }
+
+      if (data.type === "next" && data.payload?.data) {
+        const payload = data.payload.data;
+
+        if (data.id === "sub_created" && payload.onAttestationCreated) {
+          const raw = payload.onAttestationCreated as { id: string; subject: string; issuer: string; claimType: string };
+          onEventRef.current({
+            type: "attestation_created",
+            id: raw.id,
+            subject: raw.subject,
+            issuer: raw.issuer,
+            claim_type: raw.claimType,
+          });
+        }
+
+        if (data.id === "sub_revoked" && payload.onAttestationRevoked) {
+          const raw = payload.onAttestationRevoked as { id: string; subject: string; issuer: string; claimType: string };
+          onEventRef.current({
+            type: "attestation_revoked",
+            id: raw.id,
+            subject: raw.subject,
+            issuer: raw.issuer,
+            claim_type: raw.claimType,
+          });
+        }
+      }
+    };
+
+    return () => {
+      if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+        ws.close();
+      }
+    };
+  }, [address]);
+}

--- a/examples/react-app/src/panels/IssuerDashboard.tsx
+++ b/examples/react-app/src/panels/IssuerDashboard.tsx
@@ -7,6 +7,32 @@ import {
 } from "../contract";
 import { useIssuerStats } from "../../../../sdk/react/src";
 
+function exportAttestationsCSV(attestations: Attestation[]) {
+  const header = ["id", "subject", "claim_type", "status", "expiration"];
+  const now = BigInt(Math.floor(Date.now() / 1000));
+  const rows = attestations.map((a) => {
+    const status = a.revoked
+      ? "Revoked"
+      : a.expiration && a.expiration < now
+        ? "Expired"
+        : "Valid";
+    const expiration = a.expiration
+      ? new Date(Number(a.expiration) * 1000).toISOString()
+      : "";
+    return [a.id, a.subject, a.claim_type, status, expiration]
+      .map((v) => `"${String(v).replace(/"/g, '""')}"`)
+      .join(",");
+  });
+  const csv = [header.join(","), ...rows].join("\n");
+  const blob = new Blob([csv], { type: "text/csv" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "attestations.csv";
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 interface Props { address: string; }
 
 export default function IssuerDashboard({ address }: Props) {
@@ -16,6 +42,18 @@ export default function IssuerDashboard({ address }: Props) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [renewing, setRenewing] = useState<Set<string>>(new Set());
+
+  async function handleRenew(id: string, currentExpiration: bigint) {
+    setRenewing((prev) => new Set(prev).add(id));
+    try {
+      const { renewAttestation } = await import("../contract");
+      const newExpiration = currentExpiration + BigInt(30 * 86400);
+      await renewAttestation(address, id, newExpiration);
+      await handleRefresh();
+    } finally {
+      setRenewing((prev) => { const s = new Set(prev); s.delete(id); return s; });
+    }
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -178,9 +216,16 @@ export default function IssuerDashboard({ address }: Props) {
         </div>
       </div>
 
-      <div style={{ marginTop: "2rem", textAlign: "center" }}>
+      <div style={{ marginTop: "2rem", textAlign: "center", display: "flex", gap: "0.75rem", justifyContent: "center" }}>
         <button className="btn btn-outline" onClick={handleRefresh}>
           Refresh
+        </button>
+        <button
+          className="btn btn-outline"
+          onClick={() => exportAttestationsCSV([...recent, ...expiring])}
+          disabled={recent.length === 0 && expiring.length === 0}
+        >
+          Export CSV
         </button>
       </div>
     </div>

--- a/examples/react-app/src/panels/IssuerPanel.tsx
+++ b/examples/react-app/src/panels/IssuerPanel.tsx
@@ -1,12 +1,13 @@
-import { useState } from "react";
-import { createAttestation, revokeAttestation, getSubjectAttestations, Attestation } from "../contract";
+import { useState, useEffect } from "react";
+import { createAttestation, revokeAttestation, getSubjectAttestations, listTemplates, createAttestationFromTemplate, Attestation, AttestationTemplate } from "../contract";
 import { SkeletonAttestationList } from "../SkeletonList";
 import IssuerDashboard from "./IssuerDashboard";
+import TemplatePanel from "./TemplatePanel";
 
 interface Props { address: string; }
 
 export default function IssuerPanel({ address }: Props) {
-  const [tab, setTab] = useState<"dashboard" | "create" | "revoke" | "lookup">("dashboard");
+  const [tab, setTab] = useState<"dashboard" | "create" | "revoke" | "lookup" | "templates">("dashboard");
   const [subject, setSubject] = useState("");
   const [claimType, setClaimType] = useState("");
   const [metadata, setMetadata] = useState("");
@@ -19,6 +20,15 @@ export default function IssuerPanel({ address }: Props) {
   const [lookupAddr, setLookupAddr] = useState("");
   const [attestations, setAttestations] = useState<Attestation[]>([]);
   const [lookupLoading, setLookupLoading] = useState(false);
+
+  const [templates, setTemplates] = useState<AttestationTemplate[]>([]);
+  const [selectedTemplate, setSelectedTemplate] = useState("");
+  const [templateSubject, setTemplateSubject] = useState("");
+  const [templateLoading, setTemplateLoading] = useState(false);
+
+  useEffect(() => {
+    listTemplates(address).then(setTemplates).catch(() => {});
+  }, [address]);
 
   async function handleCreate() {
     if (!subject || !claimType) return;
@@ -47,6 +57,21 @@ export default function IssuerPanel({ address }: Props) {
       setStatus({ type: "error", msg: (e as Error).message });
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function handleFromTemplate() {
+    if (!selectedTemplate || !templateSubject) return;
+    setTemplateLoading(true);
+    setStatus(null);
+    try {
+      await createAttestationFromTemplate(address, selectedTemplate, templateSubject.trim(), null);
+      setStatus({ type: "success", msg: "Attestation created from template." });
+      setTemplateSubject("");
+    } catch (e: unknown) {
+      setStatus({ type: "error", msg: (e as Error).message });
+    } finally {
+      setTemplateLoading(false);
     }
   }
 
@@ -97,8 +122,30 @@ export default function IssuerPanel({ address }: Props) {
           >
             Lookup
           </button>
+          <button
+            className={`tab ${tab === "templates" ? "active" : ""}`}
+            onClick={() => setTab("templates")}
+            style={{ flex: 1, textAlign: "center", padding: "0.5rem" }}
+          >
+            Templates
+          </button>
         </div>
         <IssuerDashboard address={address} />
+      </div>
+    );
+  }
+
+  if (tab === "templates") {
+    return (
+      <div>
+        <div style={{ display: "flex", gap: "0.5rem", marginBottom: "1rem", borderBottom: "1px solid #2d3148", paddingBottom: "0.5rem" }}>
+          {(["dashboard", "create", "revoke", "lookup", "templates"] as const).map((t) => (
+            <button key={t} className={`tab ${tab === t ? "active" : ""}`} onClick={() => setTab(t)} style={{ flex: 1, textAlign: "center", padding: "0.5rem", textTransform: "capitalize" }}>
+              {t}
+            </button>
+          ))}
+        </div>
+        <TemplatePanel address={address} />
       </div>
     );
   }
@@ -135,6 +182,13 @@ export default function IssuerPanel({ address }: Props) {
         >
           Lookup
         </button>
+        <button
+          className={`tab ${tab === "templates" ? "active" : ""}`}
+          onClick={() => setTab("templates")}
+          style={{ flex: 1, textAlign: "center", padding: "0.5rem" }}
+        >
+          Templates
+        </button>
       </div>
 
       {status && <div className={`alert alert-${status.type}`}>{status.msg}</div>}
@@ -154,6 +208,41 @@ export default function IssuerPanel({ address }: Props) {
           <button className="btn btn-primary" disabled={loading || !subject || !claimType} onClick={handleCreate}>
             Create
           </button>
+          {templates.length > 0 && (
+            <div style={{ marginTop: "1.5rem", borderTop: "1px solid #2d3148", paddingTop: "1rem" }}>
+              <h4 style={{ marginBottom: "0.75rem", color: "#94a3b8", fontSize: "0.85rem" }}>Or create from template</h4>
+              <div className="field">
+                <label>Template</label>
+                <select
+                  value={selectedTemplate}
+                  onChange={(e) => setSelectedTemplate(e.target.value)}
+                  style={{ background: "#0f1117", border: "1px solid #2d3148", borderRadius: "0.5rem", padding: "0.5rem 0.75rem", color: "#e2e8f0", width: "100%" }}
+                >
+                  <option value="">Select a template…</option>
+                  {templates.map((t) => (
+                    <option key={t.template_id} value={t.template_id}>
+                      {t.template_id} — {t.claim_type}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="field">
+                <label>Subject Address</label>
+                <input
+                  value={templateSubject}
+                  onChange={(e) => setTemplateSubject(e.target.value)}
+                  placeholder="G..."
+                />
+              </div>
+              <button
+                className="btn btn-outline"
+                disabled={templateLoading || !selectedTemplate || !templateSubject}
+                onClick={handleFromTemplate}
+              >
+                {templateLoading ? "Creating…" : "Create from Template"}
+              </button>
+            </div>
+          )}
         </div>
       )}
 

--- a/examples/react-app/src/panels/TemplatePanel.tsx
+++ b/examples/react-app/src/panels/TemplatePanel.tsx
@@ -1,0 +1,135 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  listTemplates,
+  createTemplate,
+  deleteTemplate,
+  AttestationTemplate,
+} from "../contract";
+
+interface Props { address: string; }
+
+export default function TemplatePanel({ address }: Props) {
+  const [templates, setTemplates] = useState<AttestationTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [status, setStatus] = useState<{ type: "success" | "error"; msg: string } | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [deleting, setDeleting] = useState<Set<string>>(new Set());
+
+  const [templateId, setTemplateId] = useState("");
+  const [claimType, setClaimType] = useState("");
+  const [metadata, setMetadata] = useState("");
+
+  const load = useCallback(() => {
+    setLoading(true);
+    listTemplates(address)
+      .then(setTemplates)
+      .catch((e: unknown) => setStatus({ type: "error", msg: (e as Error).message }))
+      .finally(() => setLoading(false));
+  }, [address]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function handleCreate() {
+    if (!templateId || !claimType) return;
+    setSubmitting(true);
+    setStatus(null);
+    try {
+      await createTemplate(address, templateId.trim(), claimType.trim(), metadata || null);
+      setStatus({ type: "success", msg: "Template created." });
+      setTemplateId(""); setClaimType(""); setMetadata("");
+      load();
+    } catch (e: unknown) {
+      setStatus({ type: "error", msg: (e as Error).message });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleDelete(id: string) {
+    setDeleting((prev) => new Set(prev).add(id));
+    setStatus(null);
+    try {
+      await deleteTemplate(address, id);
+      setStatus({ type: "success", msg: "Template deleted." });
+      load();
+    } catch (e: unknown) {
+      setStatus({ type: "error", msg: (e as Error).message });
+    } finally {
+      setDeleting((prev) => { const s = new Set(prev); s.delete(id); return s; });
+    }
+  }
+
+  return (
+    <div className="panel">
+      <h2>Attestation Templates</h2>
+
+      {status && <div className={`alert alert-${status.type}`}>{status.msg}</div>}
+
+      <div className="card" style={{ marginBottom: "1.5rem" }}>
+        <h3>Create Template</h3>
+        <div className="field">
+          <label>Template ID</label>
+          <input
+            value={templateId}
+            onChange={(e) => setTemplateId(e.target.value)}
+            placeholder="e.g. kyc-standard"
+          />
+        </div>
+        <div className="field">
+          <label>Claim Type</label>
+          <input
+            value={claimType}
+            onChange={(e) => setClaimType(e.target.value)}
+            placeholder="KYC, AML, accredited-investor…"
+          />
+        </div>
+        <div className="field">
+          <label>Metadata (optional)</label>
+          <input
+            value={metadata}
+            onChange={(e) => setMetadata(e.target.value)}
+            placeholder="optional note"
+          />
+        </div>
+        <button
+          className="btn btn-primary"
+          disabled={submitting || !templateId || !claimType}
+          onClick={handleCreate}
+        >
+          {submitting ? "Creating…" : "Create Template"}
+        </button>
+      </div>
+
+      <div className="card">
+        <h3>My Templates</h3>
+        {loading ? (
+          <p className="empty">Loading…</p>
+        ) : templates.length === 0 ? (
+          <p className="empty">No templates yet.</p>
+        ) : (
+          <div className="att-list">
+            {templates.map((t) => (
+              <div key={t.template_id} className="att-item">
+                <div className="row">
+                  <span className="claim">{t.claim_type}</span>
+                  <span className="meta" style={{ fontFamily: "monospace", fontSize: "0.75rem" }}>
+                    {t.template_id}
+                  </span>
+                </div>
+                {t.metadata && <span className="meta">Note: {t.metadata}</span>}
+                <button
+                  className="btn btn-danger"
+                  style={{ marginTop: "0.4rem", fontSize: "0.75rem", padding: "0.2rem 0.6rem" }}
+                  disabled={deleting.has(t.template_id)}
+                  onClick={() => handleDelete(t.template_id)}
+                >
+                  {deleting.has(t.template_id) ? "Deleting…" : "Delete"}
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/examples/react-app/src/panels/UserPanel.tsx
+++ b/examples/react-app/src/panels/UserPanel.tsx
@@ -1,13 +1,51 @@
 import { useState, useEffect } from "react";
-import { getSubjectAttestations, Attestation } from "../contract";
+import { getSubjectAttestations, getAuditLog, Attestation, AuditEntry } from "../contract";
 import { SkeletonAttestationList } from "../SkeletonList";
 
 interface Props { address: string; }
+
+function AttestationTimeline({ attestationId }: { attestationId: string }) {
+  const [log, setLog] = useState<AuditEntry[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getAuditLog(attestationId)
+      .then(setLog)
+      .catch((e: unknown) => setError((e as Error).message))
+      .finally(() => setLoading(false));
+  }, [attestationId]);
+
+  if (loading) return <p className="empty" style={{ fontSize: "0.75rem" }}>Loading history…</p>;
+  if (error) return <p className="empty" style={{ fontSize: "0.75rem", color: "#ef4444" }}>Failed to load history.</p>;
+  if (!log || log.length === 0) return <p className="empty" style={{ fontSize: "0.75rem" }}>No history available.</p>;
+
+  return (
+    <div style={{ marginTop: "0.5rem", borderLeft: "2px solid #2d3148", paddingLeft: "0.75rem" }}>
+      {log.map((entry, i) => (
+        <div key={i} style={{ marginBottom: "0.5rem", position: "relative" }}>
+          <div style={{ position: "absolute", left: "-1rem", top: "0.3rem", width: "0.5rem", height: "0.5rem", borderRadius: "50%", background: "#7c6af7" }} />
+          <div style={{ fontSize: "0.75rem", fontWeight: 600, color: "#e2e8f0" }}>{entry.action}</div>
+          <div style={{ fontSize: "0.7rem", color: "#94a3b8", fontFamily: "monospace" }}>
+            {entry.actor.slice(0, 6)}…{entry.actor.slice(-4)}
+          </div>
+          <div style={{ fontSize: "0.7rem", color: "#64748b" }}>
+            {new Date(Number(entry.timestamp) * 1000).toLocaleString()}
+          </div>
+          {entry.details && (
+            <div style={{ fontSize: "0.7rem", color: "#94a3b8" }}>{entry.details}</div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
 
 export default function UserPanel({ address }: Props) {
   const [attestations, setAttestations] = useState<Attestation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [expandedTimeline, setExpandedTimeline] = useState<string | null>(null);
 
   useEffect(() => {
     setLoading(true);
@@ -53,6 +91,14 @@ export default function UserPanel({ address }: Props) {
               </span>
             )}
             <span className="meta">ID: {a.id}</span>
+            <button
+              className="btn btn-outline"
+              style={{ marginTop: "0.4rem", fontSize: "0.75rem", padding: "0.2rem 0.6rem" }}
+              onClick={() => setExpandedTimeline(expandedTimeline === a.id ? null : a.id)}
+            >
+              {expandedTimeline === a.id ? "Hide History" : "View History"}
+            </button>
+            {expandedTimeline === a.id && <AttestationTimeline attestationId={a.id} />}
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary

This PR implements four features for `examples/react-app` across four focused commits.

---

### #765 — CSV export for issuer attestation lists

**File:** `src/panels/IssuerDashboard.tsx`

- Added a client-side `exportAttestationsCSV()` utility that builds a CSV from the attestations already in memory — no server round-trip.
- Columns exported: `id`, `subject`, `claim_type`, `status`, `expiration`.
- Status is derived at export time (`Valid` / `Revoked` / `Expired`) using the same logic as the badge display.
- "Export CSV" button is placed next to "Refresh" and is disabled when both lists are empty.
- Also fixed a pre-existing crash: `handleRenew` was referenced in the JSX but never defined; the implementation now calls `renewAttestation` from `contract.ts` and refreshes the lists on success.

---

### #764 — Attestation history timeline view in UserPanel

**Files:** `src/panels/UserPanel.tsx`, `src/contract.ts`

- Added `getAuditLog(attestationId)` to `contract.ts`, wrapping the contract's `get_audit_log` entry point (matching the SDK's `AuditEntry` shape: `action`, `actor`, `timestamp`, `details`).
- Each attestation card in `UserPanel` now has a "View History" / "Hide History" toggle button.
- On expand, `AttestationTimeline` fetches the audit log and renders a vertical timeline with a dot marker per entry, showing action, abbreviated actor address, and human-readable timestamp.

---

### #763 — Real-time toast notifications for attestation events

**Files:** `src/hooks/useAttestationSubscription.ts` *(new)*, `src/Toast.tsx` *(new)*, `src/App.tsx`

- `useAttestationSubscription(address, onEvent)` opens a native `WebSocket` to `VITE_INDEXER_WS_URL` using the `graphql-transport-ws` subprotocol. When the connection is acknowledged it subscribes to both `onAttestationCreated` and `onAttestationRevoked` for the connected wallet's address. The socket is torn down on unmount or address change.
- The hook is a no-op when `VITE_INDEXER_WS_URL` is unset, so existing deployments are unaffected.
- `useToasts()` manages a queue of up to 5 toasts with 5-second auto-dismiss and manual close.
- `ToastContainer` renders toasts fixed to the bottom-right corner; green border for `created`, red border for `revoked`.
- Both are wired into `App.tsx`; the subscription runs for the lifetime of the connected session.
- Also fixed a pre-existing import omission: `disconnectWallet` was called in `App.tsx` but never imported.

---

### #760 — TemplatePanel for issuer attestation template management

**Files:** `src/panels/TemplatePanel.tsx` *(new)*, `src/panels/IssuerPanel.tsx`, `src/contract.ts`

- Added template contract bindings to `contract.ts`: `createTemplate`, `deleteTemplate`, `getTemplate`, `listTemplates`, and `createAttestationFromTemplate`.
- `TemplatePanel.tsx` lists all of the issuer's templates and supports creating new ones (template ID, claim type, optional metadata) and deleting existing ones, with per-row loading states.
- `IssuerPanel.tsx` gains a **Templates** tab that renders `TemplatePanel`. The tab is present in both the dashboard early-return path and the main return path.
- The **Create** tab in `IssuerPanel` now shows a "create from template" shortcut section when the issuer has at least one template: a dropdown to pick the template and a subject address field, wired to `createAttestationFromTemplate`.

---

Closes #765
Closes #764
Closes #763
Closes #760