### PR TITLE
chore(repo): add description and topics for discoverability (#107)

### DIFF
--- a/.github/repository.yml
+++ b/.github/repository.yml
@@ -1,0 +1,49 @@
+# .github/repository.yml
+#
+# Canonical record of the GitHub repository description and topics for TrustLink.
+#
+# HOW TO APPLY
+# ────────────
+# The accompanying workflow (.github/workflows/sync-repo-metadata.yml) applies
+# these values automatically on every push to main, provided the REPO_ADMIN_TOKEN
+# secret (a PAT with `repo` scope) is configured in repository settings.
+#
+# To apply manually:
+#
+#   gh repo edit Haroldwonder/TrustLink \
+#     --description "On-chain attestation & identity verification for the Stellar blockchain — KYC, AML, multi-sig credentials, TypeScript/Python SDKs" \
+#     --add-topic stellar \
+#     --add-topic soroban \
+#     --add-topic smart-contract \
+#     --add-topic attestation \
+#     --add-topic identity-verification \
+#     --add-topic kyc \
+#     --add-topic compliance \
+#     --add-topic typescript \
+#     --add-topic python \
+#     --add-topic rust \
+#     --add-topic web3 \
+#     --add-topic decentralized-identity \
+#     --add-topic blockchain
+#
+# GitHub imposes a maximum of 20 topics per repository, each ≤ 50 characters,
+# lowercase, letters/numbers/hyphens only.
+
+description: >
+  On-chain attestation & identity verification for the Stellar blockchain —
+  KYC, AML, multi-sig credentials, TypeScript/Python SDKs
+
+topics:
+  - stellar
+  - soroban
+  - smart-contract
+  - attestation
+  - identity-verification
+  - kyc
+  - compliance
+  - typescript
+  - python
+  - rust
+  - web3
+  - decentralized-identity
+  - blockchain

--- a/.github/workflows/sync-repo-metadata.yml
+++ b/.github/workflows/sync-repo-metadata.yml
@@ -1,0 +1,94 @@
+name: Sync Repository Metadata
+
+# Applies the description and topics declared in .github/repository.yml
+# to the GitHub repository whenever the file changes on main.
+#
+# Requirements:
+#   - Add a repository secret named REPO_ADMIN_TOKEN containing a classic
+#     Personal Access Token with the `repo` scope (needed because the default
+#     GITHUB_TOKEN cannot update repository metadata).
+#   - The runner's Python 3 installation must include PyYAML (it does on all
+#     GitHub-hosted ubuntu-latest runners).
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/repository.yml
+  workflow_dispatch: # allow manual trigger from the Actions tab
+
+jobs:
+  sync-metadata:
+    name: Apply description and topics
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Apply description and topics via GitHub API
+        env:
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          python3 - <<'PYEOF'
+          import json, os, subprocess, sys
+
+          try:
+              import yaml
+          except ImportError:
+              subprocess.run([sys.executable, "-m", "pip", "install", "pyyaml", "-q"], check=True)
+              import yaml
+
+          with open(".github/repository.yml") as f:
+              data = yaml.safe_load(f)
+
+          repo = os.environ["REPO"]
+          token = os.environ["GH_TOKEN"]
+
+          # Collapse YAML block scalar whitespace
+          description = " ".join(data["description"].split())
+          topics = data["topics"]
+
+          print(f"Repository : {repo}")
+          print(f"Description: {description}")
+          print(f"Topics     : {', '.join(topics)}")
+
+          def gh_api(method, path, payload=None):
+              cmd = ["gh", "api", "--method", method, f"repos/{path}"]
+              if payload:
+                  cmd += ["--input", "-"]
+              result = subprocess.run(
+                  cmd,
+                  input=json.dumps(payload).encode() if payload else None,
+                  capture_output=True,
+              )
+              if result.returncode != 0:
+                  print(f"API error: {result.stderr.decode()}", file=sys.stderr)
+                  sys.exit(1)
+              return json.loads(result.stdout) if result.stdout.strip() else {}
+
+          # 1. Update description
+          gh_api("PATCH", repo, {"description": description})
+          print("✅ Description updated")
+
+          # 2. Replace topic list atomically (PUT replaces the full set)
+          gh_api("PUT", f"{repo}/topics", {"names": topics})
+          print(f"✅ {len(topics)} topics applied")
+
+          # 3. Verify
+          result = gh_api("GET", repo)
+          print("\n=== Applied metadata ===")
+          print(f"description : {result.get('description')}")
+          PYEOF
+
+      - name: Show current repository metadata
+        env:
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
+        run: |
+          gh repo view "${{ github.repository }}" \
+            --json description,repositoryTopics \
+            --jq '{"description": .description, "topics": [.repositoryTopics[].topic.name]}'


### PR DESCRIPTION
GitHub repository description and topics are not currently set, making TrustLink harder to find and its purpose unclear from the listing page.

Changes:
- .github/repository.yml: canonical record of the repository description and 13 topics (stellar, soroban, smart-contract, attestation, identity-verification, kyc, compliance, typescript, python, rust, web3, decentralized-identity, blockchain)
- .github/workflows/sync-repo-metadata.yml: workflow that fires on every push to main that touches repository.yml, reads the YAML, and applies description + topics via the GitHub REST API using a REPO_ADMIN_TOKEN secret; also supports manual dispatch

Description chosen: "On-chain attestation & identity verification for the Stellar blockchain — KYC, AML, multi-sig credentials, TypeScript/Python SDKs"

To apply immediately without waiting for CI, run: gh repo edit Haroldwonder/TrustLink \
    --description "On-chain attestation & identity verification for the Stellar blockchain — KYC, AML, multi-sig credentials, TypeScript/Python SDKs" \
    --add-topic stellar --add-topic soroban --add-topic smart-contract \
    --add-topic attestation --add-topic identity-verification \
    --add-topic kyc --add-topic compliance --add-topic typescript \
    --add-topic python --add-topic rust --add-topic web3 \
    --add-topic decentralized-identity --add-topic blockchain

Closes #107

## Summary of Changes

<!-- Describe what this PR does and why. Link to the relevant issue(s). -->

Closes #

## Type of Change

<!-- Mark the applicable type with an "x". -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [ ] Other (describe):

## Testing Done

<!-- Describe the tests you ran and how to reproduce them. -->

- [ ] `cargo test` passes locally
- [ ] New tests added for this change (if applicable)

## Checklist

- [ ] All tests pass (`cargo test`)
- [ ] Code is formatted (`cargo fmt -- --check`)
- [ ] No Clippy warnings (`cargo clippy --all-targets -- -D warnings`)
- [ ] Commit messages follow [Conventional Commits](../CONTRIBUTING.md#commit-message-conventions)
- [ ] Documentation updated (if behaviour changed)
- [ ] No secrets, tokens, or credentials committed
