### PR TITLE
feat(indexer): add Template, Delegation, WhitelistEntry, CouncilAction types and GraphQL queries

### DIFF
--- a/indexer/prisma/migrations/0007_add_template_delegation_whitelist_council/migration.sql
+++ b/indexer/prisma/migrations/0007_add_template_delegation_whitelist_council/migration.sql
@@ -1,0 +1,64 @@
+-- CreateTable
+CREATE TABLE "Template" (
+    "id" TEXT NOT NULL,
+    "templateId" TEXT NOT NULL,
+    "issuer" TEXT NOT NULL,
+    "claimType" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Template_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Delegation" (
+    "id" TEXT NOT NULL,
+    "delegator" TEXT NOT NULL,
+    "delegate" TEXT NOT NULL,
+    "claimType" TEXT NOT NULL,
+    "expiresAt" BIGINT NOT NULL,
+    "revoked" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Delegation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "WhitelistEntry" (
+    "id" TEXT NOT NULL,
+    "issuer" TEXT NOT NULL,
+    "subject" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WhitelistEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CouncilAction" (
+    "id" TEXT NOT NULL,
+    "actionId" TEXT NOT NULL,
+    "proposer" TEXT NOT NULL,
+    "approvals" TEXT[],
+    "executed" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CouncilAction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Template_templateId_key" ON "Template"("templateId");
+CREATE INDEX "Template_issuer_idx" ON "Template"("issuer");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Delegation_delegator_delegate_claimType_key" ON "Delegation"("delegator", "delegate", "claimType");
+CREATE INDEX "Delegation_delegator_idx" ON "Delegation"("delegator");
+CREATE INDEX "Delegation_delegate_idx" ON "Delegation"("delegate");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WhitelistEntry_issuer_subject_key" ON "WhitelistEntry"("issuer", "subject");
+CREATE INDEX "WhitelistEntry_issuer_idx" ON "WhitelistEntry"("issuer");
+CREATE INDEX "WhitelistEntry_subject_idx" ON "WhitelistEntry"("subject");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CouncilAction_actionId_key" ON "CouncilAction"("actionId");
+CREATE INDEX "CouncilAction_executed_idx" ON "CouncilAction"("executed");
+CREATE INDEX "CouncilAction_proposer_idx" ON "CouncilAction"("proposer");

--- a/indexer/prisma/schema.prisma
+++ b/indexer/prisma/schema.prisma
@@ -140,3 +140,50 @@ model Endorsement {
   @@index([endorser])
   @@unique([attestationId, endorser])
 }
+
+model Template {
+  id         String   @id @default(cuid())
+  templateId String   @unique
+  issuer     String
+  claimType  String
+  createdAt  DateTime @default(now())
+
+  @@index([issuer])
+}
+
+model Delegation {
+  id        String   @id @default(cuid())
+  delegator String
+  delegate  String
+  claimType String
+  expiresAt BigInt
+  revoked   Boolean  @default(false)
+  createdAt DateTime @default(now())
+
+  @@unique([delegator, delegate, claimType])
+  @@index([delegator])
+  @@index([delegate])
+}
+
+model WhitelistEntry {
+  id        String   @id @default(cuid())
+  issuer    String
+  subject   String
+  createdAt DateTime @default(now())
+
+  @@unique([issuer, subject])
+  @@index([issuer])
+  @@index([subject])
+}
+
+model CouncilAction {
+  id        String   @id @default(cuid())
+  actionId  String   @unique
+  proposer  String
+  approvals String[]
+  executed  Boolean  @default(false)
+  createdAt DateTime @default(now())
+
+  @@index([executed])
+  @@index([proposer])
+}

--- a/indexer/src/graphql.ts
+++ b/indexer/src/graphql.ts
@@ -1,5 +1,5 @@
 import { PubSub } from "graphql-subscriptions";
-import { PrismaClient, Attestation, MultisigProposal, AttestationRequest } from "@prisma/client";
+import { PrismaClient, Attestation, MultisigProposal, AttestationRequest, Template, Delegation, WhitelistEntry, CouncilAction } from "@prisma/client";
 
 export const pubsub = new PubSub();
 export const ATTESTATION_CREATED = "ATTESTATION_CREATED";
@@ -53,6 +53,22 @@ function mapRequest(r: AttestationRequest): MappedRequest {
     createdAt: r.createdAt.toISOString(),
     updatedAt: r.updatedAt.toISOString(),
   };
+}
+
+function mapTemplate(t: Template) {
+  return { ...t, createdAt: t.createdAt.toISOString() };
+}
+
+function mapDelegation(d: Delegation) {
+  return { ...d, expiresAt: String(d.expiresAt), createdAt: d.createdAt.toISOString() };
+}
+
+function mapWhitelistEntry(w: WhitelistEntry) {
+  return { ...w, createdAt: w.createdAt.toISOString() };
+}
+
+function mapCouncilAction(c: CouncilAction) {
+  return { ...c, createdAt: c.createdAt.toISOString() };
 }
 
 export function buildResolvers(db: PrismaClient) {
@@ -211,6 +227,39 @@ export function buildResolvers(db: PrismaClient) {
           timestamp: String(e.timestamp),
           createdAt: e.createdAt.toISOString(),
         }));
+      },
+
+      templates: async (_: unknown, args: { issuer: string }) => {
+        const rows = await db.template.findMany({
+          where: { issuer: args.issuer },
+          orderBy: { createdAt: "asc" },
+        });
+        return rows.map(mapTemplate);
+      },
+
+      delegationsByDelegator: async (_: unknown, args: { delegator: string }) => {
+        const rows = await db.delegation.findMany({
+          where: { delegator: args.delegator },
+          orderBy: { createdAt: "asc" },
+        });
+        return rows.map(mapDelegation);
+      },
+
+      isWhitelisted: async (_: unknown, args: { issuer: string; subject: string }) => {
+        const entry = await db.whitelistEntry.findUnique({
+          where: { issuer_subject: { issuer: args.issuer, subject: args.subject } },
+        });
+        return entry !== null;
+      },
+
+      councilActions: async (_: unknown, args: { executed?: boolean }) => {
+        const where: Record<string, unknown> = {};
+        if (args.executed !== undefined) where.executed = args.executed;
+        const rows = await db.councilAction.findMany({
+          where,
+          orderBy: { createdAt: "desc" },
+        });
+        return rows.map(mapCouncilAction);
       },
     },
 

--- a/indexer/src/indexer.ts
+++ b/indexer/src/indexer.ts
@@ -18,7 +18,7 @@ const START_LEDGER = process.env.START_LEDGER ? parseInt(process.env.START_LEDGE
 const PAGE_LIMIT = 200;
 const POLL_MS = 5_000;
 
-const WATCHED = new Set(["created", "revoked", "imported", "bridged", "ms_prop", "ms_sign", "ms_actv", "iss_reg", "issuer_tier_updated", "att_req", "req_ful", "req_rej", "att_endorsed"]);
+const WATCHED = new Set(["created", "revoked", "imported", "bridged", "ms_prop", "ms_sign", "ms_actv", "iss_reg", "issuer_tier_updated", "att_req", "req_ful", "req_rej", "att_endorsed", "template_created", "template_deleted", "delegation_created", "delegation_revoked", "whitelist_add", "whitelist_remove", "whitelist_bulk_add", "council_propose", "council_approve", "council_execute"]);
 
 let lastLedger = 0;
 
@@ -282,6 +282,127 @@ async function handleEvent(
         endorser,
         timestamp: BigInt(rawTs),
       },
+    });
+    return;
+  }
+
+  if (topicStr === "template_created") {
+    // topics: ["template_created", issuer_address]  data: (template_id, claim_type)
+    const issuer = ev.topic[1] ? String(scValToNative(ev.topic[1])) : "";
+    const templateId = String(data[0]);
+    const claimType = String(data[1]);
+    await db.template.upsert({
+      where: { templateId },
+      update: {},
+      create: { templateId, issuer, claimType },
+    });
+    return;
+  }
+
+  if (topicStr === "template_deleted") {
+    // topics: ["template_deleted"]  data: (template_id)
+    const templateId = String(data[0]);
+    await db.template.deleteMany({ where: { templateId } });
+    return;
+  }
+
+  if (topicStr === "delegation_created") {
+    // topics: ["delegation_created", delegator_address]  data: (delegate, claim_type, expires_at)
+    const delegator = ev.topic[1] ? String(scValToNative(ev.topic[1])) : "";
+    const delegate = String(data[0]);
+    const claimType = String(data[1]);
+    const expiresAt = BigInt(data[2] as bigint | number);
+    await db.delegation.upsert({
+      where: { delegator_delegate_claimType: { delegator, delegate, claimType } },
+      update: { expiresAt, revoked: false },
+      create: { delegator, delegate, claimType, expiresAt, revoked: false },
+    });
+    return;
+  }
+
+  if (topicStr === "delegation_revoked") {
+    // topics: ["delegation_revoked", delegator_address]  data: (delegate, claim_type)
+    const delegator = ev.topic[1] ? String(scValToNative(ev.topic[1])) : "";
+    const delegate = String(data[0]);
+    const claimType = String(data[1]);
+    await db.delegation.updateMany({
+      where: { delegator, delegate, claimType },
+      data: { revoked: true },
+    });
+    return;
+  }
+
+  if (topicStr === "whitelist_add") {
+    // topics: ["whitelist_add", issuer_address]  data: (subject)
+    const issuer = ev.topic[1] ? String(scValToNative(ev.topic[1])) : "";
+    const subject = String(data[0]);
+    await db.whitelistEntry.upsert({
+      where: { issuer_subject: { issuer, subject } },
+      update: {},
+      create: { issuer, subject },
+    });
+    return;
+  }
+
+  if (topicStr === "whitelist_remove") {
+    // topics: ["whitelist_remove", issuer_address]  data: (subject)
+    const issuer = ev.topic[1] ? String(scValToNative(ev.topic[1])) : "";
+    const subject = String(data[0]);
+    await db.whitelistEntry.deleteMany({ where: { issuer, subject } });
+    return;
+  }
+
+  if (topicStr === "whitelist_bulk_add") {
+    // topics: ["whitelist_bulk_add", issuer_address]  data: (subjects[])
+    const issuer = ev.topic[1] ? String(scValToNative(ev.topic[1])) : "";
+    const subjects = (data[0] as unknown[]).map(String);
+    for (const subject of subjects) {
+      await db.whitelistEntry.upsert({
+        where: { issuer_subject: { issuer, subject } },
+        update: {},
+        create: { issuer, subject },
+      });
+    }
+    return;
+  }
+
+  if (topicStr === "council_propose") {
+    // topics: ["council_propose", proposer_address]  data: (action_id)
+    const proposer = ev.topic[1] ? String(scValToNative(ev.topic[1])) : "";
+    const actionId = String(data[0]);
+    await db.councilAction.upsert({
+      where: { actionId },
+      update: {},
+      create: { actionId, proposer, approvals: [proposer], executed: false },
+    });
+    return;
+  }
+
+  if (topicStr === "council_approve") {
+    // topics: ["council_approve", approver_address]  data: (action_id)
+    const approver = ev.topic[1] ? String(scValToNative(ev.topic[1])) : "";
+    const actionId = String(data[0]);
+    const existing = await db.councilAction.findUnique({
+      where: { actionId },
+      select: { approvals: true },
+    });
+    if (!existing) return;
+    const approvals = existing.approvals.includes(approver)
+      ? existing.approvals
+      : [...existing.approvals, approver];
+    await db.councilAction.update({
+      where: { actionId },
+      data: { approvals },
+    });
+    return;
+  }
+
+  if (topicStr === "council_execute") {
+    // topics: ["council_execute"]  data: (action_id)
+    const actionId = String(data[0]);
+    await db.councilAction.updateMany({
+      where: { actionId, executed: false },
+      data: { executed: true },
     });
     return;
   }

--- a/indexer/src/schema.graphql
+++ b/indexer/src/schema.graphql
@@ -128,6 +128,18 @@ type Query {
 
   """List endorsements for an attestation"""
   endorsements(attestationId: String!): [Endorsement!]!
+
+  """List attestation templates for an issuer"""
+  templates(issuer: String!): [Template!]!
+
+  """List delegations authorized by a delegator"""
+  delegationsByDelegator(delegator: String!): [Delegation!]!
+
+  """Check whether a subject is whitelisted by an issuer"""
+  isWhitelisted(issuer: String!, subject: String!): Boolean!
+
+  """List council governance actions, optionally filtered by execution status"""
+  councilActions(executed: Boolean): [CouncilAction!]!
 }
 
 type Subscription {
@@ -177,5 +189,39 @@ type Endorsement {
   attestationId: String!
   endorser: String!
   timestamp: String!
+  createdAt: String!
+}
+
+type Template {
+  id: String!
+  templateId: String!
+  issuer: String!
+  claimType: String!
+  createdAt: String!
+}
+
+type Delegation {
+  id: String!
+  delegator: String!
+  delegate: String!
+  claimType: String!
+  expiresAt: String!
+  revoked: Boolean!
+  createdAt: String!
+}
+
+type WhitelistEntry {
+  id: String!
+  issuer: String!
+  subject: String!
+  createdAt: String!
+}
+
+type CouncilAction {
+  id: String!
+  actionId: String!
+  proposer: String!
+  approvals: [String!]!
+  executed: Boolean!
   createdAt: String!
 }


### PR DESCRIPTION
## Summary

This PR closes four related indexer gaps — attestation templates, sub-issuer delegations, whitelist entries, and council governance actions — none of which were previously indexed or queryable via GraphQL.

---

## Changes by task

### #770 — Template type and `templates` query

**Prisma model** (`indexer/prisma/schema.prisma`)
- Added `Template` model with fields: `id`, `templateId` (unique), `issuer`, `claimType`, `createdAt`
- Index on `issuer` for fast per-issuer lookups

**GraphQL** (`indexer/src/schema.graphql`)
- Added `Template` type
- Added `templates(issuer: String!): [Template!]!` query

**Indexer** (`indexer/src/indexer.ts`)
- Handles `template_created` event: upserts a `Template` row (idempotent replay-safe)
- Handles `template_deleted` event: removes the matching `Template` row

**Resolver** (`indexer/src/graphql.ts`)
- `templates` resolver: queries by issuer, ordered by `createdAt ASC`

---

### #771 — Delegation type and `delegationsByDelegator` query

**Prisma model**
- Added `Delegation` model with fields: `id`, `delegator`, `delegate`, `claimType`, `expiresAt` (BigInt), `revoked`, `createdAt`
- Composite unique index on `(delegator, delegate, claimType)` — one row per delegation relationship
- Indexes on `delegator` and `delegate`

**GraphQL**
- Added `Delegation` type (`expiresAt` exposed as `String!`)
- Added `delegationsByDelegator(delegator: String!): [Delegation!]!` query

**Indexer**
- Handles `delegation_created` event: upserts delegation row; re-activates if previously revoked
- Handles `delegation_revoked` event: sets `revoked = true` on the matching row

**Resolver**
- `delegationsByDelegator` resolver: queries by delegator, ordered by `createdAt ASC`

---

### #772 — WhitelistEntry type and `isWhitelisted` query

**Prisma model**
- Added `WhitelistEntry` model with fields: `id`, `issuer`, `subject`, `createdAt`
- Composite unique index on `(issuer, subject)` — one row per issuer-subject pair
- Indexes on `issuer` and `subject`

**GraphQL**
- Added `WhitelistEntry` type
- Added `isWhitelisted(issuer: String!, subject: String!): Boolean!` query

**Indexer**
- Handles `whitelist_add` event: upserts a `WhitelistEntry` row (idempotent)
- Handles `whitelist_remove` event: deletes the matching row
- Handles `whitelist_bulk_add` event: upserts one row per subject in the payload array

**Resolver**
- `isWhitelisted` resolver: looks up by composite key, returns `true` if row exists

---

### #773 — CouncilAction type and `councilActions` query

**Prisma model**
- Added `CouncilAction` model with fields: `id`, `actionId` (unique), `proposer`, `approvals` (String array), `executed`, `createdAt`
- Indexes on `executed` and `proposer`

**GraphQL**
- Added `CouncilAction` type
- Added `councilActions(executed: Boolean): [CouncilAction!]!` query

**Indexer**
- Handles `council_propose` event: creates a new `CouncilAction` with the proposer seeded into `approvals`
- Handles `council_approve` event: appends the approver to `approvals` idempotently
- Handles `council_execute` event: sets `executed = true` (guard: only if currently `false`)

**Resolver**
- `councilActions` resolver: optionally filters by `executed`, ordered by `createdAt DESC`

---

## Database migration

`indexer/prisma/migrations/0007_add_template_delegation_whitelist_council/migration.sql`

Creates all four tables with their primary keys, unique constraints, and indexes in one migration.

---

## Files changed

| File | What changed |
|------|-------------|
| `indexer/prisma/schema.prisma` | Added 4 new models |
| `indexer/prisma/migrations/0007_.../migration.sql` | DDL for all 4 tables |
| `indexer/src/schema.graphql` | 4 new types + 4 new queries |
| `indexer/src/indexer.ts` | 10 new event handlers added to `WATCHED` and `handleEvent` |
| `indexer/src/graphql.ts` | 4 new resolvers + 4 type-mapping helpers |

---

Closes #770
Closes #771
Closes #772
Closes #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)