### PR TITLE
feat(react): implement and export useGlobalStats hook (#962)

### DIFF
--- a/sdk/react/src/__tests__/index.test.ts
+++ b/sdk/react/src/__tests__/index.test.ts
@@ -5,4 +5,8 @@ describe("sdk/react/src/index exports", () => {
   it("exports useIssuerStats", () => {
     expect(typeof sdkReact.useIssuerStats).toBe("function");
   });
+
+  it("exports useGlobalStats", () => {
+    expect(typeof sdkReact.useGlobalStats).toBe("function");
+  });
 });

--- a/sdk/react/src/__tests__/useGlobalStats.test.ts
+++ b/sdk/react/src/__tests__/useGlobalStats.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useGlobalStats, GlobalStats } from "../useGlobalStats";
+
+const mockStats: GlobalStats = {
+  total_attestations: 1500,
+  total_revocations: 42,
+  total_issuers: 7,
+};
+
+describe("useGlobalStats", () => {
+  it("returns loading=true initially", () => {
+    const fetchStats = vi.fn(() => new Promise<GlobalStats>(() => {}));
+    const { result } = renderHook(() => useGlobalStats(fetchStats));
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("returns data on successful fetch", async () => {
+    const fetchStats = vi.fn().mockResolvedValue(mockStats);
+    const { result } = renderHook(() => useGlobalStats(fetchStats));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toEqual(mockStats);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("populates all three stat fields correctly", async () => {
+    const fetchStats = vi.fn().mockResolvedValue(mockStats);
+    const { result } = renderHook(() => useGlobalStats(fetchStats));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data?.total_attestations).toBe(1500);
+    expect(result.current.data?.total_revocations).toBe(42);
+    expect(result.current.data?.total_issuers).toBe(7);
+  });
+
+  it("returns error on failed fetch", async () => {
+    const fetchStats = vi.fn().mockRejectedValue(new Error("network error"));
+    const { result } = renderHook(() => useGlobalStats(fetchStats));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe("network error");
+  });
+
+  it("wraps non-Error rejections in an Error", async () => {
+    const fetchStats = vi.fn().mockRejectedValue("string error");
+    const { result } = renderHook(() => useGlobalStats(fetchStats));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe("string error");
+  });
+
+  it("re-fetches when fetchStats reference changes", async () => {
+    const fetchStats1 = vi.fn().mockResolvedValue(mockStats);
+    const fetchStats2 = vi.fn().mockResolvedValue({
+      ...mockStats,
+      total_attestations: 2000,
+    });
+
+    const { result, rerender } = renderHook(
+      ({ fn }: { fn: () => Promise<GlobalStats> }) => useGlobalStats(fn),
+      { initialProps: { fn: fetchStats1 } }
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data?.total_attestations).toBe(1500);
+
+    rerender({ fn: fetchStats2 });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data?.total_attestations).toBe(2000);
+    expect(fetchStats2).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores stale response if hook unmounts before fetch resolves", async () => {
+    let resolve!: (v: GlobalStats) => void;
+    const fetchStats = vi.fn(
+      () => new Promise<GlobalStats>((res) => { resolve = res; })
+    );
+    const { result, unmount } = renderHook(() => useGlobalStats(fetchStats));
+    expect(result.current.loading).toBe(true);
+    unmount();
+    // Resolve after unmount — should not cause state update or error
+    resolve(mockStats);
+    // No assertion to make (just must not throw)
+  });
+
+  it("sets loading back to false after error", async () => {
+    const fetchStats = vi.fn().mockRejectedValue(new Error("fail"));
+    const { result } = renderHook(() => useGlobalStats(fetchStats));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).not.toBeNull();
+  });
+});

--- a/sdk/react/src/index.ts
+++ b/sdk/react/src/index.ts
@@ -1,2 +1,5 @@
 export { useIssuerStats } from "./useIssuerStats";
 export type { IssuerStats, UseIssuerStatsResult } from "./useIssuerStats";
+
+export { useGlobalStats } from "./useGlobalStats";
+export type { GlobalStats, UseGlobalStatsResult } from "./useGlobalStats";

--- a/sdk/react/src/useGlobalStats.ts
+++ b/sdk/react/src/useGlobalStats.ts
@@ -1,0 +1,63 @@
+import { useState, useEffect } from "react";
+
+export interface GlobalStats {
+  total_attestations: number;
+  total_revocations: number;
+  total_issuers: number;
+}
+
+export interface UseGlobalStatsResult {
+  data: GlobalStats | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Fetches contract-wide global statistics.
+ *
+ * Mirrors the `get_global_stats` contract function which returns:
+ *   - total_attestations: cumulative count of all attestations ever created
+ *   - total_revocations:  cumulative count of all revocations
+ *   - total_issuers:      current number of registered issuers
+ *
+ * @param fetchStats - Async function that retrieves GlobalStats (no arguments;
+ *   supply a bound or arrow function that calls your RPC client).
+ *
+ * @example
+ * ```tsx
+ * const { data, loading, error } = useGlobalStats(
+ *   () => trustlinkClient.getGlobalStats()
+ * );
+ * ```
+ */
+export function useGlobalStats(
+  fetchStats: () => Promise<GlobalStats>
+): UseGlobalStatsResult {
+  const [data, setData] = useState<GlobalStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchStats()
+      .then((stats) => {
+        if (!cancelled) {
+          setData(stats);
+          setLoading(false);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [fetchStats]);
+
+  return { data, loading, error };
+}


### PR DESCRIPTION
sdk/react/src/index.ts exported only useIssuerStats. Consumers trying to import { useGlobalStats } from '@trustlink/react' received nothing.

Changes:
- sdk/react/src/useGlobalStats.ts: new hook that fetches contract-wide GlobalStats (total_attestations, total_revocations, total_issuers). Mirrors the useIssuerStats pattern: accepts a fetchStats callback, manages loading/data/error state, cancels stale responses on unmount.
- sdk/react/src/index.ts: barrel-exports useGlobalStats and its types
- sdk/react/src/__tests__/useGlobalStats.test.ts: 8 test cases covering initial loading state, successful fetch, field values, error handling, non-Error rejection wrapping, refetch on callback change, stale-unmount safety, and loading=false after error
- sdk/react/src/__tests__/index.test.ts: asserts both useIssuerStats and useGlobalStats are exported from the package root

Acceptance criteria met:
  ✅ useGlobalStats importable from @trustlink/react package root ✅ Covered by tests in sdk/react/src/__tests__/useGlobalStats.test.ts

## Summary of Changes

<!-- Describe what this PR does and why. Link to the relevant issue(s). -->

Closes #962 
Closes #963 
Closes #964 
Closes #965 

## Type of Change

<!-- Mark the applicable type with an "x". -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [ ] Other (describe):

## Testing Done

<!-- Describe the tests you ran and how to reproduce them. -->

- [ ] `cargo test` passes locally
- [ ] New tests added for this change (if applicable)

## Checklist

- [ ] All tests pass (`cargo test`)
- [ ] Code is formatted (`cargo fmt -- --check`)
- [ ] No Clippy warnings (`cargo clippy --all-targets -- -D warnings`)
- [ ] Commit messages follow [Conventional Commits](../CONTRIBUTING.md#commit-message-conventions)
- [ ] Documentation updated (if behaviour changed)
- [ ] No secrets, tokens, or credentials committed
