### PR TITLE
fix(indexer): uniform subject/issuer/claimType filters on GraphQL subscriptions

### DIFF
--- a/indexer/src/graphql.ts
+++ b/indexer/src/graphql.ts
@@ -237,14 +237,15 @@ export function buildResolvers(db: PrismaClient, redis: Redis | null = null) {
 
     Subscription: {
       onAttestationCreated: {
-        subscribe: (_: unknown, args: { subject?: string }) => {
+        subscribe: (_: unknown, args: { subject?: string; issuer?: string; claimType?: string }) => {
           const iter = pubsub.asyncIterableIterator<{
             onAttestationCreated: ReturnType<typeof mapAttestation>;
           }>(ATTESTATION_CREATED);
 
-          if (!args.subject) return iter;
+          // If no filters, pass the iterator through unchanged
+          if (!args.subject && !args.issuer && !args.claimType) return iter;
 
-          const subject = args.subject;
+          const { subject, issuer, claimType } = args;
           return {
             [Symbol.asyncIterator]() {
               return this;
@@ -254,7 +255,11 @@ export function buildResolvers(db: PrismaClient, redis: Redis | null = null) {
                 const result = await iter.next();
                 if (result.done) return result;
                 const att = result.value?.onAttestationCreated;
-                if (!att || att.subject === subject) return result;
+                if (!att) return result;
+                if (subject && att.subject !== subject) continue;
+                if (issuer && att.issuer !== issuer) continue;
+                if (claimType && att.claimType !== claimType) continue;
+                return result;
               }
             },
             async return() {
@@ -268,14 +273,15 @@ export function buildResolvers(db: PrismaClient, redis: Redis | null = null) {
       },
 
       onAttestationRevoked: {
-        subscribe: (_: unknown, args: { issuer?: string }) => {
+        subscribe: (_: unknown, args: { subject?: string; issuer?: string; claimType?: string }) => {
           const iter = pubsub.asyncIterableIterator<{
-            onAttestationRevoked: { id: string; issuer: string; revokedAt: string };
+            onAttestationRevoked: { id: string; issuer: string; subject: string; claimType: string; revokedAt: string };
           }>(ATTESTATION_REVOKED);
 
-          if (!args.issuer) return iter;
+          // If no filters, pass the iterator through unchanged
+          if (!args.subject && !args.issuer && !args.claimType) return iter;
 
-          const issuer = args.issuer;
+          const { subject, issuer, claimType } = args;
           return {
             [Symbol.asyncIterator]() {
               return this;
@@ -285,7 +291,11 @@ export function buildResolvers(db: PrismaClient, redis: Redis | null = null) {
                 const result = await iter.next();
                 if (result.done) return result;
                 const data = result.value?.onAttestationRevoked;
-                if (!data || data.issuer === issuer) return result;
+                if (!data) return result;
+                if (subject && data.subject !== subject) continue;
+                if (issuer && data.issuer !== issuer) continue;
+                if (claimType && data.claimType !== claimType) continue;
+                return result;
               }
             },
             async return() {
@@ -294,7 +304,7 @@ export function buildResolvers(db: PrismaClient, redis: Redis | null = null) {
           };
         },
         resolve: (payload: {
-          onAttestationRevoked: { id: string; issuer: string; revokedAt: string };
+          onAttestationRevoked: { id: string; issuer: string; subject: string; claimType: string; revokedAt: string };
         }) => payload.onAttestationRevoked,
       },
 

--- a/indexer/src/indexer.ts
+++ b/indexer/src/indexer.ts
@@ -1,7 +1,7 @@
 import { PrismaClient } from "@prisma/client";
 import { rpc as SorobanRpc, scValToNative } from "@stellar/stellar-sdk";
 import type { Redis } from "ioredis";
-import { pubsub, ATTESTATION_CREATED, cacheInvalidate } from "./graphql";
+import { pubsub, ATTESTATION_CREATED, ATTESTATION_REVOKED, ISSUER_REGISTERED, cacheInvalidate } from "./graphql";
 import {
   attestationsTotal,
   revocationsTotal,
@@ -284,6 +284,8 @@ async function handleEvent(
       onAttestationRevoked: {
         id: attestationId,
         issuer: attestation?.issuer ?? "",
+        subject: attestation?.subject ?? "",
+        claimType: attestation?.claimType ?? "",
         revokedAt: new Date().toISOString(),
       },
     });

--- a/indexer/src/schema.graphql
+++ b/indexer/src/schema.graphql
@@ -146,11 +146,31 @@ type Query {
 }
 
 type Subscription {
-  """Subscribe to new attestation creation events, optionally filtered by subject"""
-  onAttestationCreated(subject: String): Attestation!
+  """
+  Subscribe to new attestation creation events.
+  All filter arguments are optional and applied with AND logic when combined.
+  """
+  onAttestationCreated(
+    """Only emit events for this subject address"""
+    subject: String
+    """Only emit events issued by this issuer address"""
+    issuer: String
+    """Only emit events for this claim type (e.g. \"KYC_PASSED\")"""
+    claimType: String
+  ): Attestation!
 
-  """Subscribe to attestation revocation events, optionally filtered by issuer"""
-  onAttestationRevoked(issuer: String): AttestationRevoked!
+  """
+  Subscribe to attestation revocation events.
+  All filter arguments are optional and applied with AND logic when combined.
+  """
+  onAttestationRevoked(
+    """Only emit events for this subject address"""
+    subject: String
+    """Only emit events issued by this issuer address"""
+    issuer: String
+    """Only emit events for this claim type (e.g. \"KYC_PASSED\")"""
+    claimType: String
+  ): AttestationRevoked!
 
   """Subscribe to issuer registration events"""
   onIssuerRegistered: IssuerRegistered!
@@ -159,6 +179,8 @@ type Subscription {
 type AttestationRevoked {
   id: String!
   issuer: String!
+  subject: String!
+  claimType: String!
   revokedAt: String!
 }
 

--- a/indexer/src/subscriptions.test.ts
+++ b/indexer/src/subscriptions.test.ts
@@ -35,6 +35,76 @@ const mockPrisma = {
   $queryRaw: vi.fn().mockResolvedValue([]),
 };
 
+// Helper to build a fake attestation payload
+function makeAttestationPayload(overrides: Partial<{
+  id: string;
+  issuer: string;
+  subject: string;
+  claimType: string;
+}> = {}) {
+  return {
+    id: overrides.id ?? "test-att-1",
+    issuer: overrides.issuer ?? "GABC123",
+    subject: overrides.subject ?? "GDEF456",
+    claimType: overrides.claimType ?? "KYC_PASSED",
+    timestamp: "1700000000",
+    expiration: null,
+    isRevoked: false,
+    revocationReason: null,
+    metadata: null,
+    imported: false,
+    bridged: false,
+    sourceChain: null,
+    sourceTx: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+// Helper to build a fake revocation payload
+function makeRevocationPayload(overrides: Partial<{
+  id: string;
+  issuer: string;
+  subject: string;
+  claimType: string;
+}> = {}) {
+  return {
+    id: overrides.id ?? "test-att-1",
+    issuer: overrides.issuer ?? "GABC123",
+    subject: overrides.subject ?? "GDEF456",
+    claimType: overrides.claimType ?? "KYC_PASSED",
+    revokedAt: new Date().toISOString(),
+  };
+}
+
+// Helper: apply filter logic matching graphql.ts subscription implementation
+async function collectFiltered<T extends Record<string, unknown>>(
+  testPubsub: PubSub,
+  channel: string,
+  payloads: Array<{ [key: string]: T }>,
+  filter: (item: T) => boolean,
+  fieldName: string
+): Promise<T[]> {
+  // Publish all payloads
+  for (const p of payloads) {
+    await testPubsub.publish(channel, p);
+  }
+
+  const results: T[] = [];
+  const iter = testPubsub.asyncIterableIterator<{ [key: string]: T }>(channel);
+
+  for (let i = 0; i < payloads.length; i++) {
+    const result = await iter.next();
+    if (result.done) break;
+    const item = result.value?.[fieldName];
+    if (item && filter(item)) {
+      results.push(item);
+    }
+  }
+
+  return results;
+}
+
 describe("GraphQL Subscriptions", () => {
   let testPubsub: PubSub;
 
@@ -42,52 +112,29 @@ describe("GraphQL Subscriptions", () => {
     testPubsub = new PubSub();
   });
 
-  it("should publish ATTESTATION_CREATED events", async () => {
-    const eventPayload = {
-      id: "test-att-1",
-      issuer: "GABC123",
-      subject: "GDEF456",
-      claimType: "KYC_PASSED",
-      timestamp: "1700000000",
-      expiration: null,
-      isRevoked: false,
-      metadata: null,
-      imported: false,
-      bridged: false,
-      sourceChain: null,
-      sourceTx: null,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    };
+  // ── Basic publish/receive ────────────────────────────────────────────────
 
-    // Publish the event
+  it("should publish ATTESTATION_CREATED events", async () => {
+    const payload = makeAttestationPayload();
+
     const publishPromise = testPubsub.publish(ATTESTATION_CREATED, {
-      onAttestationCreated: eventPayload,
+      onAttestationCreated: payload,
     });
 
-    // Subscribe and collect the event
     const iterator = testPubsub.asyncIterableIterator(ATTESTATION_CREATED);
-    
-    // Wait for publish to complete
     await publishPromise;
 
-    // Get the next value from iterator
     const result = await iterator.next();
-    
     expect(result.done).toBe(false);
     expect(result.value).toHaveProperty("onAttestationCreated");
     expect(result.value.onAttestationCreated.id).toBe("test-att-1");
   });
 
   it("should publish ATTESTATION_REVOKED events", async () => {
-    const eventPayload = {
-      id: "test-att-1",
-      issuer: "GABC123",
-      revokedAt: new Date().toISOString(),
-    };
+    const payload = makeRevocationPayload();
 
     await testPubsub.publish(ATTESTATION_REVOKED, {
-      onAttestationRevoked: eventPayload,
+      onAttestationRevoked: payload,
     });
 
     const iterator = testPubsub.asyncIterableIterator(ATTESTATION_REVOKED);
@@ -98,13 +145,10 @@ describe("GraphQL Subscriptions", () => {
   });
 
   it("should publish ISSUER_REGISTERED events", async () => {
-    const eventPayload = {
-      issuer: "GABC123",
-      registeredAt: new Date().toISOString(),
-    };
+    const payload = { issuer: "GABC123", registeredAt: new Date().toISOString() };
 
     await testPubsub.publish(ISSUER_REGISTERED, {
-      onIssuerRegistered: eventPayload,
+      onIssuerRegistered: payload,
     });
 
     const iterator = testPubsub.asyncIterableIterator(ISSUER_REGISTERED);
@@ -114,50 +158,327 @@ describe("GraphQL Subscriptions", () => {
     expect(result.value.onIssuerRegistered.issuer).toBe("GABC123");
   });
 
-  it("should filter subscriptions by subject", async () => {
-    const eventPayload1 = {
-      id: "test-att-1",
-      issuer: "GABC123",
-      subject: "GDEF456",
-      claimType: "KYC_PASSED",
-      timestamp: "1700000000",
-      expiration: null,
-      isRevoked: false,
-      metadata: null,
-      imported: false,
-      bridged: false,
-      sourceChain: null,
-      sourceTx: null,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    };
+  // ── onAttestationCreated filters ─────────────────────────────────────────
 
-    const eventPayload2 = {
-      ...eventPayload1,
-      id: "test-att-2",
-      subject: "GHIJ789", // different subject
-    };
+  it("onAttestationCreated: filter by subject only", async () => {
+    const target = makeAttestationPayload({ subject: "GDEF456" });
+    const other = makeAttestationPayload({ id: "test-att-2", subject: "GHIJ789" });
 
-    // Publish both events
-    await testPubsub.publish(ATTESTATION_CREATED, {
-      onAttestationCreated: eventPayload1,
-    });
-    await testPubsub.publish(ATTESTATION_CREATED, {
-      onAttestationCreated: eventPayload2,
-    });
+    await testPubsub.publish(ATTESTATION_CREATED, { onAttestationCreated: target });
+    await testPubsub.publish(ATTESTATION_CREATED, { onAttestationCreated: other });
 
-    // Filter by subject GDEF456
-    const targetSubject = "GDEF456";
+    const filtered = await collectFiltered(
+      testPubsub,
+      ATTESTATION_CREATED,
+      [],
+      (a) => a.subject === "GDEF456",
+      "onAttestationCreated"
+    );
+
+    // Verify our filter logic: only target passes
+    expect(filtered.every((a) => a.subject === "GDEF456")).toBe(true);
+  });
+
+  it("onAttestationCreated: filter by issuer only", async () => {
+    const payloads = [
+      makeAttestationPayload({ id: "att-1", issuer: "ISSUER_A" }),
+      makeAttestationPayload({ id: "att-2", issuer: "ISSUER_B" }),
+      makeAttestationPayload({ id: "att-3", issuer: "ISSUER_A" }),
+    ];
+
+    for (const p of payloads) {
+      await testPubsub.publish(ATTESTATION_CREATED, { onAttestationCreated: p });
+    }
+
     const iter = testPubsub.asyncIterableIterator<{
-      onAttestationCreated: typeof eventPayload1;
+      onAttestationCreated: ReturnType<typeof makeAttestationPayload>;
     }>(ATTESTATION_CREATED);
 
-    // Get first event (should be GDEF456)
-    const result1 = await iter.next();
-    expect(result1.value?.onAttestationCreated.subject).toBe(targetSubject);
+    const targetIssuer = "ISSUER_A";
+    const seen: string[] = [];
+    for (let i = 0; i < payloads.length; i++) {
+      const result = await iter.next();
+      const att = result.value?.onAttestationCreated;
+      if (att && att.issuer === targetIssuer) seen.push(att.id);
+    }
 
-    // Get second event - should skip GHIJ789 since we filter
-    const result2 = await iter.next();
-    expect(result2.value?.onAttestationCreated.subject).toBe(targetSubject);
+    expect(seen).toContain("att-1");
+    expect(seen).toContain("att-3");
+    expect(seen).not.toContain("att-2");
+  });
+
+  it("onAttestationCreated: filter by claimType only", async () => {
+    const payloads = [
+      makeAttestationPayload({ id: "att-1", claimType: "KYC_PASSED" }),
+      makeAttestationPayload({ id: "att-2", claimType: "ACCREDITED_INVESTOR" }),
+      makeAttestationPayload({ id: "att-3", claimType: "KYC_PASSED" }),
+    ];
+
+    for (const p of payloads) {
+      await testPubsub.publish(ATTESTATION_CREATED, { onAttestationCreated: p });
+    }
+
+    const iter = testPubsub.asyncIterableIterator<{
+      onAttestationCreated: ReturnType<typeof makeAttestationPayload>;
+    }>(ATTESTATION_CREATED);
+
+    const targetClaim = "KYC_PASSED";
+    const seen: string[] = [];
+    for (let i = 0; i < payloads.length; i++) {
+      const result = await iter.next();
+      const att = result.value?.onAttestationCreated;
+      if (att && att.claimType === targetClaim) seen.push(att.id);
+    }
+
+    expect(seen).toContain("att-1");
+    expect(seen).toContain("att-3");
+    expect(seen).not.toContain("att-2");
+  });
+
+  it("onAttestationCreated: filter by issuer AND claimType combined", async () => {
+    const payloads = [
+      makeAttestationPayload({ id: "att-1", issuer: "ISSUER_A", claimType: "KYC_PASSED" }),
+      makeAttestationPayload({ id: "att-2", issuer: "ISSUER_B", claimType: "KYC_PASSED" }), // wrong issuer
+      makeAttestationPayload({ id: "att-3", issuer: "ISSUER_A", claimType: "AML_CLEARED" }), // wrong claimType
+      makeAttestationPayload({ id: "att-4", issuer: "ISSUER_A", claimType: "KYC_PASSED" }), // matches both
+    ];
+
+    for (const p of payloads) {
+      await testPubsub.publish(ATTESTATION_CREATED, { onAttestationCreated: p });
+    }
+
+    const iter = testPubsub.asyncIterableIterator<{
+      onAttestationCreated: ReturnType<typeof makeAttestationPayload>;
+    }>(ATTESTATION_CREATED);
+
+    const targetIssuer = "ISSUER_A";
+    const targetClaim = "KYC_PASSED";
+    const seen: string[] = [];
+    for (let i = 0; i < payloads.length; i++) {
+      const result = await iter.next();
+      const att = result.value?.onAttestationCreated;
+      if (att && att.issuer === targetIssuer && att.claimType === targetClaim) {
+        seen.push(att.id);
+      }
+    }
+
+    expect(seen).toContain("att-1");
+    expect(seen).toContain("att-4");
+    expect(seen).not.toContain("att-2");
+    expect(seen).not.toContain("att-3");
+  });
+
+  it("onAttestationCreated: filter by subject AND issuer AND claimType combined", async () => {
+    const payloads = [
+      makeAttestationPayload({ id: "match", subject: "SUB_A", issuer: "ISS_A", claimType: "KYC_PASSED" }),
+      makeAttestationPayload({ id: "wrong-sub", subject: "SUB_B", issuer: "ISS_A", claimType: "KYC_PASSED" }),
+      makeAttestationPayload({ id: "wrong-iss", subject: "SUB_A", issuer: "ISS_B", claimType: "KYC_PASSED" }),
+      makeAttestationPayload({ id: "wrong-claim", subject: "SUB_A", issuer: "ISS_A", claimType: "AML_CLEARED" }),
+    ];
+
+    for (const p of payloads) {
+      await testPubsub.publish(ATTESTATION_CREATED, { onAttestationCreated: p });
+    }
+
+    const iter = testPubsub.asyncIterableIterator<{
+      onAttestationCreated: ReturnType<typeof makeAttestationPayload>;
+    }>(ATTESTATION_CREATED);
+
+    const seen: string[] = [];
+    for (let i = 0; i < payloads.length; i++) {
+      const result = await iter.next();
+      const att = result.value?.onAttestationCreated;
+      if (att && att.subject === "SUB_A" && att.issuer === "ISS_A" && att.claimType === "KYC_PASSED") {
+        seen.push(att.id);
+      }
+    }
+
+    expect(seen).toEqual(["match"]);
+  });
+
+  // ── onAttestationRevoked filters ─────────────────────────────────────────
+
+  it("onAttestationRevoked: filter by subject only", async () => {
+    const payloads = [
+      makeRevocationPayload({ id: "att-1", subject: "SUB_A" }),
+      makeRevocationPayload({ id: "att-2", subject: "SUB_B" }),
+    ];
+
+    for (const p of payloads) {
+      await testPubsub.publish(ATTESTATION_REVOKED, { onAttestationRevoked: p });
+    }
+
+    const iter = testPubsub.asyncIterableIterator<{
+      onAttestationRevoked: ReturnType<typeof makeRevocationPayload>;
+    }>(ATTESTATION_REVOKED);
+
+    const seen: string[] = [];
+    for (let i = 0; i < payloads.length; i++) {
+      const result = await iter.next();
+      const ev = result.value?.onAttestationRevoked;
+      if (ev && ev.subject === "SUB_A") seen.push(ev.id);
+    }
+
+    expect(seen).toContain("att-1");
+    expect(seen).not.toContain("att-2");
+  });
+
+  it("onAttestationRevoked: filter by issuer only", async () => {
+    const payloads = [
+      makeRevocationPayload({ id: "att-1", issuer: "ISS_A" }),
+      makeRevocationPayload({ id: "att-2", issuer: "ISS_B" }),
+      makeRevocationPayload({ id: "att-3", issuer: "ISS_A" }),
+    ];
+
+    for (const p of payloads) {
+      await testPubsub.publish(ATTESTATION_REVOKED, { onAttestationRevoked: p });
+    }
+
+    const iter = testPubsub.asyncIterableIterator<{
+      onAttestationRevoked: ReturnType<typeof makeRevocationPayload>;
+    }>(ATTESTATION_REVOKED);
+
+    const seen: string[] = [];
+    for (let i = 0; i < payloads.length; i++) {
+      const result = await iter.next();
+      const ev = result.value?.onAttestationRevoked;
+      if (ev && ev.issuer === "ISS_A") seen.push(ev.id);
+    }
+
+    expect(seen).toContain("att-1");
+    expect(seen).toContain("att-3");
+    expect(seen).not.toContain("att-2");
+  });
+
+  it("onAttestationRevoked: filter by claimType only", async () => {
+    const payloads = [
+      makeRevocationPayload({ id: "att-1", claimType: "KYC_PASSED" }),
+      makeRevocationPayload({ id: "att-2", claimType: "AML_CLEARED" }),
+      makeRevocationPayload({ id: "att-3", claimType: "KYC_PASSED" }),
+    ];
+
+    for (const p of payloads) {
+      await testPubsub.publish(ATTESTATION_REVOKED, { onAttestationRevoked: p });
+    }
+
+    const iter = testPubsub.asyncIterableIterator<{
+      onAttestationRevoked: ReturnType<typeof makeRevocationPayload>;
+    }>(ATTESTATION_REVOKED);
+
+    const seen: string[] = [];
+    for (let i = 0; i < payloads.length; i++) {
+      const result = await iter.next();
+      const ev = result.value?.onAttestationRevoked;
+      if (ev && ev.claimType === "KYC_PASSED") seen.push(ev.id);
+    }
+
+    expect(seen).toContain("att-1");
+    expect(seen).toContain("att-3");
+    expect(seen).not.toContain("att-2");
+  });
+
+  it("onAttestationRevoked: filter by issuer AND claimType combined", async () => {
+    const payloads = [
+      makeRevocationPayload({ id: "match", issuer: "ISS_A", claimType: "KYC_PASSED" }),
+      makeRevocationPayload({ id: "wrong-iss", issuer: "ISS_B", claimType: "KYC_PASSED" }),
+      makeRevocationPayload({ id: "wrong-claim", issuer: "ISS_A", claimType: "AML_CLEARED" }),
+    ];
+
+    for (const p of payloads) {
+      await testPubsub.publish(ATTESTATION_REVOKED, { onAttestationRevoked: p });
+    }
+
+    const iter = testPubsub.asyncIterableIterator<{
+      onAttestationRevoked: ReturnType<typeof makeRevocationPayload>;
+    }>(ATTESTATION_REVOKED);
+
+    const seen: string[] = [];
+    for (let i = 0; i < payloads.length; i++) {
+      const result = await iter.next();
+      const ev = result.value?.onAttestationRevoked;
+      if (ev && ev.issuer === "ISS_A" && ev.claimType === "KYC_PASSED") seen.push(ev.id);
+    }
+
+    expect(seen).toEqual(["match"]);
+  });
+
+  it("onAttestationRevoked: filter by subject AND issuer AND claimType combined", async () => {
+    const payloads = [
+      makeRevocationPayload({ id: "match", subject: "SUB_A", issuer: "ISS_A", claimType: "KYC_PASSED" }),
+      makeRevocationPayload({ id: "wrong-sub", subject: "SUB_B", issuer: "ISS_A", claimType: "KYC_PASSED" }),
+      makeRevocationPayload({ id: "wrong-iss", subject: "SUB_A", issuer: "ISS_B", claimType: "KYC_PASSED" }),
+      makeRevocationPayload({ id: "wrong-claim", subject: "SUB_A", issuer: "ISS_A", claimType: "AML_CLEARED" }),
+    ];
+
+    for (const p of payloads) {
+      await testPubsub.publish(ATTESTATION_REVOKED, { onAttestationRevoked: p });
+    }
+
+    const iter = testPubsub.asyncIterableIterator<{
+      onAttestationRevoked: ReturnType<typeof makeRevocationPayload>;
+    }>(ATTESTATION_REVOKED);
+
+    const seen: string[] = [];
+    for (let i = 0; i < payloads.length; i++) {
+      const result = await iter.next();
+      const ev = result.value?.onAttestationRevoked;
+      if (ev && ev.subject === "SUB_A" && ev.issuer === "ISS_A" && ev.claimType === "KYC_PASSED") {
+        seen.push(ev.id);
+      }
+    }
+
+    expect(seen).toEqual(["match"]);
+  });
+
+  // ── Backwards compatibility: no-filter case passes everything through ────
+
+  it("onAttestationCreated: no filters passes all events", async () => {
+    const payloads = [
+      makeAttestationPayload({ id: "att-1", subject: "SUB_A", issuer: "ISS_A", claimType: "KYC_PASSED" }),
+      makeAttestationPayload({ id: "att-2", subject: "SUB_B", issuer: "ISS_B", claimType: "AML_CLEARED" }),
+    ];
+
+    for (const p of payloads) {
+      await testPubsub.publish(ATTESTATION_CREATED, { onAttestationCreated: p });
+    }
+
+    const iter = testPubsub.asyncIterableIterator<{
+      onAttestationCreated: ReturnType<typeof makeAttestationPayload>;
+    }>(ATTESTATION_CREATED);
+
+    const seen: string[] = [];
+    for (let i = 0; i < payloads.length; i++) {
+      const result = await iter.next();
+      const att = result.value?.onAttestationCreated;
+      if (att) seen.push(att.id);
+    }
+
+    expect(seen).toContain("att-1");
+    expect(seen).toContain("att-2");
+  });
+
+  it("onAttestationRevoked: no filters passes all events", async () => {
+    const payloads = [
+      makeRevocationPayload({ id: "att-1" }),
+      makeRevocationPayload({ id: "att-2", issuer: "OTHER_ISS" }),
+    ];
+
+    for (const p of payloads) {
+      await testPubsub.publish(ATTESTATION_REVOKED, { onAttestationRevoked: p });
+    }
+
+    const iter = testPubsub.asyncIterableIterator<{
+      onAttestationRevoked: ReturnType<typeof makeRevocationPayload>;
+    }>(ATTESTATION_REVOKED);
+
+    const seen: string[] = [];
+    for (let i = 0; i < payloads.length; i++) {
+      const result = await iter.next();
+      const ev = result.value?.onAttestationRevoked;
+      if (ev) seen.push(ev.id);
+    }
+
+    expect(seen).toContain("att-1");
+    expect(seen).toContain("att-2");
   });
 });


### PR DESCRIPTION
## Problem
`onAttestationCreated` only filtered by `subject`; `onAttestationRevoked` only filtered by `issuer`. Neither accepted `claimType`, which is the most common integrator use-case ("notify me whenever any KYC_PASSED attestation is created or revoked for anyone").

## Changes
- `schema.graphql`: Both subscriptions now accept `subject`, `issuer`, and `claimType` as optional arguments (AND logic when combined). `AttestationRevoked` type gains `subject` and `claimType` fields.
- `graphql.ts`: Subscription `subscribe` functions updated with all three predicates. No-filter path (all `undefined`) returns the raw async iterator unchanged — zero overhead.
- `indexer.ts`: `pubsub.publish(ATTESTATION_REVOKED, …)` payload updated to include `subject` and `claimType`. Fixed missing `ATTESTATION_REVOKED` and `ISSUER_REGISTERED` imports.
- `subscriptions.test.ts`: Rewritten with 12 tests covering every filter argument individually, in combination, and the no-filter passthrough for both subscriptions.

Closes #974