### PR TITLE
fix: resolve duplicate type defs, missing StorageKey variants, unwrap violations, and configurable chunk size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ soroban-sdk = "21.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "21.0.0", features = ["testutils"] }
-proptest = { version = "1.5.0", default-features = false, features = ["std"] }
+proptest = { version = "=1.2.0", default-features = false, features = ["std"] }
 
 [[test]]
 name = "performance"

--- a/scripts/changelog-preview.sh
+++ b/scripts/changelog-preview.sh
@@ -13,10 +13,46 @@
 #   refactor → Refactoring
 #   test, chore → hidden (not shown)
 #
-# Usage: bash scripts/changelog-preview.sh
-#        make changelog-preview
+# Usage:
+#   bash scripts/changelog-preview.sh [--since <ref>] [--help]
+#   make changelog-preview
+#
+# Options:
+#   --since <ref>   Start scanning from <ref> instead of the last release tag.
+#                   <ref> can be any git ref: a tag, branch, or commit SHA.
+#                   Example: --since v0.1.0  or  --since main
+#   --help          Show this help text and exit.
 
 set -euo pipefail
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+SINCE_REF=""
+
+usage() {
+    sed -n '/^# Usage:/,/^[^#]/{ /^[^#]/d; s/^# \{0,3\}//; p }' "$0"
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --since)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --since requires a git ref argument." >&2
+                exit 1
+            fi
+            SINCE_REF="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            ;;
+        *)
+            echo "Error: Unknown option '$1'. Use --help for usage." >&2
+            exit 1
+            ;;
+    esac
+done
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -38,13 +74,24 @@ bump_version() {
 
 # ── Determine commit range ────────────────────────────────────────────────────
 
-LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-if [ -n "$LAST_TAG" ]; then
-    RANGE="${LAST_TAG}..HEAD"
-    SINCE_MSG="since ${LAST_TAG}"
+if [ -n "$SINCE_REF" ]; then
+    # Validate the provided ref exists in the repository
+    if ! git rev-parse --verify "${SINCE_REF}" >/dev/null 2>&1; then
+        echo "Error: git ref '${SINCE_REF}' not found in this repository." >&2
+        exit 1
+    fi
+    LAST_TAG="$SINCE_REF"
+    RANGE="${SINCE_REF}..HEAD"
+    SINCE_MSG="since ${SINCE_REF} (--since override)"
 else
-    RANGE="HEAD"
-    SINCE_MSG="(no previous release tag found — scanning all commits)"
+    LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+    if [ -n "$LAST_TAG" ]; then
+        RANGE="${LAST_TAG}..HEAD"
+        SINCE_MSG="since ${LAST_TAG}"
+    else
+        RANGE="HEAD"
+        SINCE_MSG="(no previous release tag found — scanning all commits)"
+    fi
 fi
 
 # ── Collect conventional commits ─────────────────────────────────────────────

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -411,6 +411,9 @@ pub fn set_require_registered_claim_type(env: &Env, admin: Address, require: boo
                 fee_token: None,
             }),
             require_registered_claim_type: false,
+            metadata_hash_only: false,
+            multisig_ttl_days: 7,
+            chunk_size: 50,
         }
     });
     
@@ -442,6 +445,54 @@ pub fn get_metadata_hash_only(env: &Env) -> bool {
     Storage::get_contract_config(env)
         .map(|config| config.metadata_hash_only)
         .unwrap_or(false)
+}
+
+/// Sets the `ChunkedIndex` chunk size stored in `ContractConfig`.
+///
+/// The chunk size controls how many attestation IDs are packed into each
+/// on-chain storage entry for the subject/issuer indexes.
+///
+/// **This should only be called before any attestations are written.** Changing
+/// the chunk size after index data exists will cause the old chunks (written
+/// with the previous size) to be read correctly, but new writes will use the
+/// new size, producing inconsistently-sized chunks. A full index migration is
+/// required to normalise an existing index to a new chunk size.
+///
+/// # Errors
+/// - [`Error::Unauthorized`] — caller is not a registered admin.
+/// - [`Error::InvalidInput`] — `chunk_size` is 0.
+pub fn set_chunk_size(env: &Env, admin: Address, chunk_size: u32) -> Result<(), Error> {
+    admin.require_auth();
+    Validation::require_admin(env, &admin)?;
+    if chunk_size == 0 {
+        return Err(Error::InvalidChunkSize);
+    }
+    let mut config = Storage::get_contract_config(env).unwrap_or_else(|| ContractConfig {
+        contract_name: String::from_str(env, "TrustLink"),
+        contract_version: String::from_str(env, ""),
+        contract_description: String::from_str(env, ""),
+        fee_config: crate::types::FeeConfig {
+            attestation_fee: 0,
+            fee_collector: admin.clone(),
+            fee_token: None,
+        },
+        ttl_config: crate::types::TtlConfig { ttl_days: 30 },
+        require_registered_claim_type: false,
+        metadata_hash_only: false,
+        multisig_ttl_days: 7,
+        chunk_size: 50,
+    });
+    config.chunk_size = chunk_size;
+    Storage::set_contract_config(env, &config);
+    Ok(())
+}
+
+/// Returns the currently configured `ChunkedIndex` chunk size (default: 50).
+pub fn get_chunk_size(env: &Env) -> u32 {
+    Storage::get_contract_config(env)
+        .map(|config| config.chunk_size)
+        .filter(|&s| s >= 1)
+        .unwrap_or(50)
 }
 
 // -----------------------------------------------------------------------

--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -894,7 +894,9 @@ pub fn list_endorsements_by_endorser(env: &Env, endorser: Address, start: u32, l
     let end = (start + limit).min(total);
     let mut result = Vec::new(env);
     for i in start..end {
-        result.push_back(all.get(i).unwrap());
+        if let Some(item) = all.get(i) {
+            result.push_back(item);
+        }
     }
     result
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -55,4 +55,6 @@ pub enum Error {
     LimitExceeded = 29,
     /// The proposal has been cancelled by the proposer.
     ProposalCancelled = 30,
+    /// `chunk_size` passed to `set_chunk_size` is 0 or otherwise out of range.
+    InvalidChunkSize = 31,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,6 +279,19 @@ impl TrustLinkContract {
         admin::get_metadata_hash_only(&env)
     }
 
+    /// Sets the `ChunkedIndex` chunk size (number of attestation IDs per
+    /// storage entry). Admin-only. See [`admin::set_chunk_size`] for
+    /// important caveats about calling this after data has been written.
+    pub fn set_chunk_size(env: Env, admin: Address, chunk_size: u32) -> Result<(), Error> {
+        admin::set_chunk_size(&env, admin, chunk_size)
+    }
+
+    /// Returns the currently configured `ChunkedIndex` chunk size (default: 50).
+    #[must_use]
+    pub fn get_chunk_size(env: Env) -> u32 {
+        admin::get_chunk_size(&env)
+    }
+
     // -----------------------------------------------------------------------
     // Limits
     // -----------------------------------------------------------------------
@@ -969,6 +982,9 @@ impl TrustLinkContract {
                 "On-chain attestation and verification system for the Stellar blockchain.",
             ),
             multisig_ttl_days: Storage::get_multisig_ttl(&env),
+            require_registered_claim_type: admin::get_require_registered_claim_type(&env),
+            metadata_hash_only: admin::get_metadata_hash_only(&env),
+            chunk_size: admin::get_chunk_size(&env),
         }
     }
 

--- a/src/multisig.rs
+++ b/src/multisig.rs
@@ -75,6 +75,7 @@ pub fn propose_attestation(
         created_at: timestamp,
         expires_at: timestamp + MULTISIG_PROPOSAL_TTL_SECS,
         finalized: false,
+        cancelled: false,
     };
     Storage::set_multisig_proposal(env, &proposal);
     Events::multisig_proposed(env, &proposal_id, &proposer, &subject, threshold);

--- a/src/query.rs
+++ b/src/query.rs
@@ -252,7 +252,6 @@ pub fn get_attestations_in_range_after(
     if let Some(cursor_id) = after_attestation_id {
         let mut cursor_found = false;
         let mut cursor_timestamp: u64 = 0;
-        let mut cursor_id_ref = cursor_id.clone();
         if let Ok(cursor_attestation) = Storage::get_attestation(env, &cursor_id) {
             cursor_timestamp = cursor_attestation.timestamp;
             for i in 0..filtered.len() {
@@ -272,7 +271,7 @@ pub fn get_attestations_in_range_after(
             for i in 0..filtered.len() {
                 if let Some(attestation) = filtered.get(i) {
                     if attestation.timestamp > cursor_timestamp
-                        || (attestation.timestamp == cursor_timestamp && attestation.id > cursor_id_ref)
+                        || (attestation.timestamp == cursor_timestamp && attestation.id > cursor_id)
                     {
                         start_index = i;
                         cursor_found = true;
@@ -469,11 +468,11 @@ pub fn get_expiring_attestations(
     let len = filtered.len();
     for i in 0..len {
         for j in 0..len - i - 1 {
-            let a = filtered.get(j).unwrap();
-            let b = filtered.get(j + 1).unwrap();
-            if a.expiration.unwrap_or(u64::MAX) > b.expiration.unwrap_or(u64::MAX) {
-                filtered.set(j, b);
-                filtered.set(j + 1, a);
+            if let (Some(a), Some(b)) = (filtered.get(j), filtered.get(j + 1)) {
+                if a.expiration.unwrap_or(u64::MAX) > b.expiration.unwrap_or(u64::MAX) {
+                    filtered.set(j, b);
+                    filtered.set(j + 1, a);
+                }
             }
         }
     }
@@ -520,11 +519,11 @@ pub fn get_issuer_expiring_attestations(
     let len = filtered.len();
     for i in 0..len {
         for j in 0..len - i - 1 {
-            let a = filtered.get(j).unwrap();
-            let b = filtered.get(j + 1).unwrap();
-            if a.expiration.unwrap_or(u64::MAX) > b.expiration.unwrap_or(u64::MAX) {
-                filtered.set(j, b);
-                filtered.set(j + 1, a);
+            if let (Some(a), Some(b)) = (filtered.get(j), filtered.get(j + 1)) {
+                if a.expiration.unwrap_or(u64::MAX) > b.expiration.unwrap_or(u64::MAX) {
+                    filtered.set(j, b);
+                    filtered.set(j + 1, a);
+                }
             }
         }
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -4,9 +4,10 @@
 
 use crate::constants::{DAY_IN_LEDGERS, DEFAULT_INSTANCE_LIFETIME};
 use crate::types::{
-    Attestation, AttestationRequest, AuditEntry, ClaimTypeInfo, Endorsement, Error, ExpirationHook,
-    FeeConfig, GlobalStats, IssuerMetadata, IssuerStats, IssuerTier, MultiSigProposal,
-    RateLimitConfig, StorageLimits, TtlConfig,
+    AdminCouncil, Attestation, AttestationRequest, AttestationTemplate, AuditEntry, ClaimTypeConstraints,
+    ClaimTypeInfo, CouncilProposal, DecayConfig, Delegation, DisputeRecord, Endorsement, Error,
+    ExpirationHook, FeeConfig, GlobalStats, IssuerMetadata, IssuerStats, IssuerTier,
+    MultiSigProposal, PendingAdminTransfer, RateLimitConfig, StorageLimits, TtlConfig,
 };
 use soroban_sdk::{contracttype, Address, Env, String, Vec};
 
@@ -20,6 +21,8 @@ pub enum StorageKey {
     ContractConfig,
     Issuer(Address),
     Bridge(Address),
+    /// Ordered list of all registered bridge addresses.
+    BridgeList,
     Attestation(String),
     SubjectAttestations(Address),
     IssuerAttestations(Address),
@@ -30,6 +33,10 @@ pub enum StorageKey {
     ClaimTypeList,
     /// Constraints for a specific claim type.
     ClaimTypeConstraints(String),
+    /// Per-claim-type attestation count across all issuers.
+    ClaimTypeCount(String),
+    /// Per-claim-type minimum issuance interval (rate limit).
+    ClaimTypeRateLimit(String),
     IssuerList,
     MultisigTtlDays,
     IssuerTier(Address),
@@ -37,7 +44,11 @@ pub enum StorageKey {
     GlobalStats,
     ExpirationHook(Address),
     Endorsements(String),
+    /// Index of attestation IDs endorsed by a given endorser.
+    EndorserIndex(Address),
     StorageLimits,
+    /// Alias for StorageLimits used in some code paths.
+    Limits,
     RateLimitConfig,
     LastIssuanceTime(Address),
     IssuerWhitelistMode(Address),
@@ -49,6 +60,10 @@ pub enum StorageKey {
     AuditLog(String),
     /// Multi-sig proposal keyed by proposal ID.
     MultiSigProposal(String),
+    /// Admin council proposal keyed by proposal ID.
+    CouncilProposal(u32),
+    /// Monotonic counter for admin council proposal IDs.
+    ProposalCounter,
     /// An attestation request record.
     AttestationRequest(String),
     IssuerPendingRequests(Address),
@@ -58,14 +73,30 @@ pub enum StorageKey {
     WhitelistEnabled(Address),
     /// Presence flag for a whitelisted subject under a specific issuer.
     SubjectWhitelist(Address, Address),
-    /// Rate limit configuration (minimum seconds between attestations).
-    RateLimitConfig,
-    /// Last attestation issuance timestamp per issuer.
-    LastIssuanceTime(Address),
     /// Ordered list of proposal IDs for a subject (for list_open_proposals).
     ProposalIndex(Address),
     /// Configurable TTL in days for multisig proposals (default: 7).
     MultisigTtl,
+    /// Pending two-step admin transfer.
+    PendingAdminTransfer,
+    /// Attestation template keyed by (issuer, template_id).
+    AttestationTemplate(Address, String),
+    /// Ordered list of template IDs for a given issuer.
+    AttestationTemplateList(Address),
+    /// Index of valid attestation IDs for a subject (optimised lookup).
+    ValidAttestations(Address),
+    /// Delegation record keyed by (delegator, delegate, claim_type).
+    Delegation(Address, Address, String),
+    /// Index of active delegations for a delegator.
+    DelegatorIndex(Address),
+    /// Decay configuration for issuer reputation scoring.
+    DecayConfig,
+    /// Active dispute record for an attestation.
+    Dispute(String),
+    /// Timelock delay in seconds for council action execution.
+    CouncilTimelockDelay,
+    /// Cumulative revocation count for an issuer (used in confidence scoring).
+    IssuerRevocations(Address),
 }
 
 /// Composite key for per-issuer-per-claim-type last issuance timestamps.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1196,7 +1196,18 @@ pub fn paginate_addresses(env: &Env, list: &Vec<Address>, start: u32, limit: u32
     result
 }
 
-const CHUNKED_INDEX_CHUNK_SIZE: u32 = 50;
+/// Default chunk size used when no value has been configured in `ContractConfig`.
+const DEFAULT_CHUNK_SIZE: u32 = 50;
+
+/// Returns the configured `ChunkedIndex` chunk size, falling back to
+/// `DEFAULT_CHUNK_SIZE` when the contract has not been initialised yet or
+/// when `chunk_size` was not explicitly stored.
+fn get_chunk_size(env: &Env) -> u32 {
+    Storage::get_contract_config(env)
+        .map(|cfg| cfg.chunk_size)
+        .filter(|&s| s >= 1)
+        .unwrap_or(DEFAULT_CHUNK_SIZE)
+}
 
 pub struct ChunkedIndex;
 
@@ -1239,11 +1250,12 @@ impl ChunkedIndex {
 
     fn write_subject_chunks(env: &Env, subject: &Address, ids: &Vec<String>) {
         let ttl = get_ttl_lifetime(env);
+        let chunk_size = get_chunk_size(env);
         let mut chunk_index = 0;
         let mut offset = 0;
         while offset < ids.len() {
             let mut chunk = Vec::new(env);
-            for _ in 0..CHUNKED_INDEX_CHUNK_SIZE {
+            for _ in 0..chunk_size {
                 if let Some(id) = ids.get(offset) {
                     chunk.push_back(id.clone());
                     offset += 1;
@@ -1272,11 +1284,12 @@ impl ChunkedIndex {
 
     fn write_issuer_chunks(env: &Env, issuer: &Address, ids: &Vec<String>) {
         let ttl = get_ttl_lifetime(env);
+        let chunk_size = get_chunk_size(env);
         let mut chunk_index = 0;
         let mut offset = 0;
         while offset < ids.len() {
             let mut chunk = Vec::new(env);
-            for _ in 0..CHUNKED_INDEX_CHUNK_SIZE {
+            for _ in 0..chunk_size {
                 if let Some(id) = ids.get(offset) {
                     chunk.push_back(id.clone());
                     offset += 1;

--- a/src/types.rs
+++ b/src/types.rs
@@ -94,19 +94,6 @@ pub struct MultiSigProposal {
     pub cancelled: bool,
 }
 
-/// Full contract configuration snapshot returned by `get_config`.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ContractConfig {
-    pub ttl_config: TtlConfig,
-    pub fee_config: FeeConfig,
-    pub contract_name: String,
-    pub contract_version: String,
-    pub contract_description: String,
-    /// Configurable TTL for multisig proposals in days (default: 7).
-    pub multisig_ttl_days: u32,
-}
-
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ContractMetadata {
@@ -152,13 +139,6 @@ pub struct HealthStatus {
     pub total_attestations: u64,
 }
 
-/// Issuer statistics.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct IssuerStats {
-    pub total_issued: u64,
-}
-
 /// TTL configuration.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -173,7 +153,7 @@ pub struct RateLimitConfig {
     pub min_issuance_interval: u64,
 }
 
-/// Contract configuration.
+/// Full contract configuration snapshot returned by `get_config`.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ContractConfig {
@@ -187,6 +167,8 @@ pub struct ContractConfig {
     /// `None` or a 64-character lowercase hexadecimal string (SHA-256 hash).
     /// Enables enforcement of GDPR data-minimisation at the contract level.
     pub metadata_hash_only: bool,
+    /// Configurable TTL for multisig proposals in days (default: 7).
+    pub multisig_ttl_days: u32,
 }
 
 #[contracttype]
@@ -299,22 +281,6 @@ pub struct Endorsement {
     pub timestamp: u64,
 }
 
-/// A multi-signature attestation proposal requiring threshold signatures.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct MultiSigProposal {
-    pub id: String,
-    pub proposer: Address,
-    pub subject: Address,
-    pub claim_type: String,
-    pub required_signers: Vec<Address>,
-    pub threshold: u32,
-    pub signers: Vec<Address>,
-    pub created_at: u64,
-    pub expires_at: u64,
-    pub finalized: bool,
-}
-
 /// Configurable storage limits to prevent exhaustion attacks.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -330,14 +296,6 @@ impl Default for StorageLimits {
             max_attestations_per_subject: 100,
         }
     }
-}
-
-/// Expiration notification hook configuration.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ExpirationHook {
-    pub callback_contract: Address,
-    pub notify_days_before: u32,
 }
 
 /// Delegation from an issuer to a sub-issuer for specific claim types.

--- a/src/types.rs
+++ b/src/types.rs
@@ -169,6 +169,15 @@ pub struct ContractConfig {
     pub metadata_hash_only: bool,
     /// Configurable TTL for multisig proposals in days (default: 7).
     pub multisig_ttl_days: u32,
+    /// Number of attestation IDs stored per chunk in the `ChunkedIndex`.
+    ///
+    /// Larger values reduce storage-read counts for high-volume issuers/subjects
+    /// at the cost of larger individual reads/writes. Smaller values keep each
+    /// read/write cheap at the cost of more round-trips for large indexes.
+    /// Must be ≥ 1. Defaults to 50 when not explicitly set.
+    /// **Should only be changed before any attestations are written**; changing
+    /// it afterwards requires a full index migration.
+    pub chunk_size: u32,
 }
 
 #[contracttype]

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -18,6 +18,33 @@ use crate::storage::Storage;
 use crate::types::Error;
 use soroban_sdk::{Address, Env, String};
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared byte-copy helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Copies the bytes of a Soroban SDK `String` into a fixed 64-byte stack
+/// buffer and returns both the buffer and the number of bytes written.
+///
+/// This single helper eliminates the duplicate hand-written buffer-copy logic
+/// that previously appeared in both `validate_claim_type` and
+/// `validate_metadata_hash_only`. Both validators now call this function,
+/// ensuring consistent behaviour if the buffer size or bounds-check ever
+/// needs to change.
+///
+/// # Panics
+/// Panics (via an out-of-bounds slice) if `s.len() > 64`.
+/// All callers **must** validate length ≤ 64 before invoking this helper.
+fn copy_into_fixed_buffer(s: &String) -> ([u8; 64], usize) {
+    let len = s.len() as usize;
+    let mut buf = [0u8; 64];
+    s.copy_into_slice(&mut buf[..len]);
+    (buf, len)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Validation guards
+// ─────────────────────────────────────────────────────────────────────────────
+
 /// Authorization checks used by contract entry points.
 pub struct Validation;
 
@@ -103,12 +130,9 @@ impl Validation {
         if len == 0 || len > 64 {
             return Err(Error::InvalidClaimType);
         }
-        // Copy bytes out of the host-side String for inspection.
-        // len is u32 in Soroban SDK; safe to cast since we already checked <= 64.
-        let mut buf = [0u8; 64];
-        let slice = &mut buf[..len as usize];
-        claim_type.copy_into_slice(slice);
-        for &b in slice.iter() {
+        // Use the shared helper; length is already verified <= 64 above.
+        let (buf, byte_len) = copy_into_fixed_buffer(claim_type);
+        for &b in buf[..byte_len].iter() {
             let is_alpha = b.is_ascii_alphabetic();
             let is_digit = b.is_ascii_digit();
             let is_underscore = b == b'_';
@@ -151,8 +175,8 @@ impl Validation {
                 if value.len() != 64 {
                     return Err(Error::InvalidMetadata);
                 }
-                let mut buf = [0u8; 64];
-                value.copy_into_slice(&mut buf);
+                // Use the shared helper; length is exactly 64 verified above.
+                let (buf, _) = copy_into_fixed_buffer(value);
                 for &b in buf.iter() {
                     if !matches!(b, b'0'..=b'9' | b'a'..=b'f') {
                         return Err(Error::InvalidMetadata);


### PR DESCRIPTION
## Summary

Fixes four issues identified in the Stellar Wave audit sweep.

### Fixes

**#577 — Add `--since` flag to `changelog-preview.sh`**
- Added `--since <ref>` option allowing changelog preview to be scoped to any git ref (tag, branch, or SHA)
- Added `--help` / `-h` option with usage text
- Input validation: unknown flags and missing `--since` argument both exit with an error

**#954 — Extract shared 64-byte buffer-copy helper in `validation.rs`**
- Extracted `copy_into_fixed_buffer()` helper used by both `validate_claim_type` and `validate_metadata_hash_only`
- Eliminates duplicate hand-written buffer-copy logic; consistent bounds behaviour going forward

**#955 — Fix `.unwrap()` calls violating `#![deny(clippy::unwrap_used)]`**
- `query.rs`: replaced bare `.unwrap()` in `get_expiring_attestations` and `get_issuer_expiring_attestations` bubble-sort loops with safe `if let (Some(a), Some(b))` pattern
- `attestation.rs`: replaced `.unwrap()` in `list_endorsements_by_endorser` with `if let Some(item)` guard
- `query.rs`: removed vestigial `cursor_id_ref` unused-mut variable in `get_attestations_in_range_after` (related cleanup, closes #942)

**#956 — Make `ChunkedIndex` chunk size admin-configurable**
- Moved hardcoded `CHUNKED_INDEX_CHUNK_SIZE = 50` constant into `ContractConfig.chunk_size`
- `storage.rs`: added `get_chunk_size(env)` helper that reads from `ContractConfig`, falling back to 50
- `admin.rs` / `lib.rs`: added `set_chunk_size(admin, chunk_size)` and `get_chunk_size()` contract entry points
- `errors.rs`: added `InvalidChunkSize = 31` error variant for `chunk_size == 0`
- Should only be called before attestations are written; documented in function-level doc comment

### Related fixes (surface issues uncovered during the above work)
- `types.rs`: removed duplicate `ContractConfig`, `IssuerStats`, `ExpirationHook`, and `MultiSigProposal` definitions (closes #912); consolidated `ContractConfig` now includes `multisig_ttl_days`, `metadata_hash_only`, and `chunk_size` fields
- `storage.rs`: removed duplicate `RateLimitConfig` and `LastIssuanceTime` variants from `StorageKey` (closes #911); added ~15 missing `StorageKey` variants referenced by other modules (closes #918)
- `multisig.rs`: added missing `cancelled: false` to `MultiSigProposal` constructor (surface fix from #912 dedup)
- `Cargo.toml`: pinned `proptest` to `=1.2.0` (exact version) for reproducible `no_std` builds

## Testing

The pre-existing build has 170+ errors unrelated to these changes (tracked in #910, #914, #915, #916, #919, #922, etc.). The changes in this PR reduce the error count — no new errors introduced, verified with `cargo check --lib` before/after diff.

Closes #577
Closes #942
Closes #954
Closes #955
Closes #956