### PR TITLE
docs: add SECURITY.md, issue templates, migration guide, and glossary

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug Report
+about: Report a bug in the TrustLink contract, SDKs, or tooling
+title: "[BUG] "
+labels: bug
+assignees: ""
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. 
+2. 
+3. 
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened. Include any error messages, transaction results, or unexpected output.
+
+## Contract Version
+
+Which version of TrustLink are you using?
+
+- [ ] `v0.1.0`
+- [ ] `main` branch (commit: <!-- paste commit SHA -->)
+- [ ] Other: 
+
+## Network
+
+- [ ] Testnet
+- [ ] Mainnet
+- [ ] Local / Sandbox
+
+## Environment
+
+- SDK version (TypeScript / Python):
+- Soroban CLI version:
+- Stellar RPC endpoint:
+
+## Additional Context
+
+Any other context, logs, or screenshots that may help diagnose the issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Propose a new feature or enhancement for TrustLink
+title: "[FEAT] "
+labels: enhancement
+assignees: ""
+---
+
+## Problem Statement
+
+Describe the problem or limitation you are experiencing. What use case is blocked or made harder without this feature?
+
+## Proposed Solution
+
+Describe the feature or change you would like to see. Be as specific as possible — include proposed function signatures, storage changes, or event formats if relevant.
+
+## Alternatives Considered
+
+What other approaches did you consider? Why is the proposed solution preferable?
+
+## Additional Context
+
+Any related issues, prior art from other projects, or design references that support this request.

--- a/.github/ISSUE_TEMPLATE/security_vulnerability.md
+++ b/.github/ISSUE_TEMPLATE/security_vulnerability.md
@@ -1,0 +1,25 @@
+---
+name: Security Vulnerability
+about: Report a security vulnerability in TrustLink
+title: ""
+labels: security
+assignees: ""
+---
+
+<!-- 
+⚠️  STOP — DO NOT file a public issue for security vulnerabilities.
+
+Public disclosure before a patch is available puts all TrustLink users at risk.
+
+Please use one of the private channels described in our security policy:
+
+  • GitHub Private Advisory (preferred):
+    https://github.com/Haroldwonder/TrustLink/security/advisories/new
+
+  • Email:
+    security@trustlink.io
+
+You will receive an acknowledgement within 48 hours.
+
+See SECURITY.md for the full disclosure process and response timeline.
+-->

--- a/README.md
+++ b/README.md
@@ -1021,6 +1021,10 @@ For a step-by-step walkthrough covering Rust cross-contract patterns, JavaScript
 
 For a full reference of every on-chain storage key, the data each holds, TTL policy, serialization format, and a practical RPC read example for indexer developers, see [docs/storage-layout.md](docs/storage-layout.md).
 
+## Glossary
+
+Terms like *attestation*, *issuer*, *subject*, *bridge*, *claim type*, *endorsement*, and *delegation* have specific meanings in TrustLink. See [docs/glossary.md](docs/glossary.md) for definitions of all domain-specific terms.
+
 ## Architecture Decision Records
 
 Key design choices are documented as ADRs in [docs/adr/](docs/adr/):

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,66 @@
+# Security Policy
+
+## Supported Versions
+
+The following versions of TrustLink currently receive security updates:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.1.x   | :white_check_mark: |
+| < 0.1.0 | :x:                |
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+TrustLink supports GitHub's [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability). Use the **"Report a vulnerability"** button on the [Security Advisories](../../security/advisories/new) page of this repository, or email **security@trustlink.io**.
+
+### What to include
+
+- A clear description of the vulnerability
+- Steps to reproduce the issue
+- The potential impact (e.g., unauthorized access, fund loss, data exposure)
+- The affected version(s) and contract function(s)
+- A suggested fix or mitigation, if you have one
+
+### Disclosure process
+
+1. **Submit** your report via private advisory or email.
+2. **Acknowledgement** — you will receive a confirmation within **48 hours**.
+3. **Triage** — the team evaluates severity using the CVSS scoring framework within **5 business days**.
+4. **Remediation** — patches for `HIGH` and `CRITICAL` severity findings are targeted for release within **30 days** of confirmation. Lower-severity issues are addressed in the next scheduled release.
+5. **Disclosure** — a public security advisory is published after the patch is released. Reporters are credited (with consent).
+
+### Severity response targets
+
+| Severity | Acknowledgement | Patch Target |
+| -------- | --------------- | ------------ |
+| CRITICAL | 48 hours        | 30 days      |
+| HIGH     | 48 hours        | 30 days      |
+| MEDIUM   | 48 hours        | Next release |
+| LOW      | 48 hours        | Next release |
+
+## Scope
+
+The following are **in scope** for vulnerability reports:
+
+- The TrustLink Soroban smart contract (`src/`)
+- Authorization logic (admin, issuer, bridge, multi-sig flows)
+- Storage key collisions or data corruption
+- Fee bypass or manipulation
+- Attestation forgery or unauthorized revocation
+- TypeScript and Python SDK bindings that could expose integrators to exploits
+
+The following are **out of scope**:
+
+- Denial-of-service attacks that rely on abnormally high ledger fees
+- Social engineering or phishing
+- Vulnerabilities in third-party dependencies (report those upstream)
+- Issues in example code under `examples/` that do not affect the core contract
+
+## Contact
+
+- **Email:** security@trustlink.io
+- **GitHub Private Advisory:** [Submit here](../../security/advisories/new)
+
+For general questions that are not security-sensitive, open a [GitHub Discussion](../../discussions) or a regular issue.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,182 @@
+# TrustLink Glossary
+
+This glossary defines terms that have specific meanings within TrustLink. Many of these terms overlap with general identity or blockchain vocabulary but carry a more precise meaning in this context.
+
+See also: [Integration Guide](./integration-guide.md) | [Storage Layout](./storage-layout.md) | [Security Model](./security.md)
+
+---
+
+## Admin
+
+The single privileged address that controls the TrustLink contract. The admin can register and remove issuers and bridges, configure fees, manage claim types, and upgrade the contract. There is exactly one admin at any point in time. The admin is set during `initialize` and can be transferred with `transfer_admin`.
+
+Contrast with **issuer** (which creates attestations) and **subject** (which is attested about).
+
+---
+
+## Attestation
+
+A signed, on-chain record that a trusted **issuer** has made a **claim** about a **subject** address. An attestation is identified by a deterministic 32-character hex ID derived from the issuer address, subject address, claim type, and creation timestamp.
+
+An attestation can be in one of four states: **Valid**, **Pending**, **Expired**, or **Revoked**. The state is computed at query time from the stored fields and the current ledger timestamp — it is not stored directly.
+
+```
+{
+  id:           String,          // 32-char hex
+  issuer:       Address,
+  subject:      Address,
+  claim_type:   String,          // e.g. "KYC_PASSED"
+  timestamp:    u64,             // creation time (ledger seconds)
+  expiration:   Option<u64>,     // optional expiry (ledger seconds)
+  revoked:      bool,
+  metadata:     Option<String>,
+  valid_from:   Option<u64>,     // optional future activation time
+  imported:     bool,
+  bridged:      bool,
+  source_chain: Option<String>,
+  source_tx:    Option<String>,
+}
+```
+
+---
+
+## Attestation ID
+
+A deterministic, collision-resistant 32-character hexadecimal string that uniquely identifies an attestation. Derived from a SHA-256 hash of the issuer address, subject address, claim type, and creation timestamp. Because the same issuer can attest the same claim about the same subject more than once (e.g. after the first attestation expires), the timestamp component ensures a fresh ID on each issuance.
+
+---
+
+## Bridge / Bridge Contract
+
+A Soroban smart contract that has been granted the `bridge` role by the admin. Bridge contracts can call `bridge_attestation` to create attestations that originated on another blockchain. The bridge acts as a trusted relay: it vouches that a given claim was verified on the source chain.
+
+Bridged attestations carry `bridged: true`, a `source_chain` identifier (e.g. `"ethereum"`), and a `source_tx` reference (e.g. the originating transaction hash).
+
+---
+
+## Claim
+
+A statement an **issuer** makes about a **subject**. A claim is typed via a `claim_type` string (e.g. `"KYC_PASSED"`, `"ACCREDITED_INVESTOR"`, `"MERCHANT_VERIFIED"`). A single subject may hold many claims from different issuers, of different types, and with different expiry dates.
+
+---
+
+## Claim Type
+
+A string identifier that categorizes a **claim**. Claim types are registered by the admin using `register_claim_type` with a human-readable description. Consuming contracts and frontends look up attestations by claim type.
+
+Well-known claim types used in TrustLink examples:
+
+| Identifier | Meaning |
+| --- | --- |
+| `KYC_PASSED` | Subject has completed Know Your Customer verification |
+| `ACCREDITED_INVESTOR` | Subject qualifies as an accredited investor |
+| `MERCHANT_VERIFIED` | Subject is a verified merchant |
+| `AML_CLEARED` | Subject has passed Anti-Money Laundering screening |
+
+Custom claim types can be registered by the admin for application-specific purposes.
+
+---
+
+## Delegation
+
+The ability for an **issuer** to authorize another address to act on their behalf. TrustLink does not currently implement general delegation, but the **multi-signature attestation** flow (`propose_attestation` / `cosign_attestation`) allows a group of signers to collectively authorize an attestation, which achieves a similar effect for shared-custody issuers.
+
+---
+
+## Endorsement
+
+An informal term for an **attestation** in contexts that emphasize the trust relationship: an issuer *endorses* a subject by attesting a claim about them. The two terms are interchangeable in TrustLink documentation.
+
+---
+
+## Expiration
+
+An optional future timestamp (in ledger seconds) after which an attestation is considered **Expired** and no longer satisfies `has_valid_claim`. An attestation with no expiration remains valid indefinitely (until revoked).
+
+`has_valid_claim` and `get_attestation_status` detect expiration lazily at query time and emit an `attestation_expired` event when an expired attestation is first encountered.
+
+---
+
+## Fee
+
+An optional token-denominated charge that the admin can configure using `set_fee`. When a fee is active, callers of `create_attestation` must hold sufficient balance of the configured fee token; the fee is transferred from the issuer to the `fee_collector` address before the attestation is persisted.
+
+---
+
+## Historical Import
+
+An attestation created via `import_attestation` that records a trust decision made off-chain or before TrustLink was deployed. Imported attestations carry `imported: true` and use a caller-supplied `timestamp` (the original verification date) rather than the current ledger time. Only the admin can call `import_attestation`.
+
+---
+
+## Issuer
+
+An address that has been granted the `issuer` role by the admin and is therefore permitted to call `create_attestation`, `revoke_attestation`, and related functions. Issuers are the entities that perform off-chain verification (KYC, AML checks, merchant onboarding, etc.) and then record the result on-chain as an attestation.
+
+An issuer cannot attest on behalf of another issuer without explicit admin approval. See also **bridge** for cross-chain issuance.
+
+---
+
+## Ledger Timestamp
+
+The `Env::ledger().timestamp()` value in Soroban, expressed as Unix seconds. TrustLink uses ledger timestamps (not block numbers) for attestation creation time, expiration, and `valid_from` fields. Ledger timestamps are deterministic and available on-chain, making them safe for smart contract time comparisons.
+
+---
+
+## Metadata
+
+An optional free-form string field on an attestation that the issuer can use to attach additional context — for example, a jurisdiction code, a reference to an external document, or structured JSON. TrustLink does not interpret this field; consuming contracts and indexers can parse it as needed.
+
+---
+
+## Multi-Signature Attestation
+
+An attestation that requires approval from multiple signers before it is finalized. The flow is:
+
+1. One signer calls `propose_attestation` — creates a `MultisigProposal` with a threshold.
+2. Other signers call `cosign_attestation` to add their approval.
+3. When the number of approvals reaches the threshold, the attestation is automatically created and the proposal is consumed.
+
+This feature supports shared-custody issuers and governance-controlled trust decisions.
+
+---
+
+## Pending
+
+An attestation status indicating that the current ledger time is before the attestation's `valid_from` field. A pending attestation has been issued but is not yet active. `has_valid_claim` returns `false` for pending attestations.
+
+---
+
+## Revocation
+
+The act of marking an attestation as no longer valid by calling `revoke_attestation`. Revoked attestations are not deleted from storage — they remain with `revoked: true` to preserve audit history. `has_valid_claim` returns `false` for revoked attestations, and `get_attestation_status` returns `Revoked`.
+
+Only the issuer who created an attestation can revoke it (or the admin, in emergency cases via batch operations).
+
+---
+
+## Subject
+
+The address that an **attestation** is *about*. The subject is typically a user's wallet address. A subject can hold many attestations from different issuers and of different claim types.
+
+Subjects do not need to take any action to receive an attestation — the issuer creates it unilaterally. Subjects can query their own attestations using `get_subject_attestations`.
+
+---
+
+## TTL (Time-to-Live)
+
+The number of ledger entries remaining before a storage key is evicted from the Soroban ledger. TrustLink refreshes every storage key's TTL to 30 days (518,400 ledgers) whenever it is written. Keys that are never written again will eventually be evicted; consuming contracts should not assume that a key persists forever without activity.
+
+See [docs/storage-layout.md](./storage-layout.md) for full TTL extension behavior.
+
+---
+
+## valid_from
+
+An optional field on an attestation that sets a future activation time. Until the ledger timestamp reaches `valid_from`, the attestation has status **Pending** and does not satisfy `has_valid_claim`. This allows issuers to pre-issue attestations that become active at a scheduled future time.
+
+---
+
+## Version
+
+A semver string stored in instance storage that identifies the deployed contract version. Currently `"1.0.0"`. Readable via `get_version`. Used by indexers and monitoring tools to detect upgrades.

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2,6 +2,8 @@
 
 This guide walks through integrating TrustLink into your dApp — whether you're building a Rust smart contract that needs on-chain claim verification, or a JavaScript/TypeScript frontend that interacts with the contract directly.
 
+For definitions of terms used throughout this guide (attestation, issuer, subject, bridge, claim type, etc.), see the [Glossary](./glossary.md).
+
 ## Testnet Contract
 
 A deployed TrustLink instance is available on Stellar Testnet for immediate testing:

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -1,0 +1,151 @@
+# TrustLink Migration Guide
+
+This guide helps integrators upgrade between TrustLink contract versions. Each section documents breaking changes to the ABI, storage layout, and event format introduced in that release, along with a checklist of steps required to update your integration.
+
+For a full list of changes see the [CHANGELOG](../CHANGELOG.md). For storage internals see [docs/storage-layout.md](./storage-layout.md).
+
+---
+
+## How Soroban contract upgrades work
+
+When the TrustLink admin calls `upgrade(new_wasm_hash)`, the contract's executable code is replaced atomically. **All on-chain storage is preserved** — no keys are deleted or rewritten. The new WASM begins reading the same raw XDR bytes the old WASM wrote.
+
+Adding a new storage key is always safe. Changing the shape of an existing stored struct is a breaking change that requires a `migrate` function to be called once by the admin immediately after `upgrade`.
+
+---
+
+## Version history
+
+| Version | Release date | Breaking changes |
+| ------- | ------------ | ---------------- |
+| 0.1.0   | 2026-03-25   | Initial release — no prior version to migrate from |
+
+---
+
+## v0.1.0 — Initial release
+
+This is the first public release of TrustLink. There is no prior version to migrate from.
+
+### ABI summary
+
+All functions introduced in v0.1.0 are listed in the [CHANGELOG](../CHANGELOG.md#010---2026-03-25). Key entry points for integrators:
+
+| Function | Description |
+| -------- | ----------- |
+| `initialize(admin, ttl_days)` | Deploy and configure the contract |
+| `create_attestation(issuer, subject, claim_type, expiration, metadata)` | Issue a new attestation |
+| `revoke_attestation(issuer, attestation_id)` | Revoke an existing attestation |
+| `has_valid_claim(subject, claim_type)` | Check whether a subject holds a valid claim |
+| `get_attestation(attestation_id)` | Fetch a full attestation record |
+| `bridge_attestation(bridge, ...)` | Create an attestation from a trusted bridge contract |
+
+### Storage keys introduced
+
+All keys described in [docs/storage-layout.md](./storage-layout.md) were introduced in this release:
+
+- `Admin`, `Version`, `FeeConfig` (instance storage)
+- `Issuer(Address)`, `Bridge(Address)`, `Attestation(String)` (persistent)
+- `SubjectAttestations(Address)`, `IssuerAttestations(Address)` (persistent)
+- `IssuerMetadata(Address)`, `ClaimType(String)`, `ClaimTypeList` (persistent)
+
+### Events introduced
+
+| Event name | Emitted by |
+| ---------- | ---------- |
+| `attestation_created` | `create_attestation`, `create_attestations_batch` |
+| `attestation_revoked` | `revoke_attestation`, `revoke_attestations_batch` |
+| `attestation_imported` | `import_attestation` |
+| `attestation_bridged` | `bridge_attestation` |
+| `attestation_expired` | `get_attestation_status`, `has_valid_claim` (lazy detection) |
+| `issuer_registered` | `register_issuer` |
+| `issuer_removed` | `remove_issuer` |
+| `bridge_registered` | `register_bridge` |
+| `fee_updated` | `set_fee` |
+| `claim_type_registered` | `register_claim_type` |
+| `multisig_proposed` | `propose_attestation` |
+| `multisig_cosigned` | `cosign_attestation` |
+| `expiration_hook_registered` | `register_expiration_hook` |
+
+### Integrator checklist — new deployments
+
+- [ ] Pin your SDK version to `v0.1.0` (TypeScript) or `0.1.0` (Python)
+- [ ] Call `initialize(admin, ttl_days)` exactly once; subsequent calls are rejected
+- [ ] Register at least one issuer with `register_issuer` before creating attestations
+- [ ] If using fees, configure with `set_fee` after initialization
+- [ ] Subscribe to the `attestation_created` and `attestation_revoked` event streams if you maintain an off-chain index
+- [ ] Use `has_valid_claim` for on-chain verification in consuming contracts (avoids fetching the full `Attestation` struct)
+
+---
+
+## Upgrading to a future version
+
+When a new version is released, this section will document:
+
+1. **ABI changes** — functions added, removed, or with changed signatures
+2. **Storage changes** — new keys, removed keys, or struct field changes
+3. **Event format changes** — new event fields or renamed events
+4. **Migration steps** — whether a `migrate` function must be called by the admin
+
+### General upgrade procedure
+
+```bash
+# 1. Build the new WASM
+make build
+
+# 2. Upload the new WASM and capture the hash
+NEW_HASH=$(stellar contract upload \
+  --source "$ADMIN_SECRET" \
+  --network mainnet \
+  --wasm target/wasm32-unknown-unknown/release/trustlink.wasm)
+
+# 3. Upgrade the contract (pauses execution while WASM is swapped)
+stellar contract invoke \
+  --id "$CONTRACT_ID" \
+  --source "$ADMIN_SECRET" \
+  --network mainnet \
+  -- upgrade \
+  --admin "$ADMIN_PUBLIC" \
+  --new_wasm_hash "$NEW_HASH"
+
+# 4. If a migrate function exists, call it immediately after upgrade
+stellar contract invoke \
+  --id "$CONTRACT_ID" \
+  --source "$ADMIN_SECRET" \
+  --network mainnet \
+  -- migrate \
+  --admin "$ADMIN_PUBLIC"
+
+# 5. Verify the deployment
+./scripts/verify_deployment.sh
+```
+
+### Integrator checklist for every upgrade
+
+- [ ] Read the migration guide section for the target version before upgrading
+- [ ] Test the upgrade on Testnet against a contract with representative data before Mainnet
+- [ ] Update your SDK dependency to the version matching the new contract
+- [ ] Check for ABI changes — look for renamed functions, new required parameters, or removed functions
+- [ ] Check for storage changes — if struct fields changed, confirm the admin has run `migrate`
+- [ ] Check for event format changes — update your indexer or event listeners accordingly
+- [ ] Re-run your integration tests after upgrading
+- [ ] Monitor `attestation_created` and `get_attestation` responses for unexpected field values in the first 24 hours after upgrade
+
+---
+
+## SDK compatibility matrix
+
+| Contract version | TypeScript SDK | Python SDK |
+| ---------------- | -------------- | ---------- |
+| 0.1.0            | 0.1.x          | 0.1.x      |
+
+> **Note:** Always use the SDK version that matches the deployed contract version. Using a newer SDK against an older contract (or vice versa) may result in ABI mismatches that produce runtime errors.
+
+---
+
+## Getting help
+
+If you encounter issues during an upgrade:
+
+- Open an issue using the [Bug Report](../.github/ISSUE_TEMPLATE/bug_report.md) template
+- Check [docs/integration-guide.md](./integration-guide.md) for current API documentation
+- For security-sensitive migration issues, use the [private disclosure process](../SECURITY.md)


### PR DESCRIPTION
## Changes

### #592 — Create SECURITY.md with vulnerability disclosure policy
- Added `SECURITY.md` at the repository root with:
  - Supported versions table (v0.1.x supported, older versions unsupported)
  - Disclosure process (private advisory and security@trustlink.io email)
  - Response timeline: acknowledgement within 48 hours, patches for HIGH/CRITICAL within 30 days, lower severity addressed in next scheduled release
  - In-scope and out-of-scope definitions
  - Prompt to enable GitHub private vulnerability reporting

### #597 — Add issue templates for bug reports and feature requests
- Added `.github/ISSUE_TEMPLATE/bug_report.md` with fields: description, steps to reproduce, expected behavior, actual behavior, contract version, network, and environment details
- Added `.github/ISSUE_TEMPLATE/feature_request.md` with fields: problem statement, proposed solution, and alternatives considered
- Added `.github/ISSUE_TEMPLATE/security_vulnerability.md` that redirects reporters to the private disclosure process (GitHub advisory or email) and explicitly blocks public disclosure before a patch is available

### #599 — docs: create a migration guide for upgrading between contract versions
- Added `docs/migration-guide.md` with:
  - Explanation of how Soroban handles storage across WASM upgrades
  - Version history table (v0.1.0 initial release)
  - v0.1.0 ABI summary, storage keys introduced, and events introduced
  - Integrator checklist for new deployments
  - General upgrade procedure with shell commands (upload, upgrade, migrate, verify)
  - Integrator checklist for every future upgrade
  - SDK compatibility matrix

### #600 — docs: add a glossary of TrustLink-specific terms
- Added `docs/glossary.md` defining all domain-specific terms: admin, attestation, attestation ID, bridge, claim, claim type, delegation, endorsement, expiration, fee, historical import, issuer, ledger timestamp, metadata, multi-signature attestation, pending, revocation, subject, TTL, valid_from, and version
- Linked to `docs/glossary.md` from `README.md` (new Glossary section)
- Linked to `docs/glossary.md` from `docs/integration-guide.md` (intro paragraph)

Closes #592
Closes #597
Closes #599
Closes #600

