### PR TITLE
feat(errors): single source of truth for contract error codes (#964)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,3 +271,34 @@ jobs:
             echo "Run 'make bindings' locally and commit the updated bindings/typescript/ directory."
             exit 1
           )
+
+  error-codes:
+    name: Error Code Single Source of Truth
+    runs-on: ubuntu-latest
+    needs: ci
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Regenerate error-code artifacts
+        run: node scripts/generate-error-codes.mjs
+
+      - name: Fail if any generated artifact is out of date
+        run: |
+          git diff --exit-code \
+            error-codes.json \
+            sdk/typescript/src/generated/error-codes.ts \
+            bindings/typescript/src/generated/error-codes.ts \
+            bindings/python/trustlink/generated_error_codes.py || (
+            echo "::error::Generated error-code files are out of date."
+            echo "Run 'node scripts/generate-error-codes.mjs' locally and commit the results."
+            exit 1
+          )
+
+      - name: Verify all clients reference the generated source
+        run: node scripts/check-error-codes.mjs

--- a/bindings/python/trustlink/generated_error_codes.py
+++ b/bindings/python/trustlink/generated_error_codes.py
@@ -1,0 +1,42 @@
+"""
+GENERATED FILE — DO NOT EDIT BY HAND.
+Run `node scripts/generate-error-codes.mjs` (or `make generate`) to regenerate.
+Source of truth: src/errors.rs
+"""
+
+from typing import Dict
+
+# Map of contract error code -> error name, generated from src/errors.rs.
+CONTRACT_ERRORS: Dict[int, str] = {
+    1: "AlreadyInitialized",
+    2: "NotInitialized",
+    3: "Unauthorized",  # Caller lacks required permissions. Includes rejection when `issuer` equals `subject` in `create_attestation`.
+    4: "NotFound",
+    5: "DuplicateAttestation",
+    6: "AlreadyRevoked",
+    7: "Expired",
+    8: "InvalidValidFrom",
+    9: "InvalidExpiration",
+    10: "MetadataTooLong",
+    11: "InvalidTimestamp",
+    12: "InvalidFee",
+    13: "FeeTokenRequired",
+    14: "TooManyTags",
+    15: "TagTooLong",
+    16: "InvalidThreshold",  # Threshold must be >= 1 and <= number of required signers.
+    17: "NotRequiredSigner",  # The signer is not in the proposal's required_signers list.
+    18: "AlreadySigned",  # The signer has already co-signed this proposal.
+    19: "ProposalFinalized",  # The proposal has already been finalized.
+    20: "ProposalExpired",  # The proposal has expired without reaching threshold.
+    21: "ReasonTooLong",  # The revocation reason exceeds the maximum allowed length of 128 characters.
+    22: "CannotEndorseOwn",  # Endorser cannot endorse their own attestation.
+    23: "AlreadyEndorsed",  # Endorser has already endorsed this attestation.
+    24: "ContractPaused",  # The contract is paused; write operations are temporarily disabled.
+    25: "SubjectNotWhitelisted",  # Subject is not on the issuer's whitelist and the issuer has whitelist mode enabled.
+    26: "InvalidClaimType",  # Claim type string is empty, too long, or contains disallowed characters.
+    27: "InvalidJurisdiction",  # Jurisdiction code is not a valid ISO 3166-1 alpha-2 code.
+    28: "RateLimited",  # Issuer has exceeded the minimum issuance interval (rate limit).
+    29: "LimitExceeded",  # Storage limit exceeded for issuer or subject.
+    30: "ProposalCancelled",  # The proposal has been cancelled by the proposer.
+    44: "InvalidSourceReference",  # Source reference string is missing or empty.
+}

--- a/bindings/python/trustlink/types.py
+++ b/bindings/python/trustlink/types.py
@@ -100,19 +100,6 @@ class ContractError(TrustLinkError):
         super().__init__(f"Contract error #{code}: {message}")
 
 
-# Contract error codes
-CONTRACT_ERRORS = {
-    0: "AlreadyInitialized",
-    1: "NotInitialized",
-    2: "Unauthorized",
-    3: "NotFound",
-    4: "DuplicateAttestation",
-    5: "AlreadyRevoked",
-    6: "Expired",
-    7: "LimitExceeded",
-    8: "InvalidThreshold",
-    9: "NotRequiredSigner",
-    10: "AlreadySigned",
-    11: "ProposalFinalized",
-    12: "ProposalExpired",
-}
+# Contract error codes are generated from src/errors.rs — do not hand-edit.
+# Run `node scripts/generate-error-codes.mjs` (or `make generate`) to regenerate.
+from trustlink.generated_error_codes import CONTRACT_ERRORS  # noqa: E402, F401

--- a/bindings/typescript/src/generated/error-codes.ts
+++ b/bindings/typescript/src/generated/error-codes.ts
@@ -1,0 +1,40 @@
+/**
+ * GENERATED FILE — DO NOT EDIT BY HAND.
+ * Run `node scripts/generate-error-codes.mjs` (or `make generate`) to regenerate.
+ * Source of truth: src/errors.rs
+ */
+
+/** Map of contract error code → error name, generated from src/errors.rs. */
+export const ERROR_CODES: Readonly<Record<number, string>> = {
+  1: "AlreadyInitialized",
+  2: "NotInitialized",
+  3: "Unauthorized",  // Caller lacks required permissions. Includes rejection when `issuer` equals `subject` in `create_attestation`.
+  4: "NotFound",
+  5: "DuplicateAttestation",
+  6: "AlreadyRevoked",
+  7: "Expired",
+  8: "InvalidValidFrom",
+  9: "InvalidExpiration",
+  10: "MetadataTooLong",
+  11: "InvalidTimestamp",
+  12: "InvalidFee",
+  13: "FeeTokenRequired",
+  14: "TooManyTags",
+  15: "TagTooLong",
+  16: "InvalidThreshold",  // Threshold must be >= 1 and <= number of required signers.
+  17: "NotRequiredSigner",  // The signer is not in the proposal's required_signers list.
+  18: "AlreadySigned",  // The signer has already co-signed this proposal.
+  19: "ProposalFinalized",  // The proposal has already been finalized.
+  20: "ProposalExpired",  // The proposal has expired without reaching threshold.
+  21: "ReasonTooLong",  // The revocation reason exceeds the maximum allowed length of 128 characters.
+  22: "CannotEndorseOwn",  // Endorser cannot endorse their own attestation.
+  23: "AlreadyEndorsed",  // Endorser has already endorsed this attestation.
+  24: "ContractPaused",  // The contract is paused; write operations are temporarily disabled.
+  25: "SubjectNotWhitelisted",  // Subject is not on the issuer's whitelist and the issuer has whitelist mode enabled.
+  26: "InvalidClaimType",  // Claim type string is empty, too long, or contains disallowed characters.
+  27: "InvalidJurisdiction",  // Jurisdiction code is not a valid ISO 3166-1 alpha-2 code.
+  28: "RateLimited",  // Issuer has exceeded the minimum issuance interval (rate limit).
+  29: "LimitExceeded",  // Storage limit exceeded for issuer or subject.
+  30: "ProposalCancelled",  // The proposal has been cancelled by the proposer.
+  44: "InvalidSourceReference",  // Source reference string is missing or empty.
+} as const;

--- a/bindings/typescript/src/types.ts
+++ b/bindings/typescript/src/types.ts
@@ -151,6 +151,10 @@ export interface TtlConfig {
 
 // ─── Errors ───────────────────────────────────────────────────────────────────
 
+// Error code table is generated from src/errors.rs — do not hand-edit.
+// Run `node scripts/generate-error-codes.mjs` (or `make generate`) to regenerate.
+export { ERROR_CODES as CONTRACT_ERRORS } from "./generated/error-codes";
+
 export enum ContractErrorCode {
   AlreadyInitialized = 1,
   NotInitialized = 2,
@@ -182,40 +186,8 @@ export enum ContractErrorCode {
   RateLimited = 28,
   LimitExceeded = 29,
   ProposalCancelled = 30,
+  InvalidSourceReference = 44,
 }
-
-export const CONTRACT_ERRORS: Record<number, string> = {
-  1: "AlreadyInitialized",
-  2: "NotInitialized",
-  3: "Unauthorized",
-  4: "NotFound",
-  5: "DuplicateAttestation",
-  6: "AlreadyRevoked",
-  7: "Expired",
-  8: "InvalidValidFrom",
-  9: "InvalidExpiration",
-  10: "MetadataTooLong",
-  11: "InvalidTimestamp",
-  12: "InvalidFee",
-  13: "FeeTokenRequired",
-  14: "TooManyTags",
-  15: "TagTooLong",
-  16: "InvalidThreshold",
-  17: "NotRequiredSigner",
-  18: "AlreadySigned",
-  19: "ProposalFinalized",
-  20: "ProposalExpired",
-  21: "ReasonTooLong",
-  22: "CannotEndorseOwn",
-  23: "AlreadyEndorsed",
-  24: "ContractPaused",
-  25: "SubjectNotWhitelisted",
-  26: "InvalidClaimType",
-  27: "InvalidJurisdiction",
-  28: "RateLimited",
-  29: "LimitExceeded",
-  30: "ProposalCancelled",
-};
 
 // ─── XDR helpers ──────────────────────────────────────────────────────────────
 

--- a/error-codes.json
+++ b/error-codes.json
@@ -1,0 +1,161 @@
+{
+  "generated": "2026-07-28T23:13:05.000Z",
+  "source": "src/errors.rs",
+  "errors": [
+    {
+      "code": 1,
+      "name": "AlreadyInitialized",
+      "description": null
+    },
+    {
+      "code": 2,
+      "name": "NotInitialized",
+      "description": null
+    },
+    {
+      "code": 3,
+      "name": "Unauthorized",
+      "description": "Caller lacks required permissions. Includes rejection when `issuer` equals `subject` in `create_attestation`."
+    },
+    {
+      "code": 4,
+      "name": "NotFound",
+      "description": null
+    },
+    {
+      "code": 5,
+      "name": "DuplicateAttestation",
+      "description": null
+    },
+    {
+      "code": 6,
+      "name": "AlreadyRevoked",
+      "description": null
+    },
+    {
+      "code": 7,
+      "name": "Expired",
+      "description": null
+    },
+    {
+      "code": 8,
+      "name": "InvalidValidFrom",
+      "description": null
+    },
+    {
+      "code": 9,
+      "name": "InvalidExpiration",
+      "description": null
+    },
+    {
+      "code": 10,
+      "name": "MetadataTooLong",
+      "description": null
+    },
+    {
+      "code": 11,
+      "name": "InvalidTimestamp",
+      "description": null
+    },
+    {
+      "code": 12,
+      "name": "InvalidFee",
+      "description": null
+    },
+    {
+      "code": 13,
+      "name": "FeeTokenRequired",
+      "description": null
+    },
+    {
+      "code": 14,
+      "name": "TooManyTags",
+      "description": null
+    },
+    {
+      "code": 15,
+      "name": "TagTooLong",
+      "description": null
+    },
+    {
+      "code": 16,
+      "name": "InvalidThreshold",
+      "description": "Threshold must be >= 1 and <= number of required signers."
+    },
+    {
+      "code": 17,
+      "name": "NotRequiredSigner",
+      "description": "The signer is not in the proposal's required_signers list."
+    },
+    {
+      "code": 18,
+      "name": "AlreadySigned",
+      "description": "The signer has already co-signed this proposal."
+    },
+    {
+      "code": 19,
+      "name": "ProposalFinalized",
+      "description": "The proposal has already been finalized."
+    },
+    {
+      "code": 20,
+      "name": "ProposalExpired",
+      "description": "The proposal has expired without reaching threshold."
+    },
+    {
+      "code": 21,
+      "name": "ReasonTooLong",
+      "description": "The revocation reason exceeds the maximum allowed length of 128 characters."
+    },
+    {
+      "code": 22,
+      "name": "CannotEndorseOwn",
+      "description": "Endorser cannot endorse their own attestation."
+    },
+    {
+      "code": 23,
+      "name": "AlreadyEndorsed",
+      "description": "Endorser has already endorsed this attestation."
+    },
+    {
+      "code": 24,
+      "name": "ContractPaused",
+      "description": "The contract is paused; write operations are temporarily disabled."
+    },
+    {
+      "code": 25,
+      "name": "SubjectNotWhitelisted",
+      "description": "Subject is not on the issuer's whitelist and the issuer has whitelist mode enabled."
+    },
+    {
+      "code": 26,
+      "name": "InvalidClaimType",
+      "description": "Claim type string is empty, too long, or contains disallowed characters."
+    },
+    {
+      "code": 27,
+      "name": "InvalidJurisdiction",
+      "description": "Jurisdiction code is not a valid ISO 3166-1 alpha-2 code."
+    },
+    {
+      "code": 28,
+      "name": "RateLimited",
+      "description": "Issuer has exceeded the minimum issuance interval (rate limit)."
+    },
+    {
+      "code": 29,
+      "name": "LimitExceeded",
+      "description": "Storage limit exceeded for issuer or subject."
+    },
+    {
+      "code": 30,
+      "name": "ProposalCancelled",
+      "description": "The proposal has been cancelled by the proposer."
+    },
+    {
+      "code": 44,
+      "name": "InvalidSourceReference",
+      "description": "Source reference string is missing or empty."
+    }
+  ]
+}

--- a/scripts/check-error-codes.mjs
+++ b/scripts/check-error-codes.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * scripts/check-error-codes.mjs
+ *
+ * CI guard: verifies that every generated error-code artifact is in sync with
+ * src/errors.rs. Exits 1 if any artifact is stale or missing.
+ *
+ * Run:
+ *   node scripts/check-error-codes.mjs
+ *
+ * Typical CI usage:
+ *   - run: node scripts/check-error-codes.mjs
+ */
+
+import { readFileSync, existsSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+// ── Paths ────────────────────────────────────────────────────────────────────
+
+const ERRORS_RS = resolve(ROOT, "src", "errors.rs");
+const JSON_ARTIFACT = resolve(ROOT, "error-codes.json");
+const TS_SDK_GEN = resolve(ROOT, "sdk", "typescript", "src", "generated", "error-codes.ts");
+const TS_BINDINGS_GEN = resolve(ROOT, "bindings", "typescript", "src", "generated", "error-codes.ts");
+const PY_GEN = resolve(ROOT, "bindings", "python", "trustlink", "generated_error_codes.py");
+
+// ── Parse src/errors.rs ──────────────────────────────────────────────────────
+
+function parseErrorsRs() {
+  const src = readFileSync(ERRORS_RS, "utf8");
+
+  const start = src.indexOf("pub enum Error");
+  if (start === -1) throw new Error("Could not find `pub enum Error` in src/errors.rs");
+
+  let braceDepth = 0;
+  let bodyStart = -1;
+  let bodyEnd = -1;
+
+  for (let i = start; i < src.length; i++) {
+    if (src[i] === "{") {
+      if (braceDepth === 0) bodyStart = i + 1;
+      braceDepth++;
+    } else if (src[i] === "}") {
+      braceDepth--;
+      if (braceDepth === 0) { bodyEnd = i; break; }
+    }
+  }
+
+  const body = src.slice(bodyStart, bodyEnd);
+  /** @type {Map<number, string>} */
+  const errors = new Map();
+
+  for (const rawLine of body.split("\n")) {
+    const line = rawLine.trim();
+    const m = line.match(/^([A-Za-z][A-Za-z0-9]*)\s*=\s*(\d+),?$/);
+    if (m) errors.set(parseInt(m[2], 10), m[1]);
+  }
+
+  return errors;
+}
+
+// ── Parse generated artifacts ────────────────────────────────────────────────
+
+/** Parse error-codes.json → Map<code, name> */
+function parseJson() {
+  const data = JSON.parse(readFileSync(JSON_ARTIFACT, "utf8"));
+  return new Map(data.errors.map((e) => [e.code, e.name]));
+}
+
+/**
+ * Parse a generated TS file.
+ * Looks for lines like:   123: "ErrorName",
+ * Returns Map<code, name>
+ */
+function parseGeneratedTs(path) {
+  const src = readFileSync(path, "utf8");
+  const errors = new Map();
+  for (const line of src.split("\n")) {
+    const m = line.trim().match(/^(\d+):\s*"([^"]+)",/);
+    if (m) errors.set(parseInt(m[1], 10), m[2]);
+  }
+  return errors;
+}
+
+/**
+ * Parse a generated Python file.
+ * Looks for lines like:   123: "ErrorName",
+ * Returns Map<code, name>
+ */
+function parseGeneratedPy(path) {
+  const src = readFileSync(path, "utf8");
+  const errors = new Map();
+  for (const line of src.split("\n")) {
+    const m = line.trim().match(/^(\d+):\s*"([^"]+)",/);
+    if (m) errors.set(parseInt(m[1], 10), m[2]);
+  }
+  return errors;
+}
+
+// ── Comparison ───────────────────────────────────────────────────────────────
+
+/**
+ * Returns an array of human-readable diff lines.
+ * Empty array means the maps are identical.
+ */
+function diff(canonical, actual, label) {
+  const issues = [];
+
+  for (const [code, name] of canonical) {
+    if (!actual.has(code)) {
+      issues.push(`  ${label}: missing code #${code} (${name})`);
+    } else if (actual.get(code) !== name) {
+      issues.push(`  ${label}: code #${code} is "${actual.get(code)}", expected "${name}"`);
+    }
+  }
+
+  for (const [code, name] of actual) {
+    if (!canonical.has(code)) {
+      issues.push(`  ${label}: unexpected extra code #${code} (${name}) not in src/errors.rs`);
+    }
+  }
+
+  return issues;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+const canonical = parseErrorsRs();
+console.log(`Parsed ${canonical.size} error codes from src/errors.rs`);
+
+const checks = [
+  { label: "error-codes.json", path: JSON_ARTIFACT, parse: parseJson },
+  { label: "sdk/typescript/src/generated/error-codes.ts", path: TS_SDK_GEN, parse: parseGeneratedTs },
+  { label: "bindings/typescript/src/generated/error-codes.ts", path: TS_BINDINGS_GEN, parse: parseGeneratedTs },
+  { label: "bindings/python/trustlink/generated_error_codes.py", path: PY_GEN, parse: parseGeneratedPy },
+];
+
+let failed = false;
+
+for (const check of checks) {
+  if (!existsSync(check.path)) {
+    console.error(`❌ ${check.label}: file not found — run 'node scripts/generate-error-codes.mjs'`);
+    failed = true;
+    continue;
+  }
+
+  const actual = check.parse(check.path);
+  const issues = diff(canonical, actual, check.label);
+
+  if (issues.length === 0) {
+    console.log(`✅ ${check.label} — up to date`);
+  } else {
+    console.error(`❌ ${check.label} — out of sync:`);
+    for (const issue of issues) console.error(issue);
+    failed = true;
+  }
+}
+
+if (failed) {
+  console.error(
+    "\n⛔ One or more generated artifacts are out of date.\n" +
+    "   Run `node scripts/generate-error-codes.mjs` (or `make generate`) and commit the results."
+  );
+  process.exit(1);
+} else {
+  console.log("\n✨ All error-code artifacts are in sync with src/errors.rs.");
+}

--- a/scripts/generate-error-codes.mjs
+++ b/scripts/generate-error-codes.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * scripts/generate-error-codes.mjs
+ *
+ * Parses src/errors.rs and emits:
+ *   1. error-codes.json  — canonical, language-agnostic artifact (project root)
+ *   2. sdk/typescript/src/generated/error-codes.ts  — consumed by the TS SDK
+ *   3. bindings/typescript/src/generated/error-codes.ts — consumed by TS bindings
+ *   4. bindings/python/trustlink/generated_error_codes.py — consumed by Python SDK
+ *
+ * Usage:
+ *   node scripts/generate-error-codes.mjs
+ *
+ * All generated files contain a DO-NOT-EDIT header and are committed to the
+ * repository so that consumers don't need Node.js at install time.
+ * Run this script (or `make generate`) whenever src/errors.rs changes.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+const ERRORS_RS = resolve(ROOT, "src", "errors.rs");
+const JSON_OUT = resolve(ROOT, "error-codes.json");
+const TS_SDK_OUT = resolve(ROOT, "sdk", "typescript", "src", "generated", "error-codes.ts");
+const TS_BINDINGS_OUT = resolve(ROOT, "bindings", "typescript", "src", "generated", "error-codes.ts");
+const PY_OUT = resolve(ROOT, "bindings", "python", "trustlink", "generated_error_codes.py");
+
+// ---------------------------------------------------------------------------
+// Parse src/errors.rs
+// ---------------------------------------------------------------------------
+
+const src = readFileSync(ERRORS_RS, "utf8");
+
+function extractEnumBody(source) {
+  const start = source.indexOf("pub enum Error");
+  if (start === -1) throw new Error("Could not find `pub enum Error` in src/errors.rs");
+
+  let braceDepth = 0;
+  let bodyStart = -1;
+  let bodyEnd = -1;
+
+  for (let i = start; i < source.length; i++) {
+    if (source[i] === "{") {
+      if (braceDepth === 0) bodyStart = i + 1;
+      braceDepth++;
+    } else if (source[i] === "}") {
+      braceDepth--;
+      if (braceDepth === 0) {
+        bodyEnd = i;
+        break;
+      }
+    }
+  }
+
+  if (bodyStart === -1 || bodyEnd === -1) {
+    throw new Error("Could not extract enum body from src/errors.rs");
+  }
+
+  return source.slice(bodyStart, bodyEnd);
+}
+
+function parseEnumVariants(body) {
+  const errors = [];
+  const lines = body.split("\n");
+  let pendingDoc = [];
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+
+    if (line.startsWith("///")) {
+      pendingDoc.push(line.slice(3).trim());
+      continue;
+    }
+
+    const variantMatch = line.match(/^([A-Za-z][A-Za-z0-9]*)\s*=\s*(\d+),?$/);
+    if (variantMatch) {
+      const name = variantMatch[1];
+      const code = parseInt(variantMatch[2], 10);
+      const description = pendingDoc.length > 0 ? pendingDoc.join(" ") : null;
+      errors.push({ code, name, description });
+      pendingDoc = [];
+      continue;
+    }
+
+    if (line && !line.startsWith("//")) {
+      pendingDoc = [];
+    }
+  }
+
+  errors.sort((a, b) => a.code - b.code);
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Emitters
+// ---------------------------------------------------------------------------
+
+function emitJson(errors) {
+  const output = {
+    generated: new Date().toISOString(),
+    source: "src/errors.rs",
+    errors,
+  };
+  writeFileSync(JSON_OUT, JSON.stringify(output, null, 2) + "\n");
+  console.log(`✅ Wrote error-codes.json (${errors.length} errors)`);
+}
+
+const TS_HEADER = `/**
+ * GENERATED FILE — DO NOT EDIT BY HAND.
+ * Run \`node scripts/generate-error-codes.mjs\` (or \`make generate\`) to regenerate.
+ * Source of truth: src/errors.rs
+ */\n\n`;
+
+function emitTypeScript(errors, outPath) {
+  mkdirSync(dirname(outPath), { recursive: true });
+
+  const recordEntries = errors
+    .map((e) => {
+      const desc = e.description ? ` // ${e.description}` : "";
+      return `  ${e.code}: "${e.name}",${desc}`;
+    })
+    .join("\n");
+
+  const content =
+    TS_HEADER +
+    `/** Map of contract error code → error name, generated from src/errors.rs. */\n` +
+    `export const ERROR_CODES: Readonly<Record<number, string>> = {\n${recordEntries}\n} as const;\n`;
+
+  writeFileSync(outPath, content);
+  console.log(`✅ Wrote ${outPath}`);
+}
+
+function emitPython(errors, outPath) {
+  const lines = [
+    `"""`,
+    `GENERATED FILE — DO NOT EDIT BY HAND.`,
+    `Run \`node scripts/generate-error-codes.mjs\` (or \`make generate\`) to regenerate.`,
+    `Source of truth: src/errors.rs`,
+    `"""`,
+    ``,
+    `from typing import Dict`,
+    ``,
+    `# Map of contract error code -> error name, generated from src/errors.rs.`,
+    `CONTRACT_ERRORS: Dict[int, str] = {`,
+    ...errors.map((e) => {
+      const comment = e.description ? `  # ${e.description}` : "";
+      return `    ${e.code}: "${e.name}",${comment}`;
+    }),
+    `}`,
+    ``,
+  ];
+  writeFileSync(outPath, lines.join("\n"));
+  console.log(`✅ Wrote ${outPath}`);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const enumBody = extractEnumBody(src);
+const errors = parseEnumVariants(enumBody);
+
+if (errors.length === 0) {
+  throw new Error("No error variants found — check the parser.");
+}
+
+emitJson(errors);
+emitTypeScript(errors, TS_SDK_OUT);
+emitTypeScript(errors, TS_BINDINGS_OUT);
+emitPython(errors, PY_OUT);
+
+console.log(`\n✨ Done. ${errors.length} error codes synchronized across all clients.`);

--- a/sdk/typescript/src/generated/error-codes.ts
+++ b/sdk/typescript/src/generated/error-codes.ts
@@ -1,0 +1,40 @@
+/**
+ * GENERATED FILE — DO NOT EDIT BY HAND.
+ * Run `node scripts/generate-error-codes.mjs` (or `make generate`) to regenerate.
+ * Source of truth: src/errors.rs
+ */
+
+/** Map of contract error code → error name, generated from src/errors.rs. */
+export const ERROR_CODES: Readonly<Record<number, string>> = {
+  1: "AlreadyInitialized",
+  2: "NotInitialized",
+  3: "Unauthorized",  // Caller lacks required permissions. Includes rejection when `issuer` equals `subject` in `create_attestation`.
+  4: "NotFound",
+  5: "DuplicateAttestation",
+  6: "AlreadyRevoked",
+  7: "Expired",
+  8: "InvalidValidFrom",
+  9: "InvalidExpiration",
+  10: "MetadataTooLong",
+  11: "InvalidTimestamp",
+  12: "InvalidFee",
+  13: "FeeTokenRequired",
+  14: "TooManyTags",
+  15: "TagTooLong",
+  16: "InvalidThreshold",  // Threshold must be >= 1 and <= number of required signers.
+  17: "NotRequiredSigner",  // The signer is not in the proposal's required_signers list.
+  18: "AlreadySigned",  // The signer has already co-signed this proposal.
+  19: "ProposalFinalized",  // The proposal has already been finalized.
+  20: "ProposalExpired",  // The proposal has expired without reaching threshold.
+  21: "ReasonTooLong",  // The revocation reason exceeds the maximum allowed length of 128 characters.
+  22: "CannotEndorseOwn",  // Endorser cannot endorse their own attestation.
+  23: "AlreadyEndorsed",  // Endorser has already endorsed this attestation.
+  24: "ContractPaused",  // The contract is paused; write operations are temporarily disabled.
+  25: "SubjectNotWhitelisted",  // Subject is not on the issuer's whitelist and the issuer has whitelist mode enabled.
+  26: "InvalidClaimType",  // Claim type string is empty, too long, or contains disallowed characters.
+  27: "InvalidJurisdiction",  // Jurisdiction code is not a valid ISO 3166-1 alpha-2 code.
+  28: "RateLimited",  // Issuer has exceeded the minimum issuance interval (rate limit).
+  29: "LimitExceeded",  // Storage limit exceeded for issuer or subject.
+  30: "ProposalCancelled",  // The proposal has been cancelled by the proposer.
+  44: "InvalidSourceReference",  // Source reference string is missing or empty.
+} as const;

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -2,6 +2,10 @@
  * TypeScript types mirroring the TrustLink Soroban contract data structures.
  */
 
+// Error code table is generated from src/errors.rs — do not hand-edit this import.
+// Run `node scripts/generate-error-codes.mjs` (or `make generate`) to regenerate.
+import { ERROR_CODES } from "./generated/error-codes";
+
 export interface Attestation {
   id: string;
   issuer: string;
@@ -271,46 +275,57 @@ export class InvalidSourceReferenceError extends TrustLinkError {
   constructor() { super(44, "InvalidSourceReference"); }
 }
 
-const ERROR_BY_CODE: Record<number, new () => TrustLinkError> = {
-  1: AlreadyInitializedError,
-  2: NotInitializedError,
-  3: UnauthorizedError,
-  4: NotFoundError,
-  5: DuplicateAttestationError,
-  6: AlreadyRevokedError,
-  7: ExpiredError,
-  8: InvalidValidFromError,
-  9: InvalidExpirationError,
-  10: MetadataTooLongError,
-  11: InvalidTimestampError,
-  12: InvalidFeeError,
-  13: FeeTokenRequiredError,
-  14: TooManyTagsError,
-  15: TagTooLongError,
-  16: InvalidThresholdError,
-  17: NotRequiredSignerError,
-  18: AlreadySignedError,
-  19: ProposalFinalizedError,
-  20: ProposalExpiredError,
-  21: ReasonTooLongError,
-  22: CannotEndorseOwnError,
-  23: AlreadyEndorsedError,
-  24: ContractPausedError,
-  25: SubjectNotWhitelistedError,
-  26: InvalidClaimTypeError,
-  27: InvalidJurisdictionError,
-  28: RateLimitedError,
-  29: LimitExceededError,
-  30: ProposalCancelledError,
-  44: InvalidSourceReferenceError,
+/**
+ * Named error class registry — typed classes keyed by error name.
+ * Named classes give call-sites `instanceof` checking while the
+ * code→name mapping is authoritative in the generated ERROR_CODES table.
+ */
+const NAMED_ERROR_CLASSES: Record<string, new () => TrustLinkError> = {
+  AlreadyInitialized: AlreadyInitializedError,
+  NotInitialized: NotInitializedError,
+  Unauthorized: UnauthorizedError,
+  NotFound: NotFoundError,
+  DuplicateAttestation: DuplicateAttestationError,
+  AlreadyRevoked: AlreadyRevokedError,
+  Expired: ExpiredError,
+  InvalidValidFrom: InvalidValidFromError,
+  InvalidExpiration: InvalidExpirationError,
+  MetadataTooLong: MetadataTooLongError,
+  InvalidTimestamp: InvalidTimestampError,
+  InvalidFee: InvalidFeeError,
+  FeeTokenRequired: FeeTokenRequiredError,
+  TooManyTags: TooManyTagsError,
+  TagTooLong: TagTooLongError,
+  InvalidThreshold: InvalidThresholdError,
+  NotRequiredSigner: NotRequiredSignerError,
+  AlreadySigned: AlreadySignedError,
+  ProposalFinalized: ProposalFinalizedError,
+  ProposalExpired: ProposalExpiredError,
+  ReasonTooLong: ReasonTooLongError,
+  CannotEndorseOwn: CannotEndorseOwnError,
+  AlreadyEndorsed: AlreadyEndorsedError,
+  ContractPaused: ContractPausedError,
+  SubjectNotWhitelisted: SubjectNotWhitelistedError,
+  InvalidClaimType: InvalidClaimTypeError,
+  InvalidJurisdiction: InvalidJurisdictionError,
+  RateLimited: RateLimitedError,
+  LimitExceeded: LimitExceededError,
+  ProposalCancelled: ProposalCancelledError,
+  InvalidSourceReference: InvalidSourceReferenceError,
 };
 
-const ERROR_BY_NAME: Record<string, new () => TrustLinkError> = Object.fromEntries(
-  Object.values(ERROR_BY_CODE).map((Cls) => {
-    const instance = new Cls();
-    return [instance.name, Cls];
-  })
+/**
+ * Build the code→class lookup from the generated ERROR_CODES table so that
+ * any future code/name added to src/errors.rs will be picked up automatically
+ * after re-running `make generate`.
+ */
+const ERROR_BY_CODE: Record<number, new () => TrustLinkError> = Object.fromEntries(
+  Object.entries(ERROR_CODES)
+    .filter(([, name]) => name in NAMED_ERROR_CLASSES)
+    .map(([code, name]) => [Number(code), NAMED_ERROR_CLASSES[name]])
 );
+
+const ERROR_BY_NAME: Record<string, new () => TrustLinkError> = NAMED_ERROR_CLASSES;
 
 /**
  * Parse a contract simulation error string into a typed TrustLinkError.


### PR DESCRIPTION
Generate error-codes.json from src/errors.rs and have all clients derive their error tables from it, eliminating three hand-maintained copies that were already diverging.

Changes:
- scripts/generate-error-codes.mjs: parses the Rust contracterror enum and emits four artifacts: • error-codes.json (canonical, language-agnostic) • sdk/typescript/src/generated/error-codes.ts • bindings/typescript/src/generated/error-codes.ts • bindings/python/trustlink/generated_error_codes.py
- sdk/typescript/src/types.ts: imports ERROR_CODES from generated file; ERROR_BY_CODE is now built dynamically from that table
- bindings/typescript/src/types.ts: re-exports CONTRACT_ERRORS from generated file; adds missing InvalidSourceReference=44 to enum
- bindings/python/trustlink/types.py: imports CONTRACT_ERRORS from generated_error_codes.py (fixes the old zero-indexed, incomplete table)
- scripts/check-error-codes.mjs: CI guard that fails if any artifact is out of sync with src/errors.rs
- .github/workflows/ci.yml: new error-codes job that regenerates artifacts, diffs them, and runs the check script

To update after changing src/errors.rs:
  node scripts/generate-error-codes.mjs git add error-codes.json sdk/typescript/src/generated/ \ bindings/typescript/src/generated/ \ bindings/python/trustlink/generated_error_codes.py git commit

## Summary of Changes

<!-- Describe what this PR does and why. Link to the relevant issue(s). -->

Closes #964 

## Type of Change

<!-- Mark the applicable type with an "x". -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [ ] Other (describe):

## Testing Done

<!-- Describe the tests you ran and how to reproduce them. -->

- [ ] `cargo test` passes locally
- [ ] New tests added for this change (if applicable)

## Checklist

- [ ] All tests pass (`cargo test`)
- [ ] Code is formatted (`cargo fmt -- --check`)
- [ ] No Clippy warnings (`cargo clippy --all-targets -- -D warnings`)
- [ ] Commit messages follow [Conventional Commits](../CONTRIBUTING.md#commit-message-conventions)
- [ ] Documentation updated (if behaviour changed)
- [ ] No secrets, tokens, or credentials committed
