### PR TITLE
Issue 968 add client side input validation

### DIFF
--- a/sdk/typescript/__tests__/client-validation.test.ts
+++ b/sdk/typescript/__tests__/client-validation.test.ts
@@ -1,0 +1,42 @@
+import { TrustLinkClient } from "../src/client";
+
+describe("TrustLinkClient constructor validation", () => {
+  const CONTRACT_ID = "CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+
+  test("accepts valid network names", () => {
+    expect(() => new TrustLinkClient({ contractId: CONTRACT_ID, network: "testnet" })).not.toThrow();
+    expect(() => new TrustLinkClient({ contractId: CONTRACT_ID, network: "mainnet" })).not.toThrow();
+    expect(() => new TrustLinkClient({ contractId: CONTRACT_ID, network: "local" })).not.toThrow();
+  });
+
+  test("throws clear error for invalid network name", () => {
+    const error = "Invalid network: \"testnest\". Valid networks are: testnet, mainnet, local. For custom RPC URLs, use the 'rpcUrl' option instead.";
+    expect(() => new TrustLinkClient({ contractId: CONTRACT_ID, network: "testnest" as any })).toThrow(error);
+  });
+
+  test("throws clear error for misspelled network name", () => {
+    const error = "Invalid network: \"mainet\". Valid networks are: testnet, mainnet, local. For custom RPC URLs, use the 'rpcUrl' option instead.";
+    expect(() => new TrustLinkClient({ contractId: CONTRACT_ID, network: "mainet" as any })).toThrow(error);
+  });
+
+  test("throws clear error for arbitrary string", () => {
+    const error = "Invalid network: \"https://custom-rpc.com\". Valid networks are: testnet, mainnet, local. For custom RPC URLs, use the 'rpcUrl' option instead.";
+    expect(() => new TrustLinkClient({ contractId: CONTRACT_ID, network: "https://custom-rpc.com" as any })).toThrow(error);
+  });
+
+  test("accepts valid rpcUrl", () => {
+    expect(() => new TrustLinkClient({
+      contractId: CONTRACT_ID,
+      network: "testnet",
+      rpcUrl: "https://custom-rpc.com"
+    })).not.toThrow();
+  });
+
+  test("throws error for invalid rpcUrl", () => {
+    expect(() => new TrustLinkClient({
+      contractId: CONTRACT_ID,
+      network: "testnet",
+      rpcUrl: "not-a-valid-url"
+    })).toThrow("Invalid rpcUrl: \"not-a-valid-url\" is not a valid URL.");
+  });
+});

--- a/sdk/typescript/__tests__/validation.test.ts
+++ b/sdk/typescript/__tests__/validation.test.ts
@@ -1,0 +1,212 @@
+import {
+  validateAddress,
+  validateClaimType,
+  validateAttestationId,
+  validateProposalId,
+  validateRequestId,
+  validateTemplateId,
+  validateNonNegative,
+  validatePositive,
+  InvalidAddressError,
+  InvalidClaimTypeError,
+  InvalidNumericValueError,
+  TrustLinkValidationError,
+} from "../src/validation";
+
+describe("Validation functions", () => {
+  describe("validateAddress", () => {
+    test("accepts valid Stellar addresses (G...)", () => {
+      expect(() => validateAddress("GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN")).not.toThrow();
+    });
+
+    test("accepts valid contract addresses (C...)", () => {
+      expect(() => validateAddress("CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABCD")).not.toThrow();
+    });
+
+    test("rejects invalid address format", () => {
+      expect(() => validateAddress("invalid")).toThrow(InvalidAddressError);
+      expect(() => validateAddress("GABC")).toThrow(InvalidAddressError);
+      expect(() => validateAddress("XAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN")).toThrow(InvalidAddressError);
+    });
+
+    test("rejects empty address", () => {
+      expect(() => validateAddress("")).toThrow(InvalidAddressError);
+      expect(() => validateAddress("   ")).toThrow(InvalidAddressError);
+    });
+
+    test("rejects non-string input", () => {
+      expect(() => validateAddress(null as any)).toThrow(InvalidAddressError);
+      expect(() => validateAddress(undefined as any)).toThrow(InvalidAddressError);
+    });
+  });
+
+  describe("validateClaimType", () => {
+    test("accepts valid claim types", () => {
+      expect(() => validateClaimType("KYC_PASSED")).not.toThrow();
+      expect(() => validateClaimType("IDENTITY_VERIFIED")).not.toThrow();
+      expect(() => validateClaimType("CREDIT_SCORE")).not.toThrow();
+    });
+
+    test("accepts claim types starting with letter and containing alphanumeric/underscore", () => {
+      expect(() => validateClaimType("A1_B2")).not.toThrow();
+      expect(() => validateClaimType("Test123")).not.toThrow();
+    });
+
+    test("rejects claim types starting with number", () => {
+      expect(() => validateClaimType("123_KYC")).toThrow(InvalidClaimTypeError);
+    });
+
+    test("rejects claim types with special characters", () => {
+      expect(() => validateClaimType("KYC-PASSED")).toThrow(InvalidClaimTypeError);
+      expect(() => validateClaimType("KYC.PASSED")).toThrow(InvalidClaimTypeError);
+      expect(() => validateClaimType("KYC PASSED")).toThrow(InvalidClaimTypeError);
+    });
+
+    test("rejects empty claim type", () => {
+      expect(() => validateClaimType("")).toThrow(InvalidClaimTypeError);
+      expect(() => validateClaimType("   ")).toThrow(InvalidClaimTypeError);
+    });
+
+    test("rejects non-string input", () => {
+      expect(() => validateClaimType(null as any)).toThrow(InvalidClaimTypeError);
+      expect(() => validateClaimType(undefined as any)).toThrow(InvalidClaimTypeError);
+    });
+  });
+
+  describe("validateAttestationId", () => {
+    test("accepts non-empty strings", () => {
+      expect(() => validateAttestationId("attestation-123")).not.toThrow();
+      expect(() => validateAttestationId("abc")).not.toThrow();
+    });
+
+    test("rejects empty string", () => {
+      expect(() => validateAttestationId("")).toThrow(TrustLinkValidationError);
+      expect(() => validateAttestationId("   ")).toThrow(TrustLinkValidationError);
+    });
+
+    test("rejects non-string input", () => {
+      expect(() => validateAttestationId(null as any)).toThrow(TrustLinkValidationError);
+      expect(() => validateAttestationId(undefined as any)).toThrow(TrustLinkValidationError);
+    });
+  });
+
+  describe("validateProposalId", () => {
+    test("accepts non-empty strings", () => {
+      expect(() => validateProposalId("proposal-123")).not.toThrow();
+      expect(() => validateProposalId("abc")).not.toThrow();
+    });
+
+    test("rejects empty string", () => {
+      expect(() => validateProposalId("")).toThrow(TrustLinkValidationError);
+      expect(() => validateProposalId("   ")).toThrow(TrustLinkValidationError);
+    });
+
+    test("rejects non-string input", () => {
+      expect(() => validateProposalId(null as any)).toThrow(TrustLinkValidationError);
+      expect(() => validateProposalId(undefined as any)).toThrow(TrustLinkValidationError);
+    });
+  });
+
+  describe("validateRequestId", () => {
+    test("accepts non-empty strings", () => {
+      expect(() => validateRequestId("request-123")).not.toThrow();
+      expect(() => validateRequestId("abc")).not.toThrow();
+    });
+
+    test("rejects empty string", () => {
+      expect(() => validateRequestId("")).toThrow(TrustLinkValidationError);
+      expect(() => validateRequestId("   ")).toThrow(TrustLinkValidationError);
+    });
+
+    test("rejects non-string input", () => {
+      expect(() => validateRequestId(null as any)).toThrow(TrustLinkValidationError);
+      expect(() => validateRequestId(undefined as any)).toThrow(TrustLinkValidationError);
+    });
+  });
+
+  describe("validateTemplateId", () => {
+    test("accepts non-empty strings", () => {
+      expect(() => validateTemplateId("template-123")).not.toThrow();
+      expect(() => validateTemplateId("abc")).not.toThrow();
+    });
+
+    test("rejects empty string", () => {
+      expect(() => validateTemplateId("")).toThrow(TrustLinkValidationError);
+      expect(() => validateTemplateId("   ")).toThrow(TrustLinkValidationError);
+    });
+
+    test("rejects non-string input", () => {
+      expect(() => validateTemplateId(null as any)).toThrow(TrustLinkValidationError);
+      expect(() => validateTemplateId(undefined as any)).toThrow(TrustLinkValidationError);
+    });
+  });
+
+  describe("validateNonNegative", () => {
+    test("accepts non-negative numbers", () => {
+      expect(() => validateNonNegative(0, "test")).not.toThrow();
+      expect(() => validateNonNegative(1, "test")).not.toThrow();
+      expect(() => validateNonNegative(100, "test")).not.toThrow();
+    });
+
+    test("accepts non-negative bigints", () => {
+      expect(() => validateNonNegative(0n, "test")).not.toThrow();
+      expect(() => validateNonNegative(1n, "test")).not.toThrow();
+      expect(() => validateNonNegative(100n, "test")).not.toThrow();
+    });
+
+    test("rejects negative numbers", () => {
+      expect(() => validateNonNegative(-1, "test")).toThrow(InvalidNumericValueError);
+      expect(() => validateNonNegative(-100, "test")).toThrow(InvalidNumericValueError);
+    });
+
+    test("rejects negative bigints", () => {
+      expect(() => validateNonNegative(-1n, "test")).toThrow(InvalidNumericValueError);
+      expect(() => validateNonNegative(-100n, "test")).toThrow(InvalidNumericValueError);
+    });
+
+    test("rejects NaN", () => {
+      expect(() => validateNonNegative(NaN, "test")).toThrow(InvalidNumericValueError);
+    });
+
+    test("rejects Infinity", () => {
+      expect(() => validateNonNegative(Infinity, "test")).toThrow(InvalidNumericValueError);
+      expect(() => validateNonNegative(-Infinity, "test")).toThrow(InvalidNumericValueError);
+    });
+  });
+
+  describe("validatePositive", () => {
+    test("accepts positive numbers", () => {
+      expect(() => validatePositive(1, "test")).not.toThrow();
+      expect(() => validatePositive(100, "test")).not.toThrow();
+    });
+
+    test("accepts positive bigints", () => {
+      expect(() => validatePositive(1n, "test")).not.toThrow();
+      expect(() => validatePositive(100n, "test")).not.toThrow();
+    });
+
+    test("rejects zero", () => {
+      expect(() => validatePositive(0, "test")).toThrow(InvalidNumericValueError);
+      expect(() => validatePositive(0n, "test")).toThrow(InvalidNumericValueError);
+    });
+
+    test("rejects negative numbers", () => {
+      expect(() => validatePositive(-1, "test")).toThrow(InvalidNumericValueError);
+      expect(() => validatePositive(-100, "test")).toThrow(InvalidNumericValueError);
+    });
+
+    test("rejects negative bigints", () => {
+      expect(() => validatePositive(-1n, "test")).toThrow(InvalidNumericValueError);
+      expect(() => validatePositive(-100n, "test")).toThrow(InvalidNumericValueError);
+    });
+
+    test("rejects NaN", () => {
+      expect(() => validatePositive(NaN, "test")).toThrow(InvalidNumericValueError);
+    });
+
+    test("rejects Infinity", () => {
+      expect(() => validatePositive(Infinity, "test")).toThrow(InvalidNumericValueError);
+      expect(() => validatePositive(-Infinity, "test")).toThrow(InvalidNumericValueError);
+    });
+  });
+});

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -41,6 +41,17 @@ import {
   type RetryOptions,
 } from "./resilience";
 
+import {
+  validateAddress,
+  validateClaimType,
+  validateAttestationId,
+  validateProposalId,
+  validateRequestId,
+  validateTemplateId,
+  validatePositive,
+  validateNonNegative,
+} from "./validation";
+
 const RPC_URLS: Record<string, string> = {
   testnet: "https://soroban-testnet.stellar.org",
   mainnet: "https://mainnet.stellar.validationcloud.io/v1/XCSmR1nSS3we7PCXV4oMiA",
@@ -81,10 +92,12 @@ export class TrustLinkClient {
 
     // Validate rpcUrl if provided
     if (rpcUrl) {
-      try {
-        new URL(rpcUrl);
-      } catch {
+      if (typeof rpcUrl !== "string" || !rpcUrl.trim()) {
         throw new Error(`Invalid rpcUrl: "${rpcUrl}" is not a valid URL.`);
+      }
+      const trimmed = rpcUrl.trim();
+      if (!trimmed.startsWith("http://") && !trimmed.startsWith("https://")) {
+        throw new Error(`Invalid rpcUrl: "${rpcUrl}" must start with http:// or https://`);
       }
     }
 
@@ -211,32 +224,41 @@ export class TrustLinkClient {
   // ── Issuer Registry ────────────────────────────────────────────────────────
 
   async isIssuer(address: string): Promise<boolean> {
+    validateAddress(address);
     return this.simulate("is_issuer", this.addr(address));
   }
 
   async getIssuerStats(issuer: string): Promise<IssuerStats> {
+    validateAddress(issuer);
     return this.simulate("get_issuer_stats", this.addr(issuer));
   }
 
   async getIssuerTier(issuer: string): Promise<IssuerTier | null> {
+    validateAddress(issuer);
     return this.simulate("get_issuer_tier", this.addr(issuer));
   }
 
   async getIssuerMetadata(issuer: string): Promise<IssuerMetadata | null> {
+    validateAddress(issuer);
     return this.simulate("get_issuer_metadata", this.addr(issuer));
   }
 
   async getIssuerList(start: number, limit: number): Promise<string[]> {
+    validateNonNegative(start, "start");
+    validatePositive(limit, "limit");
     return this.simulate("get_issuer_list", this.u32(start), this.u32(limit));
   }
 
   // ── Bridge Registry ────────────────────────────────────────────────────────
 
   async isBridge(address: string): Promise<boolean> {
+    validateAddress(address);
     return this.simulate("is_bridge", this.addr(address));
   }
 
   async getBridgeList(start: number, limit: number): Promise<string[]> {
+    validateNonNegative(start, "start");
+    validatePositive(limit, "limit");
     return this.simulate("get_bridge_list", this.u32(start), this.u32(limit));
   }
 
@@ -247,15 +269,19 @@ export class TrustLinkClient {
   // ── Claim Type Registry ────────────────────────────────────────────────────
 
   async getClaimTypeDescription(claimType: string): Promise<string | null> {
+    validateClaimType(claimType);
     return this.simulate("get_claim_type_description", this.str(claimType));
   }
 
   async listClaimTypes(start: number, limit: number): Promise<string[]> {
+    validateNonNegative(start, "start");
+    validatePositive(limit, "limit");
     return this.simulate("list_claim_types", this.u32(start), this.u32(limit));
   }
 
   /** Returns whether the given claim type is registered in the contract registry. */
   async getRegisteredClaimType(claimType: string): Promise<boolean> {
+    validateClaimType(claimType);
     return this.simulate("get_registered_claim_type", this.str(claimType));
   }
 
@@ -274,6 +300,7 @@ export class TrustLinkClient {
    * Distinct from getRateLimit(), which operates at the per-issuer level.
    */
   async getRateLimitForClaimType(claimType: string): Promise<bigint> {
+    validateClaimType(claimType);
     return this.simulate("get_rate_limit_for_claim_type", this.str(claimType));
   }
 
@@ -284,6 +311,9 @@ export class TrustLinkClient {
     delegate: string,
     claimType: string
   ): Promise<Delegation | null> {
+    validateAddress(delegator);
+    validateAddress(delegate);
+    validateClaimType(claimType);
     return this.simulate(
       "get_delegation",
       this.addr(delegator),
@@ -293,16 +323,21 @@ export class TrustLinkClient {
   }
 
   async listDelegationsByDelegator(delegator: string, start: number, limit: number): Promise<Delegation[]> {
+    validateAddress(delegator);
+    validateNonNegative(start, "start");
+    validatePositive(limit, "limit");
     return this.simulate("list_delegations_by_delegator", this.addr(delegator), this.u32(start), this.u32(limit));
   }
 
   // ── Attestation Queries ────────────────────────────────────────────────────
 
   async getAttestation(attestationId: string): Promise<Attestation> {
+    validateAttestationId(attestationId);
     return this.simulate("get_attestation", this.str(attestationId));
   }
 
   async getAttestationStatus(attestationId: string): Promise<AttestationStatus> {
+    validateAttestationId(attestationId);
     return this.simulate("get_attestation_status", this.str(attestationId));
   }
 
@@ -310,6 +345,8 @@ export class TrustLinkClient {
     subject: string,
     claimType: string
   ): Promise<Attestation> {
+    validateAddress(subject);
+    validateClaimType(claimType);
     return this.simulate(
       "get_attestation_by_type",
       this.addr(subject),
@@ -322,6 +359,9 @@ export class TrustLinkClient {
     start: number,
     limit: number
   ): Promise<Attestation[]> {
+    validateAddress(subject);
+    validateNonNegative(start, "start");
+    validatePositive(limit, "limit");
     return this.simulate(
       "get_subject_attestations",
       this.addr(subject),
@@ -335,6 +375,9 @@ export class TrustLinkClient {
     start: number,
     limit: number
   ): Promise<Attestation[]> {
+    validateAddress(issuer);
+    validateNonNegative(start, "start");
+    validatePositive(limit, "limit");
     return this.simulate(
       "get_issuer_attestations",
       this.addr(issuer),
@@ -344,6 +387,9 @@ export class TrustLinkClient {
   }
 
   async getAttestationsByTag(subject: string, tag: string, start = 0, limit = 20): Promise<string[]> {
+    validateAddress(subject);
+    validateNonNegative(start, "start");
+    validatePositive(limit, "limit");
     const all = await this.simulate<string[]>(
       "get_attestations_by_tag",
       this.addr(subject),
@@ -366,6 +412,9 @@ export class TrustLinkClient {
     start: number,
     limit: number
   ): Promise<string[]> {
+    validateAddress(subject);
+    validateNonNegative(start, "start");
+    validatePositive(limit, "limit");
     return this.simulate(
       "get_attestations_by_jurisdiction",
       this.addr(subject),
@@ -376,16 +425,20 @@ export class TrustLinkClient {
   }
 
   async getValidClaims(subject: string): Promise<string[]> {
+    validateAddress(subject);
     return this.simulate("get_valid_claims", this.addr(subject));
   }
 
   async getAuditLog(attestationId: string): Promise<AuditEntry[]> {
+    validateAttestationId(attestationId);
     return this.simulate("get_audit_log", this.str(attestationId));
   }
 
   // ── Claim Verification ─────────────────────────────────────────────────────
 
   async hasValidClaim(subject: string, claimType: string): Promise<boolean> {
+    validateAddress(subject);
+    validateClaimType(claimType);
     return this.simulate(
       "has_valid_claim",
       this.addr(subject),
@@ -398,6 +451,9 @@ export class TrustLinkClient {
     claimType: string,
     issuer: string
   ): Promise<boolean> {
+    validateAddress(subject);
+    validateClaimType(claimType);
+    validateAddress(issuer);
     return this.simulate(
       "has_valid_claim_from_issuer",
       this.addr(subject),
@@ -407,6 +463,8 @@ export class TrustLinkClient {
   }
 
   async hasAnyClaim(subject: string, claimTypes: string[]): Promise<boolean> {
+    validateAddress(subject);
+    claimTypes.forEach(ct => validateClaimType(ct));
     return this.simulate(
       "has_any_claim",
       this.addr(subject),
@@ -415,6 +473,8 @@ export class TrustLinkClient {
   }
 
   async hasAllClaims(subject: string, claimTypes: string[]): Promise<boolean> {
+    validateAddress(subject);
+    claimTypes.forEach(ct => validateClaimType(ct));
     return this.simulate(
       "has_all_claims",
       this.addr(subject),
@@ -427,6 +487,8 @@ export class TrustLinkClient {
     claimType: string,
     minTier: IssuerTier
   ): Promise<boolean> {
+    validateAddress(subject);
+    validateClaimType(claimType);
     // IssuerTier is a Soroban #[contracttype] enum — encode as ScVec([ScSymbol(variant)])
     return this.simulate(
       "has_valid_claim_from_tier",
@@ -437,20 +499,24 @@ export class TrustLinkClient {
   }
 
   async getClaimTypeCount(claimType: string): Promise<bigint> {
+    validateClaimType(claimType);
     return this.simulate("get_claim_type_count", this.str(claimType));
   }
 
   // ── Count Queries ──────────────────────────────────────────────────────────
 
   async getSubjectAttestationCount(subject: string): Promise<bigint> {
+    validateAddress(subject);
     return this.simulate("get_subject_attestation_count", this.addr(subject));
   }
 
   async getIssuerAttestationCount(issuer: string): Promise<bigint> {
+    validateAddress(issuer);
     return this.simulate("get_issuer_attestation_count", this.addr(issuer));
   }
 
   async getValidClaimCount(subject: string): Promise<bigint> {
+    validateAddress(subject);
     return this.simulate("get_valid_claim_count", this.addr(subject));
   }
 
@@ -470,6 +536,10 @@ export class TrustLinkClient {
     start: number,
     limit: number
   ): Promise<Attestation[]> {
+    validateAddress(subject);
+    validateNonNegative(withinDays, "withinDays");
+    validateNonNegative(start, "start");
+    validatePositive(limit, "limit");
     return this.simulate(
       "get_expiring_attestations",
       this.addr(subject),
@@ -493,6 +563,10 @@ export class TrustLinkClient {
     start: number,
     limit: number
   ): Promise<Attestation[]> {
+    validateAddress(issuer);
+    validateNonNegative(daysWindow, "daysWindow");
+    validateNonNegative(start, "start");
+    validatePositive(limit, "limit");
     return this.simulate(
       "get_issuer_expiring_attestations",
       this.addr(issuer),
@@ -505,6 +579,7 @@ export class TrustLinkClient {
   // ── Multi-Sig Proposals ────────────────────────────────────────────────────
 
   async getMultisigProposal(proposalId: string): Promise<MultiSigProposal> {
+    validateProposalId(proposalId);
     return this.simulate("get_multisig_proposal", this.str(proposalId));
   }
 
@@ -517,6 +592,9 @@ export class TrustLinkClient {
     start: number,
     limit: number
   ): Promise<MultiSigProposal[]> {
+    validateAddress(subject);
+    validateNonNegative(start, "start");
+    validatePositive(limit, "limit");
     return this.simulate(
       "list_open_proposals",
       this.addr(subject),
@@ -529,6 +607,8 @@ export class TrustLinkClient {
     proposer: string,
     proposalId: string
   ): Promise<SorobanRpc.Api.SimulateTransactionResponse> {
+    validateAddress(proposer);
+    validateProposalId(proposalId);
     const dummySource = proposer;
     const account = new Account(dummySource, "0");
     const tx = new TransactionBuilder(account, {
@@ -552,6 +632,8 @@ export class TrustLinkClient {
     requestId: string,
     expiration?: bigint
   ): Promise<SorobanRpc.Api.SimulateTransactionResponse> {
+    validateAddress(issuer);
+    validateRequestId(requestId);
     const account = new Account(issuer, "0");
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
@@ -575,6 +657,8 @@ export class TrustLinkClient {
     requestId: string,
     reason?: string
   ): Promise<SorobanRpc.Api.SimulateTransactionResponse> {
+    validateAddress(issuer);
+    validateRequestId(requestId);
     const account = new Account(issuer, "0");
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
@@ -594,6 +678,7 @@ export class TrustLinkClient {
   }
 
   async getAttestationRequest(requestId: string): Promise<AttestationRequest> {
+    validateRequestId(requestId);
     return this.simulate("get_attestation_request", this.str(requestId));
   }
 
@@ -602,45 +687,61 @@ export class TrustLinkClient {
    * Distinct from getAttestationRequest(), which returns the high-level processed object.
    */
   async getRequest(requestId: string): Promise<AttestationRequest> {
+    validateRequestId(requestId);
     return this.simulate("get_request", this.str(requestId));
   }
 
   // ── Endorsements ──────────────────────────────────────────────────────────
 
   async getEndorsements(attestationId: string): Promise<Endorsement[]> {
+    validateAttestationId(attestationId);
     return this.simulate("get_endorsements", this.str(attestationId));
   }
 
   async getEndorsementCount(attestationId: string): Promise<number> {
+    validateAttestationId(attestationId);
     return this.simulate("get_endorsement_count", this.str(attestationId));
   }
 
   async listEndorsementsByEndorser(endorser: string, start: number, limit: number): Promise<Endorsement[]> {
+    validateAddress(endorser);
+    validateNonNegative(start, "start");
+    validatePositive(limit, "limit");
     return this.simulate("list_endorsements_by_endorser", this.addr(endorser), this.u32(start), this.u32(limit));
   }
 
   // ── Templates ─────────────────────────────────────────────────────────────
 
   async getTemplate(issuer: string, templateId: string): Promise<import("./types").AttestationTemplate> {
+    validateAddress(issuer);
+    validateTemplateId(templateId);
     return this.simulate("get_template", this.addr(issuer), this.str(templateId));
   }
 
   async listTemplates(issuer: string, start: number, limit: number): Promise<Template[]> {
+    validateAddress(issuer);
+    validateNonNegative(start, "start");
+    validatePositive(limit, "limit");
     return this.simulate("list_templates", this.addr(issuer), this.u32(start), this.u32(limit));
   }
 
   // ── Whitelist ──────────────────────────────────────────────────────────────
 
   async bulkAddToWhitelist(issuer: string, subjects: string[]): Promise<void> {
+    validateAddress(issuer);
+    subjects.forEach(s => validateAddress(s));
     const subjectsVal = xdr.ScVal.scvVec(subjects.map(s => this.addr(s)));
     return this.simulate("bulk_add_to_whitelist", this.addr(issuer), subjectsVal);
   }
 
   async isWhitelisted(issuer: string, subject: string): Promise<boolean> {
+    validateAddress(issuer);
+    validateAddress(subject);
     return this.simulate("is_whitelisted", this.addr(issuer), this.addr(subject));
   }
 
   async isWhitelistEnabled(issuer: string): Promise<boolean> {
+    validateAddress(issuer);
     return this.simulate("is_whitelist_enabled", this.addr(issuer));
   }
 
@@ -650,6 +751,8 @@ export class TrustLinkClient {
     subject: string,
     pageSize = 20
   ): AsyncGenerator<Attestation> {
+    validateAddress(subject);
+    validatePositive(pageSize, "pageSize");
     let start = 0;
     while (true) {
       const page = await this.getSubjectAttestations(subject, start, pageSize);
@@ -663,6 +766,8 @@ export class TrustLinkClient {
     issuer: string,
     pageSize = 20
   ): AsyncGenerator<Attestation> {
+    validateAddress(issuer);
+    validatePositive(pageSize, "pageSize");
     let start = 0;
     while (true) {
       const page = await this.getIssuerAttestations(issuer, start, pageSize);
@@ -686,6 +791,10 @@ export class TrustLinkClient {
     subject: string,
     options?: { requestIds?: string[] }
   ): Promise<SubjectDataExport> {
+    validateAddress(subject);
+    if (options?.requestIds) {
+      options.requestIds.forEach(id => validateRequestId(id));
+    }
     const attestations: Attestation[] = [];
     for await (const att of this.iterateSubjectAttestations(subject)) {
       attestations.push(att);

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -71,12 +71,25 @@ export class TrustLinkClient {
   constructor(options: TrustLinkClientOptions) {
     const { contractId, network, rpcUrl } = options;
 
-    this.rpcUrl =
-      rpcUrl ??
-      (RPC_URLS[network as string] ?? (network as string));
+    // Validate network is a known network name
+    if (!RPC_URLS[network]) {
+      throw new Error(
+        `Invalid network: "${network}". Valid networks are: ${Object.keys(RPC_URLS).join(", ")}. ` +
+        `For custom RPC URLs, use the 'rpcUrl' option instead.`
+      );
+    }
 
-    this.networkPassphrase =
-      NETWORK_PASSPHRASES[network as string] ?? Networks.TESTNET;
+    // Validate rpcUrl if provided
+    if (rpcUrl) {
+      try {
+        new URL(rpcUrl);
+      } catch {
+        throw new Error(`Invalid rpcUrl: "${rpcUrl}" is not a valid URL.`);
+      }
+    }
+
+    this.rpcUrl = rpcUrl ?? RPC_URLS[network];
+    this.networkPassphrase = NETWORK_PASSPHRASES[network];
 
     this.server = new SorobanRpc.Server(this.rpcUrl, { allowHttp: true });
     this.contract = new Contract(contractId);

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -362,7 +362,7 @@ export type Network = "testnet" | "mainnet" | "local";
 
 export interface TrustLinkClientOptions {
   contractId: string;
-  network: Network | string;
+  network: Network;
   rpcUrl?: string;
   retry?: import("./resilience").RetryOptions;
   circuitBreaker?: import("./resilience").CircuitBreakerOptions;

--- a/sdk/typescript/src/validation.ts
+++ b/sdk/typescript/src/validation.ts
@@ -1,0 +1,226 @@
+/**
+ * TrustLink SDK - Input Validation
+ *
+ * Client-side validation helpers to catch invalid inputs before RPC calls.
+ */
+
+// ─── Error Classes ───────────────────────────────────────────────────────────
+
+/**
+ * Base error class for TrustLink SDK errors.
+ */
+export class TrustLinkValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TrustLinkValidationError";
+  }
+}
+
+/**
+ * Error thrown when an address format is invalid.
+ */
+export class InvalidAddressError extends TrustLinkValidationError {
+  constructor(address: string, reason?: string) {
+    super(
+      `Invalid Stellar address: "${address}"${reason ? ` (${reason})` : ""}`
+    );
+    this.name = "InvalidAddressError";
+  }
+}
+
+/**
+ * Error thrown when a claim type is invalid.
+ */
+export class InvalidClaimTypeError extends TrustLinkValidationError {
+  constructor(claimType: string, reason?: string) {
+    super(
+      `Invalid claim type: "${claimType}"${reason ? ` (${reason})` : ""}`
+    );
+    this.name = "InvalidClaimTypeError";
+  }
+}
+
+/**
+ * Error thrown when a numeric value is out of valid range.
+ */
+export class InvalidNumericValueError extends TrustLinkValidationError {
+  constructor(value: number | bigint, field: string, reason?: string) {
+    super(
+      `Invalid ${field}: ${value}${reason ? ` (${reason})` : ""}`
+    );
+    this.name = "InvalidNumericValueError";
+  }
+}
+
+// ─── Validation Helpers ─────────────────────────────────────────────────────
+
+// Stellar address pattern: starts with G, followed by 56 base32 chars
+const STELLAR_ADDRESS_REGEX = /^G[A-Z0-9]{55}$/i;
+
+// Contract address pattern: starts with C, followed by 56 base32 chars
+const CONTRACT_ADDRESS_REGEX = /^C[A-Z0-9]{55}$/i;
+
+/**
+ * Validates a Stellar address format (G... address).
+ * @param addr - The address string to validate
+ * @throws InvalidAddressError if the address is invalid
+ */
+export function validateAddress(addr: string): void {
+  if (!addr || typeof addr !== "string") {
+    throw new InvalidAddressError(String(addr), "address is required");
+  }
+
+  const trimmed = addr.trim();
+
+  if (trimmed.length === 0) {
+    throw new InvalidAddressError(addr, "address cannot be empty");
+  }
+
+  if (!STELLAR_ADDRESS_REGEX.test(trimmed)) {
+    // Also accept contract addresses (C...)
+    if (!CONTRACT_ADDRESS_REGEX.test(trimmed)) {
+      throw new InvalidAddressError(
+        addr,
+        "must be a valid Stellar address (G... or C...)"
+      );
+    }
+  }
+}
+
+/**
+ * Validates a claim type string.
+ * @param claimType - The claim type to validate
+ * @throws InvalidClaimTypeError if the claim type is invalid
+ */
+export function validateClaimType(claimType: string): void {
+  if (!claimType || typeof claimType !== "string") {
+    throw new InvalidClaimTypeError(String(claimType), "claim type is required");
+  }
+
+  const trimmed = claimType.trim();
+
+  if (trimmed.length === 0) {
+    throw new InvalidClaimTypeError(claimType, "cannot be empty");
+  }
+
+  // Claim types should be UPPER_SNAKE_CASE typically
+  // Allow alphanumeric and underscore, must start with letter
+  if (!/^[a-zA-Z][a-zA-Z0-9_]*$/.test(trimmed)) {
+    throw new InvalidClaimTypeError(
+      claimType,
+      "must start with a letter and contain only letters, numbers, and underscores"
+    );
+  }
+}
+
+/**
+ * Validates a non-negative numeric value.
+ * @param value - The numeric value to validate
+ * @param fieldName - Name of the field for error messages
+ * @throws InvalidNumericValueError if the value is invalid
+ */
+export function validateNonNegative(value: number | bigint, fieldName: string): void {
+  if (typeof value === "number") {
+    if (isNaN(value)) {
+      throw new InvalidNumericValueError(value, fieldName, "is NaN");
+    }
+    if (!isFinite(value)) {
+      throw new InvalidNumericValueError(value, fieldName, "is not finite");
+    }
+    if (value < 0) {
+      throw new InvalidNumericValueError(value, fieldName, "must be non-negative");
+    }
+  } else if (typeof value === "bigint") {
+    if (value < 0n) {
+      throw new InvalidNumericValueError(value, fieldName, "must be non-negative");
+    }
+  }
+}
+
+/**
+ * Validates a positive numeric value.
+ * @param value - The numeric value to validate
+ * @param fieldName - Name of the field for error messages
+ * @throws InvalidNumericValueError if the value is invalid
+ */
+export function validatePositive(value: number | bigint, fieldName: string): void {
+  if (typeof value === "number") {
+    if (isNaN(value)) {
+      throw new InvalidNumericValueError(value, fieldName, "is NaN");
+    }
+    if (!isFinite(value)) {
+      throw new InvalidNumericValueError(value, fieldName, "is not finite");
+    }
+    if (value <= 0) {
+      throw new InvalidNumericValueError(value, fieldName, "must be positive");
+    }
+  } else if (typeof value === "bigint") {
+    if (value <= 0n) {
+      throw new InvalidNumericValueError(value, fieldName, "must be positive");
+    }
+  }
+}
+
+/**
+ * Validates an attestation ID format.
+ * @param id - The attestation ID to validate
+ * @throws TrustLinkValidationError if the ID is invalid
+ */
+export function validateAttestationId(id: string): void {
+  if (!id || typeof id !== "string") {
+    throw new TrustLinkValidationError(`Invalid attestation ID: ${id}`);
+  }
+
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new TrustLinkValidationError("Attestation ID cannot be empty");
+  }
+}
+
+/**
+ * Validates a proposal ID format.
+ * @param id - The proposal ID to validate
+ * @throws TrustLinkValidationError if the ID is invalid
+ */
+export function validateProposalId(id: string): void {
+  if (!id || typeof id !== "string") {
+    throw new TrustLinkValidationError(`Invalid proposal ID: ${id}`);
+  }
+
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new TrustLinkValidationError("Proposal ID cannot be empty");
+  }
+}
+
+/**
+ * Validates a request ID format.
+ * @param id - The request ID to validate
+ * @throws TrustLinkValidationError if the ID is invalid
+ */
+export function validateRequestId(id: string): void {
+  if (!id || typeof id !== "string") {
+    throw new TrustLinkValidationError(`Invalid request ID: ${id}`);
+  }
+
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new TrustLinkValidationError("Request ID cannot be empty");
+  }
+}
+
+/**
+ * Validates a template ID format.
+ * @param id - The template ID to validate
+ * @throws TrustLinkValidationError if the ID is invalid
+ */
+export function validateTemplateId(id: string): void {
+  if (!id || typeof id !== "string") {
+    throw new TrustLinkValidationError(`Invalid template ID: ${id}`);
+  }
+
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new TrustLinkValidationError("Template ID cannot be empty");
+  }
+}


### PR DESCRIPTION
## Summary
- Added client-side input validation before constructing Soroban `ScVal` values in the TypeScript SDK.
- Ported validation logic to ensure inputs are validated before any RPC interaction.
- Added validation for malformed addresses, invalid claim types, and other unsupported input values.
- Improved error reporting by returning clear, descriptive validation errors instead of relying on transaction simulation or on-chain failures.
- Kept the implementation focused on input validation without changing existing SDK behavior.

## Testing
- Verified malformed addresses are rejected with a clear client-side error.
- Verified over-length and invalid claim types are rejected before any RPC call is made.
- Confirmed valid inputs continue to construct `ScVal` objects successfully.
- Verified no RPC request is made when input validation fails.
- Confirmed all existing tests continue to pass.

Closes #968