### PR TITLE
Fix: Remove duplicates and stray code from lib, events, and storage

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -137,7 +137,7 @@ impl Events {
         timestamp: u64,
     ) {
         env.events().publish(
-            (symbol_short!("del_req"), subject.clone()),
+            (TOPIC_DEL_REQ, subject.clone()),
             (attestation_id.clone(), timestamp),
         );
     }
@@ -146,18 +146,6 @@ impl Events {
         env.events().publish(
             (TOPIC_EXPIRED, subject.clone()),
             attestation_id.clone(),
-        );
-    }
-
-    pub fn deletion_requested(
-        env: &Env,
-        subject: &Address,
-        attestation_id: &String,
-        timestamp: u64,
-    ) {
-        env.events().publish(
-            (TOPIC_DEL_REQ, subject.clone()),
-            (attestation_id.clone(), timestamp),
         );
     }
 
@@ -248,6 +236,7 @@ impl Events {
         );
     }
 
+    /// Emitted when an attestation's issuer is changed by the admin.
     pub fn attestation_transferred(
         env: &Env,
         attestation_id: &String,
@@ -255,7 +244,7 @@ impl Events {
         new_issuer: &Address,
     ) {
         env.events().publish(
-            (symbol_short!("att_xfer"), old_issuer.clone()),
+            (symbol_short!("xfer"), old_issuer.clone()),
             (attestation_id.clone(), new_issuer.clone()),
         );
     }
@@ -293,19 +282,6 @@ impl Events {
     pub fn contract_unpaused(env: &Env, admin: &Address, timestamp: u64) {
         env.events()
             .publish((symbol_short!("unpaused"),), (admin.clone(), timestamp));
-    }
-
-    /// Emitted when an attestation's issuer is changed by the admin.
-    pub fn attestation_transferred(
-        env: &Env,
-        attestation_id: &String,
-        old_issuer: &Address,
-        new_issuer: &Address,
-    ) {
-        env.events().publish(
-            (symbol_short!("xfer"), old_issuer.clone()),
-            (attestation_id.clone(), new_issuer.clone()),
-        );
     }
 
     /// Emitted when a proposer cancels a multisig proposal.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -711,15 +711,6 @@ impl TrustLinkContract {
         multisig::get_multisig_proposal(&env, proposal_id)
     }
 
-        if proposal.cancelled {
-            return Err(Error::ProposalExpired);
-        }
-
-        let current_time = env.ledger().timestamp();
-        if current_time >= proposal.expires_at {
-            return Err(Error::ProposalExpired);
-        }
-
     pub fn request_attestation(env: Env, subject: Address, issuer: Address, claim_type: String) -> Result<String, Error> {
         request::request_attestation(&env, subject, issuer, claim_type)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -711,11 +711,6 @@ impl TrustLinkContract {
         multisig::get_multisig_proposal(&env, proposal_id)
     }
 
-    #[must_use]
-    pub fn get_multisig_ttl(env: Env) -> u32 {
-        multisig::get_multisig_ttl(&env)
-    }
-
         if proposal.cancelled {
             return Err(Error::ProposalExpired);
         }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -379,12 +379,6 @@ impl Storage {
         env.storage().persistent().get(&StorageKey::ClaimTypeList).unwrap_or(Vec::new(env))
     }
 
-    /// Persist storage limits in instance storage.
-    pub fn set_limits(env: &Env, limits: &StorageLimits) {
-        let ttl = get_ttl_lifetime(env);
-        env.storage().instance().set(&StorageKey::Limits, limits);
-        env.storage().instance().extend_ttl(ttl, ttl);
-    }
 
     pub fn set_claim_type_constraints(env: &Env, claim_type: &String, constraints: &crate::types::ClaimTypeConstraints) {
         let key = StorageKey::ClaimTypeConstraints(claim_type.clone());
@@ -461,18 +455,8 @@ impl Storage {
         env.storage().instance().get(&StorageKey::Paused).unwrap_or(false)
     }
 
-    pub fn get_global_stats(env: &Env) -> GlobalStats {
-        env.storage().instance()
-            .get(&StorageKey::GlobalStats)
-            .unwrap_or(GlobalStats { total_attestations: 0, total_revocations: 0, total_issuers: 0 })
-    }
-
     pub fn set_global_stats(env: &Env, stats: &GlobalStats) {
         Self::set_global_stats_raw(env, stats)
-    }
-
-    pub fn get_global_stats_raw(env: &Env) -> GlobalStats {
-        Self::get_global_stats(env)
     }
 
     fn set_global_stats_raw(env: &Env, stats: &GlobalStats) {
@@ -533,22 +517,6 @@ impl Storage {
         env.storage().instance().get(&StorageKey::StorageLimits).unwrap_or_default()
     }
 
-    pub fn set_limits(env: &Env, limits: &StorageLimits) {
-        let ttl = get_ttl_lifetime(env);
-        env.storage().instance().set(&StorageKey::StorageLimits, limits);
-        env.storage().instance().extend_ttl(ttl, ttl);
-    }
-
-    pub fn get_rate_limit_config(env: &Env) -> Option<RateLimitConfig> {
-        env.storage().instance().get(&StorageKey::RateLimitConfig)
-    }
-
-    pub fn set_rate_limit_config(env: &Env, config: &RateLimitConfig) {
-        let ttl = get_ttl_lifetime(env);
-        env.storage().instance().set(&StorageKey::RateLimitConfig, config);
-        env.storage().instance().extend_ttl(ttl, ttl);
-    }
-
     /// Get the per-claim-type rate limit override for a claim type, or None if not set.
     pub fn get_claim_type_rate_limit(env: &Env, claim_type: &String) -> Option<u64> {
         env.storage()
@@ -563,17 +531,6 @@ impl Storage {
             .instance()
             .set(&StorageKey::ClaimTypeRateLimit(claim_type.clone()), &interval_secs);
         env.storage().instance().extend_ttl(ttl, ttl);
-    }
-
-    pub fn get_last_issuance_time(env: &Env, issuer: &Address) -> Option<u64> {
-        env.storage().persistent().get(&StorageKey::LastIssuanceTime(issuer.clone()))
-    }
-
-    pub fn set_last_issuance_time(env: &Env, issuer: &Address, timestamp: u64) {
-        let key = StorageKey::LastIssuanceTime(issuer.clone());
-        let ttl = get_ttl_lifetime(env);
-        env.storage().persistent().set(&key, &timestamp);
-        env.storage().persistent().extend_ttl(&key, ttl, ttl);
     }
 
     pub fn get_audit_log(env: &Env, attestation_id: &String) -> Vec<AuditEntry> {
@@ -604,37 +561,8 @@ impl Storage {
         env.storage().persistent().remove(&StorageKey::ExpirationHook(subject.clone()));
     }
 
-    pub fn get_multisig_proposal(env: &Env, proposal_id: &String) -> Result<MultiSigProposal, Error> {
-        env.storage().persistent().get(&StorageKey::MultiSigProposal(proposal_id.clone())).ok_or(Error::NotFound)
-    }
-
-    pub fn set_multisig_proposal(env: &Env, proposal: &MultiSigProposal) {
-        let key = StorageKey::MultiSigProposal(proposal.id.clone());
-        let ttl = get_ttl_lifetime(env);
-        env.storage().persistent().set(&key, proposal);
-        env.storage().persistent().extend_ttl(&key, ttl, ttl);
-    }
-
     pub fn get_multisig_ttl_days(env: &Env) -> u32 {
         env.storage().instance().get(&StorageKey::MultisigTtlDays).unwrap_or(7)
-    }
-
-    pub fn get_endorsements(env: &Env, attestation_id: &String) -> Vec<Endorsement> {
-        env.storage().persistent().get(&StorageKey::Endorsements(attestation_id.clone())).unwrap_or(Vec::new(env))
-    }
-
-    pub fn add_endorsement(env: &Env, attestation_id: &String, endorsement: &Endorsement) {
-        let key = StorageKey::Endorsements(attestation_id.clone());
-        let ttl = get_ttl_lifetime(env);
-        let mut list = Self::get_endorsements(env, attestation_id);
-        list.push_back(endorsement.clone());
-        env.storage().persistent().set(&key, &list);
-        env.storage().persistent().extend_ttl(&key, ttl, ttl);
-        let endorser_key = StorageKey::EndorserIndex(endorsement.endorser.clone());
-        let mut endorser_list: Vec<Endorsement> = env.storage().persistent().get(&endorser_key).unwrap_or(Vec::new(env));
-        endorser_list.push_back(endorsement.clone());
-        env.storage().persistent().set(&endorser_key, &endorser_list);
-        env.storage().persistent().extend_ttl(&endorser_key, ttl, ttl);
     }
 
     pub fn next_proposal_id(env: &Env) -> u32 {

--- a/src/test.rs
+++ b/src/test.rs
@@ -8779,3 +8779,173 @@ fn test_get_issuer_expiring_attestations_sorted_by_expiration() {
     assert_eq!(result.get(1).unwrap().expiration, Some(1000 + 10 * 86_400));
     assert_eq!(result.get(2).unwrap().expiration, Some(1000 + 20 * 86_400));
 }
+
+// Issue #917: Test for multisig proposal cancellation behavior after removing stray code
+#[test]
+fn test_cancel_multisig_proposal_validation() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, issuer, client) = setup(&env);
+    let subject = Address::generate(&env);
+    let claim_type = String::from_str(&env, "KYC");
+
+    env.ledger().set_timestamp(1000);
+    client.create_attestation(&issuer, &subject, &claim_type, &None, &None, &None);
+
+    let threshold = 2u32;
+    let proposal_id = client.propose_multisig_attestation(
+        &subject,
+        &issuer,
+        &subject,
+        &claim_type,
+        &threshold,
+    );
+
+    // Verify proposal can be cancelled by proposer
+    let result = client.cancel_multisig_proposal(&subject, &proposal_id);
+    assert!(result.is_ok());
+
+    // Verify proposal is marked as cancelled
+    let proposal = client.get_multisig_proposal(&proposal_id);
+    assert!(proposal.is_ok());
+    assert!(proposal.unwrap().cancelled);
+}
+
+// Issue #916: Test for single get_multisig_ttl function
+#[test]
+fn test_get_multisig_ttl_returns_configured_value() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, _issuer, client) = setup(&env);
+
+    // Default TTL should be 7 days
+    let default_ttl = client.get_multisig_ttl(&admin);
+    assert_eq!(default_ttl, 7);
+
+    // Set a custom TTL
+    let new_ttl = 14u32;
+    let result = client.set_multisig_ttl(&admin, &new_ttl);
+    assert!(result.is_ok());
+
+    // Verify new TTL is returned
+    let updated_ttl = client.get_multisig_ttl(&admin);
+    assert_eq!(updated_ttl, new_ttl);
+}
+
+// Issue #915: Test for event emission with proper topic constants
+#[test]
+fn test_deletion_requested_event_emission() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, issuer, client) = setup(&env);
+    let subject = Address::generate(&env);
+    let claim_type = String::from_str(&env, "KYC");
+
+    env.ledger().set_timestamp(1000);
+    let attestation_id = client.create_attestation(&issuer, &subject, &claim_type, &None, &None, &None);
+
+    // Request deletion
+    env.ledger().set_timestamp(2000);
+    client.request_deletion(&subject, &attestation_id);
+
+    let events = env.events().all();
+    let deletion_events: Vec<_> = events.iter()
+        .filter(|(event_type, _)| {
+            format!("{:?}", event_type).contains("del_req")
+        })
+        .collect();
+
+    // Should have at least one deletion requested event
+    assert!(!deletion_events.is_empty());
+}
+
+// Issue #915: Test for attestation_transferred event emission
+#[test]
+fn test_attestation_transferred_event_emission() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, issuer, client) = setup(&env);
+    let new_issuer = Address::generate(&env);
+    let subject = Address::generate(&env);
+    let claim_type = String::from_str(&env, "KYC");
+
+    // Register new issuer
+    client.register_issuer(&admin, &new_issuer);
+
+    env.ledger().set_timestamp(1000);
+    let attestation_id = client.create_attestation(&issuer, &subject, &claim_type, &None, &None, &None);
+
+    // Transfer attestation to new issuer
+    let result = client.transfer_attestation_issuer(&admin, &attestation_id, &new_issuer);
+    assert!(result.is_ok());
+
+    let events = env.events().all();
+    let transfer_events: Vec<_> = events.iter()
+        .filter(|(event_type, _)| {
+            format!("{:?}", event_type).contains("xfer")
+        })
+        .collect();
+
+    // Should have at least one transfer event
+    assert!(!transfer_events.is_empty());
+}
+
+// Issue #914: Test for non-duplicated storage methods
+#[test]
+fn test_storage_multisig_proposal_persistence() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, issuer, client) = setup(&env);
+    let subject = Address::generate(&env);
+    let claim_type = String::from_str(&env, "KYC");
+
+    env.ledger().set_timestamp(1000);
+    client.create_attestation(&issuer, &subject, &claim_type, &None, &None, &None);
+
+    let threshold = 2u32;
+    let proposal_id = client.propose_multisig_attestation(
+        &subject,
+        &issuer,
+        &subject,
+        &claim_type,
+        &threshold,
+    );
+
+    // Retrieve the proposal to verify it was stored correctly
+    let proposal = client.get_multisig_proposal(&proposal_id);
+    assert!(proposal.is_ok());
+
+    let retrieved = proposal.unwrap();
+    assert_eq!(retrieved.id, proposal_id);
+    assert_eq!(retrieved.threshold, threshold);
+    assert!(!retrieved.cancelled);
+    assert!(!retrieved.finalized);
+}
+
+// Issue #914: Test for global stats persistence
+#[test]
+fn test_storage_global_stats_persistence() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, issuer, client) = setup(&env);
+    let subject = Address::generate(&env);
+    let claim_type = String::from_str(&env, "KYC");
+
+    env.ledger().set_timestamp(1000);
+
+    // Create multiple attestations
+    client.create_attestation(&issuer, &subject, &claim_type, &None, &None, &None);
+
+    let subject2 = Address::generate(&env);
+    client.create_attestation(&issuer, &subject2, &claim_type, &None, &None, &None);
+
+    // Get global stats
+    let stats = client.get_global_stats();
+    assert!(stats.total_attestations >= 2);
+}


### PR DESCRIPTION
# Fix: Remove duplicates and stray code from lib, events, and storage

## Summary

This PR addresses four critical issues by removing duplicate code and stray artifacts from merge conflicts:

## Changes

### Issue #917: Remove stray code fragment
- Removed orphaned conditional statements in lib.rs (lines 719-726)

### Issue #916: Remove duplicate get_multisig_ttl
- Removed the first implementation, kept the Storage-based version

### Issue #915: Remove duplicate event functions
- Removed duplicate deletion_requested and attestation_transferred functions

### Issue #914: Remove duplicate storage methods
- Removed duplicate implementations of 10 storage methods

## Commits
- ba5d338: fix: remove duplicate get_multisig_ttl function (#916)
- 2b563e7: fix: remove stray code fragment in lib.rs (#917)
- 3f692bf: fix: remove duplicate event functions (#915)
- e5db61f: fix: remove duplicate storage methods (#914)
- 40b5302: test: add comprehensive tests for fixed issues

Closes #917
Closes #916
Closes #915
Closes #914