### PR TITLE
Fix build issues and duplicate definitions (#910, #911, #912, #913)

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -55,4 +55,30 @@ pub enum Error {
     LimitExceeded = 29,
     /// The proposal has been cancelled by the proposer.
     ProposalCancelled = 30,
+    /// Constraint violation in metadata or claim type.
+    ConstraintViolation = 31,
+    /// Attestation request has expired.
+    RequestExpired = 32,
+    /// Invalid metadata format or content.
+    InvalidMetadata = 33,
+    /// Council proposal could not be executed.
+    CouncilProposalExecuted = 34,
+    /// Timelock has not yet passed.
+    TimelockNotReady = 35,
+    /// Attestation is not disputed.
+    NotDisputed = 36,
+    /// Cannot remove last admin from council.
+    LastAdminCannotBeRemoved = 37,
+    /// Invalid fee token address.
+    InvalidFeeToken = 38,
+    /// Duplicate request already exists.
+    DuplicateRequest = 39,
+    /// Cannot delegate to self.
+    CannotDelegateToSelf = 40,
+    /// Attestation is already disputed.
+    AlreadyDisputed = 41,
+    /// Address has already approved this council proposal.
+    AlreadyApproved = 42,
+    /// Request has already been processed.
+    RequestAlreadyProcessed = 43,
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -31,7 +31,6 @@ pub enum StorageKey {
     /// Constraints for a specific claim type.
     ClaimTypeConstraints(String),
     IssuerList,
-    MultisigTtlDays,
     IssuerTier(Address),
     IssuerStats(Address),
     GlobalStats,
@@ -58,14 +57,8 @@ pub enum StorageKey {
     WhitelistEnabled(Address),
     /// Presence flag for a whitelisted subject under a specific issuer.
     SubjectWhitelist(Address, Address),
-    /// Rate limit configuration (minimum seconds between attestations).
-    RateLimitConfig,
-    /// Last attestation issuance timestamp per issuer.
-    LastIssuanceTime(Address),
     /// Ordered list of proposal IDs for a subject (for list_open_proposals).
     ProposalIndex(Address),
-    /// Configurable TTL in days for multisig proposals (default: 7).
-    MultisigTtl,
 }
 
 /// Composite key for per-issuer-per-claim-type last issuance timestamps.
@@ -616,7 +609,7 @@ impl Storage {
     }
 
     pub fn get_multisig_ttl_days(env: &Env) -> u32 {
-        env.storage().instance().get(&StorageKey::MultisigTtlDays).unwrap_or(7)
+        env.storage().instance().get(&StorageKey::MultisigTtl).unwrap_or(7)
     }
 
     pub fn get_endorsements(env: &Env, attestation_id: &String) -> Vec<Endorsement> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -4,9 +4,10 @@
 
 use crate::constants::{DAY_IN_LEDGERS, DEFAULT_INSTANCE_LIFETIME};
 use crate::types::{
-    Attestation, AttestationRequest, AuditEntry, ClaimTypeInfo, Endorsement, Error, ExpirationHook,
-    FeeConfig, GlobalStats, IssuerMetadata, IssuerStats, IssuerTier, MultiSigProposal,
-    RateLimitConfig, StorageLimits, TtlConfig,
+    AdminCouncil, Attestation, AttestationRequest, AttestationTemplate, AuditEntry, ClaimTypeInfo,
+    CouncilProposal, DecayConfig, DisputeRecord, Endorsement, Error, ExpirationHook, FeeConfig,
+    GlobalStats, IssuerMetadata, IssuerStats, IssuerTier, MultiSigProposal, PendingAdminTransfer,
+    RateLimitConfig, StorageLimits, TtlConfig, AttestationVersionSnapshot,
 };
 use soroban_sdk::{contracttype, Address, Env, String, Vec};
 
@@ -59,6 +60,8 @@ pub enum StorageKey {
     SubjectWhitelist(Address, Address),
     /// Ordered list of proposal IDs for a subject (for list_open_proposals).
     ProposalIndex(Address),
+    /// Configurable TTL in days for multisig proposals (default: 7).
+    MultisigTtl,
 }
 
 /// Composite key for per-issuer-per-claim-type last issuance timestamps.
@@ -1010,86 +1013,6 @@ impl Storage {
             let key = StorageKey::Attestation(attestation_id.clone());
             env.storage().persistent().extend_ttl(&key, target_ttl, target_ttl);
         }
-    }
-
-    /// Retrieve global contract statistics, returning zeroed defaults if not yet set.
-    pub fn get_global_stats(env: &Env) -> GlobalStats {
-        env.storage()
-            .instance()
-            .get(&StorageKey::GlobalStats)
-            .unwrap_or(GlobalStats {
-                total_attestations: 0,
-                total_revocations: 0,
-                total_issuers: 0,
-            })
-    }
-
-    /// Persist a multisig proposal and refresh its TTL.
-    pub fn set_multisig_proposal(env: &Env, proposal: &MultiSigProposal) {
-        let key = StorageKey::MultiSigProposal(proposal.id.clone());
-        let ttl = get_ttl_lifetime(env);
-        env.storage().persistent().set(&key, proposal);
-        env.storage().persistent().extend_ttl(&key, ttl, ttl);
-    }
-
-    /// Retrieve a multisig proposal by ID.
-    ///
-    /// # Errors
-    /// - [`Error::NotFound`] — no proposal with that ID exists.
-    pub fn get_multisig_proposal(env: &Env, id: &String) -> Result<MultiSigProposal, Error> {
-        env.storage()
-            .persistent()
-            .get(&StorageKey::MultiSigProposal(id.clone()))
-            .ok_or(Error::NotFound)
-    }
-
-    /// Return all endorsements for `attestation_id`, or an empty [`Vec`] if none.
-    pub fn get_endorsements(env: &Env, attestation_id: &String) -> Vec<Endorsement> {
-        env.storage()
-            .persistent()
-            .get(&StorageKey::Endorsements(attestation_id.clone()))
-            .unwrap_or(Vec::new(env))
-    }
-
-    /// Append an endorsement to the list for `attestation_id`.
-    pub fn add_endorsement(env: &Env, endorsement: &Endorsement) {
-        let key = StorageKey::Endorsements(endorsement.attestation_id.clone());
-        let ttl = get_ttl_lifetime(env);
-        let mut list = Self::get_endorsements(env, &endorsement.attestation_id);
-        list.push_back(endorsement.clone());
-        env.storage().persistent().set(&key, &list);
-        env.storage().persistent().extend_ttl(&key, ttl, ttl);
-    }
-
-    /// Persist the rate limit configuration.
-    pub fn set_rate_limit_config(env: &Env, config: &RateLimitConfig) {
-        let ttl = get_ttl_lifetime(env);
-        env.storage()
-            .instance()
-            .set(&StorageKey::RateLimitConfig, config);
-        env.storage().instance().extend_ttl(ttl, ttl);
-    }
-
-    /// Retrieve the rate limit configuration, or `None` if not set.
-    pub fn get_rate_limit_config(env: &Env) -> Option<RateLimitConfig> {
-        env.storage()
-            .instance()
-            .get(&StorageKey::RateLimitConfig)
-    }
-
-    /// Retrieve the last issuance timestamp for `issuer`, or `None` if never issued.
-    pub fn get_last_issuance_time(env: &Env, issuer: &Address) -> Option<u64> {
-        env.storage()
-            .persistent()
-            .get(&StorageKey::LastIssuanceTime(issuer.clone()))
-    }
-
-    /// Persist the last issuance timestamp for `issuer`.
-    pub fn set_last_issuance_time(env: &Env, issuer: &Address, timestamp: u64) {
-        let key = StorageKey::LastIssuanceTime(issuer.clone());
-        let ttl = get_ttl_lifetime(env);
-        env.storage().persistent().set(&key, &timestamp);
-        env.storage().persistent().extend_ttl(&key, ttl, ttl);
     }
 
     /// Retrieve the configured multisig proposal TTL in days (default: 7).

--- a/src/types.rs
+++ b/src/types.rs
@@ -66,6 +66,7 @@ impl IssuerTier {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct IssuerStats {
     pub total_issued: u64,
+    pub total_revoked: u64,
 }
 
 /// A registered expiration notification hook for a subject.
@@ -98,11 +99,16 @@ pub struct MultiSigProposal {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ContractConfig {
-    pub ttl_config: TtlConfig,
-    pub fee_config: FeeConfig,
     pub contract_name: String,
     pub contract_version: String,
     pub contract_description: String,
+    pub fee_config: FeeConfig,
+    pub ttl_config: TtlConfig,
+    pub require_registered_claim_type: bool,
+    /// When `true`, the `metadata` field on new attestations must be either
+    /// `None` or a 64-character lowercase hexadecimal string (SHA-256 hash).
+    /// Enables enforcement of GDPR data-minimisation at the contract level.
+    pub metadata_hash_only: bool,
     /// Configurable TTL for multisig proposals in days (default: 7).
     pub multisig_ttl_days: u32,
 }
@@ -152,12 +158,6 @@ pub struct HealthStatus {
     pub total_attestations: u64,
 }
 
-/// Issuer statistics.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct IssuerStats {
-    pub total_issued: u64,
-}
 
 /// TTL configuration.
 #[contracttype]
@@ -173,21 +173,6 @@ pub struct RateLimitConfig {
     pub min_issuance_interval: u64,
 }
 
-/// Contract configuration.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ContractConfig {
-    pub contract_name: String,
-    pub contract_version: String,
-    pub contract_description: String,
-    pub fee_config: FeeConfig,
-    pub ttl_config: TtlConfig,
-    pub require_registered_claim_type: bool,
-    /// When `true`, the `metadata` field on new attestations must be either
-    /// `None` or a 64-character lowercase hexadecimal string (SHA-256 hash).
-    /// Enables enforcement of GDPR data-minimisation at the contract level.
-    pub metadata_hash_only: bool,
-}
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -299,22 +284,6 @@ pub struct Endorsement {
     pub timestamp: u64,
 }
 
-/// A multi-signature attestation proposal requiring threshold signatures.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct MultiSigProposal {
-    pub id: String,
-    pub proposer: Address,
-    pub subject: Address,
-    pub claim_type: String,
-    pub required_signers: Vec<Address>,
-    pub threshold: u32,
-    pub signers: Vec<Address>,
-    pub created_at: u64,
-    pub expires_at: u64,
-    pub finalized: bool,
-}
-
 /// Configurable storage limits to prevent exhaustion attacks.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -330,14 +299,6 @@ impl Default for StorageLimits {
             max_attestations_per_subject: 100,
         }
     }
-}
-
-/// Expiration notification hook configuration.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ExpirationHook {
-    pub callback_contract: Address,
-    pub notify_days_before: u32,
 }
 
 /// Delegation from an issuer to a sub-issuer for specific claim types.


### PR DESCRIPTION
## Summary
- Fix #911: Remove duplicate StorageKey enum variants
- Fix #912: Remove duplicate struct definitions in types.rs
- Fix #913: Ensure MultiSigProposal has cancelled field
- Fix #910: Fix build - resolve duplicate methods

These fixes address the incomplete merge conflict resolution that was causing compilation errors due to duplicate definitions and missing fields.

## Changes
- Removed duplicate StorageKey enum variants (RateLimitConfig, LastIssuanceTime)
- Removed duplicate struct definitions (IssuerStats, ExpirationHook, ContractConfig, MultiSigProposal)
- Ensured MultiSigProposal includes the cancelled field
- Removed duplicate method implementations in Storage
- Added missing Error enum variants

## Test plan
- [x] Verify duplicate definitions are removed
- [x] Verify MultiSigProposal includes cancelled field
- [x] All 4 commits address their respective issues

Closes #913
Closes #912
Closes #911
Closes #910