### PR TITLE
Fix query issues #945 #944 #943 #942

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -248,6 +248,10 @@ pub fn get_decay_config(env: &Env) -> DecayConfig {
     Storage::get_decay_config(env).unwrap_or_default()
 }
 
+pub fn is_decay_config_set(env: &Env) -> bool {
+    Storage::get_decay_config(env).is_some()
+}
+
 pub fn get_issuer_metadata(env: &Env, issuer: Address) -> Option<IssuerMetadata> {
     Storage::get_issuer_metadata(env, &issuer)
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -14,3 +14,6 @@ pub const DEFAULT_INSTANCE_LIFETIME: u32 = DAY_IN_LEDGERS * DEFAULT_TTL_DAYS;
 
 /// Only extend TTL on read if remaining TTL drops below this threshold.
 pub const MIN_TTL_THRESHOLD: u32 = 7 * DAY_IN_LEDGERS;
+
+/// Maximum days for expiring attestations query window (issue #945).
+pub const MAX_EXPIRING_WINDOW_DAYS: u32 = 365;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,11 @@ impl TrustLinkContract {
         admin::get_decay_config(&env)
     }
 
+    #[must_use]
+    pub fn is_decay_config_set(env: Env) -> bool {
+        admin::is_decay_config_set(&env)
+    }
+
     pub fn get_issuer_metadata(env: Env, issuer: Address) -> Option<IssuerMetadata> {
         admin::get_issuer_metadata(&env, issuer)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -596,25 +596,23 @@ impl TrustLinkContract {
         query::get_valid_claim_count(&env, subject)
     }
 
-    #[must_use]
     pub fn get_expiring_attestations(
         env: Env,
         subject: Address,
         within_days: u32,
         start: u32,
         limit: u32,
-    ) -> Vec<Attestation> {
+    ) -> Result<Vec<Attestation>, Error> {
         query::get_expiring_attestations(&env, subject, within_days, start, limit)
     }
 
-    #[must_use]
     pub fn get_issuer_expiring_attestations(
         env: Env,
         issuer: Address,
         days_window: u32,
         start: u32,
         limit: u32,
-    ) -> Vec<Attestation> {
+    ) -> Result<Vec<Attestation>, Error> {
         query::get_issuer_expiring_attestations(&env, issuer, days_window, start, limit)
     }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -252,7 +252,7 @@ pub fn get_attestations_in_range_after(
     if let Some(cursor_id) = after_attestation_id {
         let mut cursor_found = false;
         let mut cursor_timestamp: u64 = 0;
-        let mut cursor_id_ref = cursor_id.clone();
+        let cursor_id_ref = cursor_id.clone();
         if let Ok(cursor_attestation) = Storage::get_attestation(env, &cursor_id) {
             cursor_timestamp = cursor_attestation.timestamp;
             for i in 0..filtered.len() {

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,7 +1,7 @@
 use soroban_sdk::{Address, Env, String, Vec};
 
 use crate::attestation::maybe_trigger_expiration_hook;
-use crate::constants::SECS_PER_DAY;
+use crate::constants::{SECS_PER_DAY, MAX_EXPIRING_WINDOW_DAYS};
 use crate::events::Events;
 use crate::storage::Storage;
 use crate::types::{
@@ -439,13 +439,19 @@ pub fn get_dispute(env: &Env, attestation_id: String) -> Option<DisputeRecord> {
 ///
 /// Excludes already-revoked, already-expired, and None-expiration attestations.
 /// Paginated via `start`/`limit`.
+///
+/// Returns an error if `within_days` exceeds `MAX_EXPIRING_WINDOW_DAYS`.
 pub fn get_expiring_attestations(
     env: &Env,
     subject: Address,
     within_days: u32,
     start: u32,
     limit: u32,
-) -> Vec<Attestation> {
+) -> Result<Vec<Attestation>, Error> {
+    if within_days > MAX_EXPIRING_WINDOW_DAYS {
+        return Err(Error::LimitExceeded);
+    }
+
     let current_time = env.ledger().timestamp();
     let window_end = current_time + (within_days as u64) * SECS_PER_DAY;
 
@@ -483,20 +489,26 @@ pub fn get_expiring_attestations(
     for attestation in paginated.iter() {
         result.push_back(attestation);
     }
-    result
+    Ok(result)
 }
 
 /// Returns issuer's attestations expiring within `days_window` days, sorted by expiration ascending.
 ///
 /// Excludes already-revoked, already-expired, and None-expiration attestations.
 /// Paginated via `start`/`limit`.
+///
+/// Returns an error if `days_window` exceeds `MAX_EXPIRING_WINDOW_DAYS`.
 pub fn get_issuer_expiring_attestations(
     env: &Env,
     issuer: Address,
     days_window: u32,
     start: u32,
     limit: u32,
-) -> Vec<Attestation> {
+) -> Result<Vec<Attestation>, Error> {
+    if days_window > MAX_EXPIRING_WINDOW_DAYS {
+        return Err(Error::LimitExceeded);
+    }
+
     let current_time = env.ledger().timestamp();
     let window_end = current_time + (days_window as u64) * SECS_PER_DAY;
 
@@ -534,7 +546,7 @@ pub fn get_issuer_expiring_attestations(
     for attestation in paginated.iter() {
         result.push_back(attestation);
     }
-    result
+    Ok(result)
 }
 
 /// Submit a dispute against an attestation. Only the subject of the

--- a/src/query.rs
+++ b/src/query.rs
@@ -47,27 +47,20 @@ pub fn has_valid_claim(env: &Env, subject: Address, claim_type: String) -> bool 
 }
 
 pub fn has_valid_claim_from_issuer(env: &Env, subject: Address, claim_type: String, issuer: Address) -> bool {
-    let attestation_ids = Storage::get_subject_attestations(env, &subject);
+    let attestation_ids = Storage::get_valid_attestations(env, &subject);
     let current_time = env.ledger().timestamp();
     for attestation_id in attestation_ids.iter() {
         if let Ok(attestation) = Storage::get_attestation(env, &attestation_id) {
-            if attestation.deleted { continue; }
             if attestation.claim_type == claim_type && attestation.issuer == issuer {
-                match attestation.get_status(current_time) {
-                    AttestationStatus::Valid => {
-                        maybe_trigger_expiration_hook(
-                            env,
-                            &subject,
-                            &attestation_id,
-                            attestation.expiration.unwrap_or(u64::MAX),
-                            current_time,
-                        );
-                        return true;
-                    }
-                    AttestationStatus::Expired => {
-                        Events::attestation_expired(env, &attestation_id, &subject);
-                    }
-                    _ => {}
+                if attestation.get_status(current_time) == AttestationStatus::Valid {
+                    maybe_trigger_expiration_hook(
+                        env,
+                        &subject,
+                        &attestation_id,
+                        attestation.expiration.unwrap_or(u64::MAX),
+                        current_time,
+                    );
+                    return true;
                 }
             }
         }
@@ -79,13 +72,12 @@ pub fn has_any_claim(env: &Env, subject: Address, claim_types: Vec<String>) -> b
     if claim_types.is_empty() {
         return false;
     }
-    let attestation_ids = Storage::get_subject_attestations(env, &subject);
+    let attestation_ids = Storage::get_valid_attestations(env, &subject);
     let current_time = env.ledger().timestamp();
     for claim_type in claim_types.iter() {
         for attestation_id in attestation_ids.iter() {
             if let Ok(attestation) = Storage::get_attestation(env, &attestation_id) {
-                if !attestation.deleted
-                    && attestation.claim_type == claim_type
+                if attestation.claim_type == claim_type
                     && attestation.get_status(current_time) == AttestationStatus::Valid
                 {
                     maybe_trigger_expiration_hook(
@@ -105,13 +97,12 @@ pub fn has_any_claim(env: &Env, subject: Address, claim_types: Vec<String>) -> b
 
 pub fn has_all_claims(env: &Env, subject: Address, claim_types: Vec<String>) -> bool {
     if claim_types.is_empty() { return true; }
-    let attestation_ids = Storage::get_subject_attestations(env, &subject);
+    let attestation_ids = Storage::get_valid_attestations(env, &subject);
     let current_time = env.ledger().timestamp();
     'claims: for claim_type in claim_types.iter() {
         for attestation_id in attestation_ids.iter() {
             if let Ok(attestation) = Storage::get_attestation(env, &attestation_id) {
-                if !attestation.deleted
-                    && attestation.claim_type == claim_type
+                if attestation.claim_type == claim_type
                     && attestation.get_status(current_time) == AttestationStatus::Valid
                 {
                     continue 'claims;

--- a/src/test.rs
+++ b/src/test.rs
@@ -8841,3 +8841,117 @@ fn test_get_attestations_in_range_after_tie_break_ordering_by_id() {
         }
     }
 }
+
+// ── Issue #943: Claim check functions optimization ───────────────────────────
+
+#[test]
+fn test_has_valid_claim_from_issuer_returns_true_for_valid() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, issuer, client) = setup(&env);
+    let subject = Address::generate(&env);
+    let claim_type = String::from_str(&env, "KYC_PASSED");
+
+    client.create_attestation(&issuer, &subject, &claim_type, &None, &None, &None);
+
+    assert!(client.has_valid_claim_from_issuer(&subject, &claim_type, &issuer));
+}
+
+#[test]
+fn test_has_valid_claim_from_issuer_returns_false_for_different_issuer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, issuer, client) = setup(&env);
+    let subject = Address::generate(&env);
+    let other_issuer = Address::generate(&env);
+    let claim_type = String::from_str(&env, "KYC_PASSED");
+
+    client.create_attestation(&issuer, &subject, &claim_type, &None, &None, &None);
+
+    assert!(!client.has_valid_claim_from_issuer(&subject, &claim_type, &other_issuer));
+}
+
+#[test]
+fn test_has_any_claim_returns_true_when_any_exists() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, issuer, client) = setup(&env);
+    let subject = Address::generate(&env);
+    let claim_type1 = String::from_str(&env, "KYC_PASSED");
+    let claim_type2 = String::from_str(&env, "ACCREDITED");
+
+    client.create_attestation(&issuer, &subject, &claim_type1, &None, &None, &None);
+
+    let mut claim_types = soroban_sdk::Vec::new(&env);
+    claim_types.push_back(claim_type2.clone());
+    claim_types.push_back(claim_type1.clone());
+
+    assert!(client.has_any_claim(&subject, &claim_types));
+}
+
+#[test]
+fn test_has_any_claim_returns_false_when_none_exist() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, issuer, client) = setup(&env);
+    let subject = Address::generate(&env);
+    let claim_type1 = String::from_str(&env, "KYC_PASSED");
+    let claim_type2 = String::from_str(&env, "ACCREDITED");
+    let claim_type3 = String::from_str(&env, "VERIFIED");
+
+    client.create_attestation(&issuer, &subject, &claim_type1, &None, &None, &None);
+
+    let mut claim_types = soroban_sdk::Vec::new(&env);
+    claim_types.push_back(claim_type2.clone());
+    claim_types.push_back(claim_type3.clone());
+
+    assert!(!client.has_any_claim(&subject, &claim_types));
+}
+
+#[test]
+fn test_has_all_claims_returns_true_when_all_exist() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, issuer, client) = setup(&env);
+    let subject = Address::generate(&env);
+    let claim_type1 = String::from_str(&env, "KYC_PASSED");
+    let claim_type2 = String::from_str(&env, "ACCREDITED");
+
+    client.create_attestation(&issuer, &subject, &claim_type1, &None, &None, &None);
+    env.ledger().with_mut(|l| l.timestamp += 1);
+    client.create_attestation(&issuer, &subject, &claim_type2, &None, &None, &None);
+
+    let mut claim_types = soroban_sdk::Vec::new(&env);
+    claim_types.push_back(claim_type1.clone());
+    claim_types.push_back(claim_type2.clone());
+
+    assert!(client.has_all_claims(&subject, &claim_types));
+}
+
+#[test]
+fn test_has_all_claims_returns_false_when_not_all_exist() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, issuer, client) = setup(&env);
+    let subject = Address::generate(&env);
+    let claim_type1 = String::from_str(&env, "KYC_PASSED");
+    let claim_type2 = String::from_str(&env, "ACCREDITED");
+    let claim_type3 = String::from_str(&env, "VERIFIED");
+
+    client.create_attestation(&issuer, &subject, &claim_type1, &None, &None, &None);
+    env.ledger().with_mut(|l| l.timestamp += 1);
+    client.create_attestation(&issuer, &subject, &claim_type2, &None, &None, &None);
+
+    let mut claim_types = soroban_sdk::Vec::new(&env);
+    claim_types.push_back(claim_type1.clone());
+    claim_types.push_back(claim_type2.clone());
+    claim_types.push_back(claim_type3.clone());
+
+    assert!(!client.has_all_claims(&subject, &claim_types));
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -8779,3 +8779,65 @@ fn test_get_issuer_expiring_attestations_sorted_by_expiration() {
     assert_eq!(result.get(1).unwrap().expiration, Some(1000 + 10 * 86_400));
     assert_eq!(result.get(2).unwrap().expiration, Some(1000 + 20 * 86_400));
 }
+
+// ── Issue #942: Cursor pagination tie-break ordering ────────────────────────
+
+#[test]
+fn test_get_attestations_in_range_after_tie_break_ordering_by_id() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, issuer, client) = setup(&env);
+    let subject = Address::generate(&env);
+    let claim_type = String::from_str(&env, "KYC_PASSED");
+
+    env.ledger().set_timestamp(5000);
+
+    let _id1 = client.create_attestation(
+        &issuer,
+        &subject,
+        &claim_type,
+        &None,
+        &None,
+        &None,
+    );
+
+    let _id2 = client.create_attestation(
+        &issuer,
+        &subject,
+        &claim_type,
+        &None,
+        &None,
+        &None,
+    );
+
+    let _id3 = client.create_attestation(
+        &issuer,
+        &subject,
+        &claim_type,
+        &None,
+        &None,
+        &None,
+    );
+
+    let all = client.get_attestations_in_range(&subject, &5000, &6000, &0, &10);
+    assert_eq!(all.len(), 3);
+
+    let page1 = client.get_attestations_in_range_after(&subject, &5000, &6000, &None, &2);
+    assert_eq!(page1.len(), 2);
+    let first_cursor_id = page1.get(1).unwrap().id.clone();
+
+    let page2 = client.get_attestations_in_range_after(&subject, &5000, &6000, &Some(first_cursor_id), &2);
+    assert_eq!(page2.len(), 1);
+
+    let mut page1_ids = soroban_sdk::Vec::new(&env);
+    for att in page1.iter() {
+        page1_ids.push_back(att.id.clone());
+    }
+
+    for page2_id in page2.iter() {
+        for page1_id in page1_ids.iter() {
+            assert_ne!(page1_id, &page2_id.id, "ID appeared in both pages");
+        }
+    }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -8955,3 +8955,62 @@ fn test_has_all_claims_returns_false_when_not_all_exist() {
 
     assert!(!client.has_all_claims(&subject, &claim_types));
 }
+
+// ── Issue #944: Distinguish decay configured vs unconfigured ──────────────────
+
+#[test]
+fn test_is_decay_config_set_false_when_not_configured() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, _, client) = setup(&env);
+
+    assert!(!client.is_decay_config_set());
+}
+
+#[test]
+fn test_is_decay_config_set_true_after_configuration() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, _, client) = setup(&env);
+    let config = types::DecayConfig {
+        half_life_days: 90,
+        revocation_weight: 50,
+    };
+
+    client.set_decay_config(&admin, &config);
+    assert!(client.is_decay_config_set());
+}
+
+#[test]
+fn test_get_confidence_score_works_when_decay_configured() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, issuer, client) = setup(&env);
+    let subject = Address::generate(&env);
+    let claim_type = String::from_str(&env, "KYC_PASSED");
+
+    env.ledger().set_timestamp(1000);
+    let attestation_id = client.create_attestation(
+        &issuer,
+        &subject,
+        &claim_type,
+        &None,
+        &None,
+        &None,
+    );
+
+    let score_before = client.get_confidence_score(&attestation_id);
+    assert!(score_before.is_some());
+
+    let config = types::DecayConfig {
+        half_life_days: 90,
+        revocation_weight: 50,
+    };
+    client.set_decay_config(&admin, &config);
+
+    let score_after = client.get_confidence_score(&attestation_id);
+    assert!(score_after.is_some());
+}


### PR DESCRIPTION
## Summary

This PR addresses 4 query optimization and validation issues:

- **Issue #945**: Add validation for `within_days` parameter in expiring attestations queries
- **Issue #944**: Enable distinguishing between unconfigured vs explicitly configured decay settings
- **Issue #943**: Optimize claim check functions to use pre-filtered attestations index
- **Issue #942**: Fix unused `mut` declaration and add cursor pagination tests

## Changes

### Issue #945: Expiring Attestations Validation
- Add MAX_EXPIRING_WINDOW_DAYS constant (365 days)
- Validate within_days parameter
- Return LimitExceeded error when exceeded

### Issue #942: Cursor Pagination Fix
- Remove unused mut from cursor_id_ref
- Add tie-break ordering test

### Issue #943: Claim Check Optimization
- Update has_any_claim, has_all_claims, has_valid_claim_from_issuer to use get_valid_attestations
- Eliminates unnecessary scans of revoked/deleted entries

### Issue #944: Decay Configuration Distinction
- Add is_decay_config_set() query function
- Enable distinguishing between configured and unconfigured states

Closes #945
Closes #944
Closes #943
Closes #942