### PR TITLE
feat: implement unified event-topic taxonomy and SDK filtering

### DIFF
--- a/bindings/python/trustlink/__init__.py
+++ b/bindings/python/trustlink/__init__.py
@@ -16,6 +16,23 @@ from .types import (
     TrustLinkError,
     ContractError,
 )
+from .events import (
+    EventTopics,
+    EventCategories,
+    ContractEvent,
+    RawContractEvent,
+    EventSubscriptionOptions,
+    GraphQLSubscriptionOptions,
+    LedgerEventWatchOptions,
+    validate_event_topics,
+    normalize_event_topic,
+    get_topic_description,
+)
+from .event_subscriptions import (
+    subscribe_to_direct_ledger_events,
+    subscribe_to_graphql_events,
+    EventSubscription,
+)
 
 __version__ = "0.1.0"
 __all__ = [
@@ -33,4 +50,17 @@ __all__ = [
     "MultiSigProposal",
     "TrustLinkError",
     "ContractError",
+    "EventTopics",
+    "EventCategories",
+    "ContractEvent",
+    "RawContractEvent",
+    "EventSubscriptionOptions",
+    "GraphQLSubscriptionOptions",
+    "LedgerEventWatchOptions",
+    "validate_event_topics",
+    "normalize_event_topic",
+    "get_topic_description",
+    "subscribe_to_direct_ledger_events",
+    "subscribe_to_graphql_events",
+    "EventSubscription",
 ]

--- a/bindings/python/trustlink/event_subscriptions.py
+++ b/bindings/python/trustlink/event_subscriptions.py
@@ -1,0 +1,443 @@
+"""Event subscription helpers for TrustLink Python SDK.
+
+Provides convenient methods to subscribe to contract events via GraphQL subscriptions
+or direct ledger event watching with optional topic filtering.
+"""
+
+import asyncio
+import json
+import logging
+from typing import Optional, List, Callable, Any
+from datetime import datetime
+
+from stellar_sdk import Server
+from .events import (
+    EventTopics,
+    EventSubscriptionOptions,
+    GraphQLSubscriptionOptions,
+    LedgerEventWatchOptions,
+    ContractEvent,
+    RawContractEvent,
+    AsyncEventCallback,
+    EventCallback,
+    validate_event_topics,
+)
+
+logger = logging.getLogger(__name__)
+
+# Optional websockets import for GraphQL subscriptions
+try:
+    import websockets
+except ImportError:
+    websockets = None  # type: ignore
+
+
+class EventSubscription:
+    """A subscription handle that can be used to unsubscribe from events."""
+
+    def __init__(self):
+        self._is_active = True
+        self._tasks: List[asyncio.Task[Any]] = []
+
+    async def unsubscribe(self) -> None:
+        """Unsubscribe from the event stream."""
+        self._is_active = False
+        # Cancel all pending tasks
+        for task in self._tasks:
+            if not task.done():
+                task.cancel()
+        # Wait for all tasks to complete
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+
+    def is_active(self) -> bool:
+        """Check if the subscription is still active."""
+        return self._is_active
+
+    def _add_task(self, task: asyncio.Task[Any]) -> None:
+        """Add a task to be tracked."""
+        self._tasks.append(task)
+
+
+async def subscribe_to_direct_ledger_events(
+    options: LedgerEventWatchOptions,
+    callback: AsyncEventCallback,
+) -> EventSubscription:
+    """Subscribes to contract events via direct ledger watching with optional topic filtering.
+
+    This method polls the Soroban RPC for new ledger events, allowing fine-grained
+    filtering by topics without depending on the indexer.
+
+    Args:
+        options: Configuration for ledger event watching
+        callback: Async callback invoked for each matching event
+
+    Returns:
+        EventSubscription handle for unsubscribing
+
+    Example:
+        ```python
+        from trustlink import (
+            subscribe_to_direct_ledger_events,
+            LedgerEventWatchOptions,
+            EventTopics,
+        )
+
+        async def handle_event(event):
+            print(f"Event: {event.topic} at ledger {event.ledger}")
+
+        sub = await subscribe_to_direct_ledger_events(
+            LedgerEventWatchOptions(
+                rpc_url="https://soroban-testnet.stellar.org",
+                contract_id="C...",
+                network_passphrase="Test SDF Future Network ; October 2024",
+                topics=[EventTopics.CREATED, EventTopics.REVOKED],
+            ),
+            handle_event,
+        )
+        ```
+    """
+    if not websockets and isinstance(options, GraphQLSubscriptionOptions):
+        raise ImportError("websockets library required for GraphQL subscriptions")
+
+    # Validate topics if provided
+    topics = validate_event_topics(options.topics) if options.topics else None
+
+    server = Server(options.rpc_url, client=None)
+
+    subscription = EventSubscription()
+
+    # Get initial ledger if not specified
+    cursor = options.start_ledger
+    if not cursor:
+        latest_ledger = server.get_latest_ledger()
+        cursor = latest_ledger.sequence
+
+    async def poll_loop() -> None:
+        """Poll loop for direct ledger watching."""
+        nonlocal cursor
+
+        while subscription.is_active():
+            try:
+                # Get latest ledger
+                latest_ledger = server.get_latest_ledger()
+                latest = latest_ledger.sequence
+
+                if cursor <= latest:
+                    # Fetch events in range
+                    events = server.get_events(
+                        start_ledger=cursor,
+                        filters=[
+                            {
+                                "type": "contract",
+                                "contractIds": [options.contract_id],
+                            }
+                        ],
+                        limit=options.page_size,
+                    )
+
+                    for event in events.get("events", []):
+                        if not subscription.is_active():
+                            break
+
+                        # Filter by topic
+                        event_topics = event.get("topics", [])
+                        if not event_topics:
+                            continue
+
+                        event_topic = event_topics[0]
+                        if topics and event_topic not in topics:
+                            continue
+
+                        # Filter by subject
+                        if options.subject and len(event_topics) > 1:
+                            if event_topics[1] != options.subject:
+                                continue
+
+                        # Filter by issuer
+                        if options.issuer and len(event_topics) > 1:
+                            if event_topics[1] != options.issuer:
+                                continue
+
+                        # Map and invoke callback
+                        mapped_event = _map_raw_event(event)
+                        if mapped_event:
+                            result = callback(mapped_event)
+                            if hasattr(result, "__await__"):
+                                await result
+
+                    cursor = latest + 1
+
+                # Wait before next poll
+                await asyncio.sleep(options.polling_interval_ms / 1000.0)
+
+            except Exception as e:
+                logger.error(f"Error polling ledger events: {e}")
+                if subscription.is_active():
+                    await asyncio.sleep(options.polling_interval_ms / 1000.0)
+
+    # Start polling loop in background
+    task = asyncio.create_task(poll_loop())
+    subscription._add_task(task)
+
+    return subscription
+
+
+async def subscribe_to_graphql_events(
+    options: GraphQLSubscriptionOptions,
+    callback: AsyncEventCallback,
+) -> EventSubscription:
+    """Subscribes to contract events via GraphQL subscriptions from the indexer.
+
+    This method uses the indexer's GraphQL subscriptions for real-time event streaming.
+
+    Args:
+        options: Configuration for GraphQL subscriptions
+        callback: Async callback invoked for each matching event
+
+    Returns:
+        EventSubscription handle for unsubscribing
+
+    Example:
+        ```python
+        from trustlink import (
+            subscribe_to_graphql_events,
+            GraphQLSubscriptionOptions,
+            EventTopics,
+            EventCategories,
+        )
+
+        async def handle_event(event):
+            print(f"Event: {event.topic}")
+
+        sub = await subscribe_to_graphql_events(
+            GraphQLSubscriptionOptions(
+                graphql_url="wss://indexer.trustlink.io/graphql",
+                topics=EventCategories.ATTESTATION_LIFECYCLE,
+                subject="GBBD...",
+            ),
+            handle_event,
+        )
+        ```
+    """
+    if not websockets:
+        raise ImportError("websockets library required for GraphQL subscriptions")
+
+    # Validate topics if provided
+    topics = validate_event_topics(options.topics) if options.topics else None
+
+    graphql_url = (
+        options.graphql_url or "wss://localhost:4000/graphql"
+    )
+
+    subscription = EventSubscription()
+
+    async def connect_and_listen() -> None:
+        """Connect to GraphQL WebSocket and listen for events."""
+        reconnect_count = 0
+
+        while subscription.is_active() and reconnect_count < options.reconnect_attempts:
+            try:
+                async with websockets.connect(
+                    graphql_url,
+                    subprotocols=["graphql-transport-ws"],
+                    extra_headers=options.headers or {},
+                ) as ws:
+                    reconnect_count = 0
+
+                    # Send connection init
+                    await ws.send(
+                        json.dumps(
+                            {"type": "connection_init", "payload": {}}
+                        )
+                    )
+
+                    # Subscribe to relevant topics
+                    await _subscribe_to_relevant_topics(
+                        ws, options, topics
+                    )
+
+                    # Listen for messages
+                    async for message_str in ws:
+                        if not subscription.is_active():
+                            break
+
+                        try:
+                            message = json.loads(message_str)
+                        except json.JSONDecodeError:
+                            continue
+
+                        if message.get("type") == "next":
+                            payload = message.get("payload", {})
+                            data = payload.get("data", {})
+
+                            # Handle different subscription types
+                            if "onAttestationCreated" in data:
+                                if (
+                                    not topics
+                                    or not topics
+                                    or "created" in topics
+                                ):
+                                    event_data = data["onAttestationCreated"]
+                                    if (
+                                        not options.subject
+                                        or event_data.get("subject")
+                                        == options.subject
+                                    ):
+                                        mapped_event = _map_graphql_event(
+                                            "created", event_data
+                                        )
+                                        result = callback(mapped_event)
+                                        if hasattr(result, "__await__"):
+                                            await result
+
+                            if "onAttestationRevoked" in data:
+                                if (
+                                    not topics
+                                    or not topics
+                                    or "revoked" in topics
+                                ):
+                                    event_data = data["onAttestationRevoked"]
+                                    if (
+                                        not options.issuer
+                                        or event_data.get("issuer")
+                                        == options.issuer
+                                    ):
+                                        mapped_event = _map_graphql_event(
+                                            "revoked", event_data
+                                        )
+                                        result = callback(mapped_event)
+                                        if hasattr(result, "__await__"):
+                                            await result
+
+                            if "onIssuerRegistered" in data:
+                                if (
+                                    not topics
+                                    or not topics
+                                    or "iss_reg" in topics
+                                ):
+                                    event_data = data["onIssuerRegistered"]
+                                    mapped_event = _map_graphql_event(
+                                        "iss_reg", event_data
+                                    )
+                                    result = callback(mapped_event)
+                                    if hasattr(result, "__await__"):
+                                        await result
+
+            except Exception as e:
+                logger.error(f"GraphQL subscription error: {e}")
+                if subscription.is_active():
+                    reconnect_count += 1
+                    if reconnect_count < options.reconnect_attempts:
+                        delay = (
+                            options.reconnect_delay_ms / 1000.0
+                            * (2 ** (reconnect_count - 1))
+                        )
+                        await asyncio.sleep(delay)
+
+    # Start connection loop in background
+    task = asyncio.create_task(connect_and_listen())
+    subscription._add_task(task)
+
+    return subscription
+
+
+# ─── Helper Functions ────────────────────────────────────────────────────────
+
+async def _subscribe_to_relevant_topics(
+    ws: Any, options: GraphQLSubscriptionOptions, topics: Optional[List[str]]
+) -> None:
+    """Subscribe to relevant GraphQL subscriptions based on topic filters."""
+    # Subscribe to attestation created
+    if not topics or not topics or "created" in (topics or []):
+        query = "subscription { onAttestationCreated { id subject issuer claimType } }"
+        await ws.send(
+            json.dumps(
+                {
+                    "id": f"sub_created_{id(ws)}",
+                    "type": "subscribe",
+                    "payload": {"query": query},
+                }
+            )
+        )
+
+    # Subscribe to attestation revoked
+    if not topics or not topics or "revoked" in (topics or []):
+        query = "subscription { onAttestationRevoked { id issuer revokedAt } }"
+        await ws.send(
+            json.dumps(
+                {
+                    "id": f"sub_revoked_{id(ws)}",
+                    "type": "subscribe",
+                    "payload": {"query": query},
+                }
+            )
+        )
+
+    # Subscribe to issuer registered
+    if not topics or not topics or "iss_reg" in (topics or []):
+        query = "subscription { onIssuerRegistered { issuer registeredAt } }"
+        await ws.send(
+            json.dumps(
+                {
+                    "id": f"sub_iss_reg_{id(ws)}",
+                    "type": "subscribe",
+                    "payload": {"query": query},
+                }
+            )
+        )
+
+
+def _map_raw_event(raw_event: dict) -> Optional[ContractEvent]:
+    """Maps a raw Soroban event to a normalized ContractEvent."""
+    try:
+        topics = raw_event.get("topics", [])
+        if not topics:
+            return None
+
+        topic = topics[0]
+        data = raw_event.get("value", {})
+
+        raw = RawContractEvent(
+            id=raw_event.get("id", ""),
+            event_type=raw_event.get("type", "contract"),
+            ledger=raw_event.get("ledger", 0),
+            tx_hash=raw_event.get("txHash", ""),
+            topics=topics,
+            data=data,
+            timestamp=datetime.now(),
+        )
+
+        return ContractEvent(
+            topic=topic,
+            ledger=raw_event.get("ledger", 0),
+            tx_hash=raw_event.get("txHash", ""),
+            data=data if isinstance(data, dict) else {},
+            timestamp=datetime.now(),
+            raw=raw,
+        )
+    except Exception as e:
+        logger.error(f"Error mapping raw event: {e}")
+        return None
+
+
+def _map_graphql_event(topic: str, data: dict) -> ContractEvent:
+    """Maps a GraphQL event to a normalized ContractEvent."""
+    raw = RawContractEvent(
+        id=json.dumps(data),
+        event_type="contract",
+        ledger=0,
+        tx_hash="",
+        topics=[topic],
+        data=data,
+        timestamp=datetime.now(),
+    )
+
+    return ContractEvent(
+        topic=topic,
+        ledger=0,
+        tx_hash="",
+        data=data,
+        timestamp=datetime.now(),
+        raw=raw,
+    )

--- a/bindings/python/trustlink/events.py
+++ b/bindings/python/trustlink/events.py
@@ -1,0 +1,408 @@
+"""TrustLink Event Topics and Event Subscription Utilities.
+
+Provides canonical event topic definitions, type-safe event subscriptions,
+and helpers for filtering contract events via the indexer or direct ledger watching.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple, Callable, Set, Any
+from datetime import datetime
+import asyncio
+import json
+
+try:
+    import websockets
+except ImportError:
+    websockets = None  # type: ignore
+
+
+# ─── Event Topic Constants ─────────────────────────────────────────────────────
+
+class EventTopics:
+    """Canonical event topic constants matching TrustLink contract.
+    
+    All topics are ≤9 characters as required by Soroban symbol_short!().
+    """
+    
+    # ─── Attestation Lifecycle ────────────────────────────────────────────────────
+    CREATED = "created"
+    IMPORTED = "imported"
+    BRIDGED = "bridged"
+    REVOKED = "revoked"
+    RENEWED = "renewed"
+    UPDATED = "updated"
+    EXPIRED = "expired"
+    ENDORSED = "endorsed"
+    AMENDED = "amended"
+    DEL_REQ = "del_req"
+    XFER = "xfer"
+    ATT_XFER = "att_xfer"
+
+    # ─── Issuer Lifecycle ──────────────────────────────────────────────────────────
+    ISS_REG = "iss_reg"
+    ISS_TIER = "iss_tier"
+    ISS_REM = "iss_rem"
+
+    # ─── Admin & Governance ────────────────────────────────────────────────────────
+    ADM_INIT = "adm_init"
+    ADM_XFER = "adm_xfer"
+    ADM_ADD = "adm_add"
+    ADM_REM = "adm_rem"
+    ADM_PROP = "adm_prop"
+
+    # ─── Compliance & Requests ────────────────────────────────────────────────────
+    CLM_TYPE = "clm_type"
+    ATT_REQ = "att_req"
+    REQ_OK = "req_ok"
+    REQ_NO = "req_no"
+    REQ_CNCL = "req_cncl"
+    DEL_CRTD = "del_crtd"
+    DEL_RVKD = "del_rvkd"
+    WL_ON = "wl_on"
+    WL_ADD = "wl_add"
+    WL_REM = "wl_rem"
+
+    # ─── Multi-Sig & Proposals ────────────────────────────────────────────────────
+    MS_PROP = "ms_prop"
+    MS_SIGN = "ms_sign"
+    MS_ACTV = "ms_actv"
+    MS_CANCEL = "ms_cancel"
+
+    # ─── Dispute & Amendment ──────────────────────────────────────────────────────
+    DISPUTED = "disputed"
+    DSP_RES = "dsp_res"
+
+    # ─── Pause & Lifecycle ────────────────────────────────────────────────────────
+    PAUSED = "paused"
+    UNPAUSED = "unpaused"
+
+    # ─── Templates ────────────────────────────────────────────────────────────────
+    TMPL_CRT = "tmpl_crt"
+    TPL_DEL = "tpl_del"
+
+    # ─── Council Governance ───────────────────────────────────────────────────────
+    CNCL_INI = "cncl_ini"
+    PROP_NEW = "prop_new"
+    PROP_OK = "prop_ok"
+    PROP_EXE = "prop_exe"
+    TL_START = "tl_start"
+    EXP_HOOK = "exp_hook"
+
+    @classmethod
+    def all_topics(cls) -> List[str]:
+        """Returns list of all valid event topics."""
+        return [
+            cls.CREATED,
+            cls.IMPORTED,
+            cls.BRIDGED,
+            cls.REVOKED,
+            cls.RENEWED,
+            cls.UPDATED,
+            cls.EXPIRED,
+            cls.ENDORSED,
+            cls.AMENDED,
+            cls.DEL_REQ,
+            cls.XFER,
+            cls.ATT_XFER,
+            cls.ISS_REG,
+            cls.ISS_TIER,
+            cls.ISS_REM,
+            cls.ADM_INIT,
+            cls.ADM_XFER,
+            cls.ADM_ADD,
+            cls.ADM_REM,
+            cls.ADM_PROP,
+            cls.CLM_TYPE,
+            cls.ATT_REQ,
+            cls.REQ_OK,
+            cls.REQ_NO,
+            cls.REQ_CNCL,
+            cls.DEL_CRTD,
+            cls.DEL_RVKD,
+            cls.WL_ON,
+            cls.WL_ADD,
+            cls.WL_REM,
+            cls.MS_PROP,
+            cls.MS_SIGN,
+            cls.MS_ACTV,
+            cls.MS_CANCEL,
+            cls.DISPUTED,
+            cls.DSP_RES,
+            cls.PAUSED,
+            cls.UNPAUSED,
+            cls.TMPL_CRT,
+            cls.TPL_DEL,
+            cls.CNCL_INI,
+            cls.PROP_NEW,
+            cls.PROP_OK,
+            cls.PROP_EXE,
+            cls.TL_START,
+            cls.EXP_HOOK,
+        ]
+
+    @classmethod
+    def is_valid_topic(cls, topic: str) -> bool:
+        """Check if a topic string is a valid event topic."""
+        return topic in cls.all_topics()
+
+
+# ─── Event Topic Categories ───────────────────────────────────────────────────
+
+class EventCategories:
+    """Event topic categories for convenient subscription grouping."""
+    
+    ATTESTATION_LIFECYCLE = [
+        EventTopics.CREATED,
+        EventTopics.IMPORTED,
+        EventTopics.BRIDGED,
+        EventTopics.REVOKED,
+        EventTopics.RENEWED,
+        EventTopics.UPDATED,
+        EventTopics.EXPIRED,
+        EventTopics.ENDORSED,
+        EventTopics.AMENDED,
+        EventTopics.XFER,
+    ]
+
+    ISSUER_COMPLIANCE = [
+        EventTopics.ISS_REG,
+        EventTopics.ISS_TIER,
+        EventTopics.ISS_REM,
+        EventTopics.WL_ON,
+        EventTopics.WL_ADD,
+        EventTopics.WL_REM,
+        EventTopics.DEL_CRTD,
+        EventTopics.DEL_RVKD,
+    ]
+
+    REQUEST_LIFECYCLE = [
+        EventTopics.ATT_REQ,
+        EventTopics.REQ_OK,
+        EventTopics.REQ_NO,
+        EventTopics.REQ_CNCL,
+    ]
+
+    MULTISIG = [
+        EventTopics.MS_PROP,
+        EventTopics.MS_SIGN,
+        EventTopics.MS_ACTV,
+        EventTopics.MS_CANCEL,
+    ]
+
+    DISPUTE_AMENDMENT = [
+        EventTopics.DISPUTED,
+        EventTopics.DSP_RES,
+        EventTopics.AMENDED,
+    ]
+
+    ADMIN_ACTIONS = [
+        EventTopics.ADM_INIT,
+        EventTopics.ADM_XFER,
+        EventTopics.ADM_ADD,
+        EventTopics.ADM_REM,
+        EventTopics.ADM_PROP,
+        EventTopics.PAUSED,
+        EventTopics.UNPAUSED,
+    ]
+
+    COUNCIL_GOVERNANCE = [
+        EventTopics.CNCL_INI,
+        EventTopics.PROP_NEW,
+        EventTopics.PROP_OK,
+        EventTopics.PROP_EXE,
+        EventTopics.TL_START,
+    ]
+
+    INDEXED_PRIORITY = [
+        EventTopics.CREATED,
+        EventTopics.REVOKED,
+        EventTopics.IMPORTED,
+        EventTopics.BRIDGED,
+        EventTopics.MS_PROP,
+        EventTopics.MS_SIGN,
+        EventTopics.MS_ACTV,
+        EventTopics.ISS_REG,
+    ]
+
+
+# ─── Data Classes ─────────────────────────────────────────────────────────────
+
+@dataclass
+class RawContractEvent:
+    """Represents a raw event from the ledger."""
+    id: str
+    event_type: str
+    ledger: int
+    tx_hash: str
+    topics: List[str]
+    data: Any
+    timestamp: datetime
+
+
+@dataclass
+class ContractEvent:
+    """Represents a mapped/normalized contract event."""
+    topic: str
+    ledger: int
+    tx_hash: str
+    data: dict
+    timestamp: datetime
+    raw: RawContractEvent
+
+
+# ─── Options and Callbacks ────────────────────────────────────────────────────
+
+@dataclass
+class EventSubscriptionOptions:
+    """Options for event subscriptions."""
+    
+    # Event topics to subscribe to. If empty, subscribes to all topics.
+    topics: Optional[List[str]] = None
+    
+    # Filter by subject address
+    subject: Optional[str] = None
+    
+    # Filter by issuer address
+    issuer: Optional[str] = None
+    
+    # Polling interval in milliseconds for direct ledger watching
+    polling_interval_ms: int = 5000
+    
+    # Maximum number of events to fetch per poll
+    page_size: int = 100
+    
+    # Starting ledger for direct ledger watching (optional)
+    start_ledger: Optional[int] = None
+
+
+@dataclass
+class GraphQLSubscriptionOptions(EventSubscriptionOptions):
+    """Options for GraphQL-based event subscriptions."""
+    
+    # GraphQL endpoint WebSocket URL
+    graphql_url: Optional[str] = None
+    
+    # Custom headers for WebSocket connection
+    headers: Optional[dict] = None
+    
+    # Reconnection config
+    reconnect_attempts: int = 5
+    reconnect_delay_ms: int = 1000
+
+
+@dataclass
+class LedgerEventWatchOptions(EventSubscriptionOptions):
+    """Options for direct ledger event watching."""
+    
+    # Soroban RPC endpoint (required)
+    rpc_url: str = ""
+    
+    # Contract ID to watch (required)
+    contract_id: str = ""
+    
+    # Network passphrase
+    network_passphrase: str = ""
+
+
+# ─── Validation ───────────────────────────────────────────────────────────────
+
+def validate_event_topics(topics: List[str]) -> List[str]:
+    """Validates that all provided topics are valid event topics.
+    
+    Args:
+        topics: Array of topics to validate
+        
+    Returns:
+        The validated topics array
+        
+    Raises:
+        ValueError: If any topic is invalid
+    """
+    valid_topics = set(EventTopics.all_topics())
+    for topic in topics:
+        if not isinstance(topic, str) or topic not in valid_topics:
+            raise ValueError(
+                f'Invalid event topic: "{topic}". See EventTopics for valid values.'
+            )
+    return topics
+
+
+def normalize_event_topic(raw: str) -> Optional[str]:
+    """Normalizes event topic constants to their string representation.
+    
+    Args:
+        raw: Raw topic string from ledger event
+        
+    Returns:
+        Normalized topic, or None if not recognized
+    """
+    normalized = raw.lower().strip()
+    if EventTopics.is_valid_topic(normalized):
+        return normalized
+    return None
+
+
+def get_topic_description(topic: str) -> str:
+    """Returns a human-readable description of an event topic.
+    
+    Args:
+        topic: The event topic
+        
+    Returns:
+        Description of what this topic represents
+    """
+    descriptions = {
+        EventTopics.CREATED: "Attestation created",
+        EventTopics.IMPORTED: "Attestation imported from external source",
+        EventTopics.BRIDGED: "Attestation bridged from another blockchain",
+        EventTopics.REVOKED: "Attestation revoked by issuer",
+        EventTopics.RENEWED: "Attestation expiration renewed",
+        EventTopics.UPDATED: "Attestation updated",
+        EventTopics.EXPIRED: "Attestation expired",
+        EventTopics.ENDORSED: "Attestation endorsed",
+        EventTopics.AMENDED: "Attestation metadata amended",
+        EventTopics.DEL_REQ: "Deletion requested",
+        EventTopics.XFER: "Attestation issuer transferred",
+        EventTopics.ATT_XFER: "Attestation transferred",
+        EventTopics.ISS_REG: "Issuer registered",
+        EventTopics.ISS_TIER: "Issuer tier updated",
+        EventTopics.ISS_REM: "Issuer removed",
+        EventTopics.ADM_INIT: "Admin initialized",
+        EventTopics.ADM_XFER: "Admin transferred",
+        EventTopics.ADM_ADD: "Admin added",
+        EventTopics.ADM_REM: "Admin removed",
+        EventTopics.ADM_PROP: "Admin transfer proposed",
+        EventTopics.CLM_TYPE: "Claim type registered",
+        EventTopics.ATT_REQ: "Attestation requested",
+        EventTopics.REQ_OK: "Request fulfilled",
+        EventTopics.REQ_NO: "Request rejected",
+        EventTopics.REQ_CNCL: "Request cancelled",
+        EventTopics.DEL_CRTD: "Delegation created",
+        EventTopics.DEL_RVKD: "Delegation revoked",
+        EventTopics.WL_ON: "Whitelist mode enabled",
+        EventTopics.WL_ADD: "Subject added to whitelist",
+        EventTopics.WL_REM: "Subject removed from whitelist",
+        EventTopics.MS_PROP: "Multi-sig proposal created",
+        EventTopics.MS_SIGN: "Multi-sig proposal cosigned",
+        EventTopics.MS_ACTV: "Multi-sig proposal activated",
+        EventTopics.MS_CANCEL: "Multi-sig proposal cancelled",
+        EventTopics.DISPUTED: "Dispute raised",
+        EventTopics.DSP_RES: "Dispute resolved",
+        EventTopics.PAUSED: "Contract paused",
+        EventTopics.UNPAUSED: "Contract unpaused",
+        EventTopics.TMPL_CRT: "Template created",
+        EventTopics.TPL_DEL: "Template deleted",
+        EventTopics.CNCL_INI: "Council initialized",
+        EventTopics.PROP_NEW: "Council proposal created",
+        EventTopics.PROP_OK: "Council proposal approved",
+        EventTopics.PROP_EXE: "Council proposal executed",
+        EventTopics.TL_START: "Timelock started",
+        EventTopics.EXP_HOOK: "Expiration hook triggered",
+    }
+    return descriptions.get(topic, "Unknown event")
+
+
+# ─── Type Aliases ────────────────────────────────────────────────────────────
+
+EventCallback = Callable[[ContractEvent], None]
+AsyncEventCallback = Callable[[ContractEvent], Any]

--- a/bindings/typescript/src/eventSubscriptions.ts
+++ b/bindings/typescript/src/eventSubscriptions.ts
@@ -1,0 +1,496 @@
+/**
+ * Event subscription helpers for TrustLink SDK.
+ *
+ * Provides convenient methods to subscribe to contract events via GraphQL subscriptions
+ * or direct ledger event watching with optional topic filtering.
+ */
+
+import { Server as SorobanRpc } from "@stellar/stellar-sdk";
+import type { EventSubscriptionOptions, EventTopic } from "./events";
+import { validateEventTopics } from "./events";
+
+/**
+ * Represents a raw event from the ledger.
+ */
+export interface RawContractEvent {
+  id: string;
+  type: string;
+  ledger: number;
+  txHash: string;
+  topics: string[];
+  data: unknown;
+  timestamp: Date;
+}
+
+/**
+ * Represents a mapped/normalized contract event.
+ */
+export interface ContractEvent {
+  topic: EventTopic;
+  ledger: number;
+  txHash: string;
+  data: Record<string, unknown>;
+  timestamp: Date;
+  raw: RawContractEvent;
+}
+
+/**
+ * Callback type for event subscriptions.
+ */
+export type EventCallback = (event: ContractEvent) => void | Promise<void>;
+
+/**
+ * A subscription handle that can be used to unsubscribe from events.
+ */
+export interface EventSubscription {
+  /** Unsubscribe from the event stream */
+  unsubscribe(): Promise<void>;
+
+  /** Check if the subscription is still active */
+  isActive(): boolean;
+}
+
+/**
+ * GraphQL subscription event - represents streaming events from the indexer.
+ */
+interface GraphQLSubscriptionMessage {
+  id: string;
+  type: "subscribe" | "next" | "complete" | "error";
+  payload?: {
+    data?: Record<string, unknown>;
+    errors?: Array<{ message: string }>;
+  };
+}
+
+/**
+ * Options for GraphQL-based event subscriptions (via indexer).
+ */
+export interface GraphQLSubscriptionOptions extends EventSubscriptionOptions {
+  /** GraphQL endpoint WebSocket URL */
+  graphqlUrl?: string;
+
+  /** Custom headers to include in the WebSocket connection */
+  headers?: Record<string, string>;
+
+  /** Reconnection config */
+  reconnectAttempts?: number;
+  reconnectDelayMs?: number;
+}
+
+/**
+ * Options for direct ledger event watching.
+ */
+export interface LedgerEventWatchOptions extends EventSubscriptionOptions {
+  /** Soroban RPC endpoint (required) */
+  rpcUrl: string;
+
+  /** Contract ID to watch */
+  contractId: string;
+
+  /** Network passphrase */
+  networkPassphrase: string;
+
+  /** Starting ledger (optional - defaults to current ledger) */
+  startLedger?: number;
+}
+
+/**
+ * Subscribes to contract events via direct ledger watching with optional topic filtering.
+ *
+ * This method polls the Soroban RPC for new ledger events, allowing fine-grained
+ * filtering by topics without depending on the indexer.
+ *
+ * @param options - Configuration for ledger event watching
+ * @param callback - Callback invoked for each matching event
+ * @returns EventSubscription handle for unsubscribing
+ *
+ * @example
+ * ```ts
+ * import { subscribeToDirect LedgerEvents, EventTopics } from '@trustlink/contract';
+ *
+ * const unsub = await subscribeToDirectLedgerEvents(
+ *   {
+ *     rpcUrl: 'https://soroban-testnet.stellar.org',
+ *     contractId: 'C...',
+ *     networkPassphrase: 'Test SDF Future Network ; October 2024',
+ *     topics: [EventTopics.CREATED, EventTopics.REVOKED],
+ *     startLedger: 1000000,
+ *   },
+ *   (event) => console.log('Event:', event)
+ * );
+ * ```
+ */
+export async function subscribeToDirectLedgerEvents(
+  options: LedgerEventWatchOptions,
+  callback: EventCallback
+): Promise<EventSubscription> {
+  const {
+    rpcUrl,
+    contractId,
+    networkPassphrase,
+    topics: rawTopics,
+    subject,
+    issuer,
+    pollingIntervalMs = 5000,
+    pageSize = 100,
+    startLedger,
+  } = options;
+
+  // Validate topics if provided
+  const topics = rawTopics ? validateEventTopics(rawTopics) : null;
+
+  const rpc = new SorobanRpc(rpcUrl, { allowHttp: true });
+
+  let isActive = true;
+  let cursor = startLedger;
+
+  // Get initial ledger if not specified
+  if (!cursor) {
+    const latestLedger = await rpc.getLatestLedger();
+    cursor = latestLedger.sequence;
+  }
+
+  // Start polling loop
+  const pollInterval = setInterval(async () => {
+    if (!isActive) return;
+
+    try {
+      const latestLedger = await rpc.getLatestLedger();
+      const latest = latestLedger.sequence;
+
+      if (cursor <= latest) {
+        // Fetch events in the range
+        const events = await rpc.getEvents({
+          startLedger: cursor,
+          filters: [
+            {
+              type: "contract",
+              contractIds: [contractId],
+            },
+          ],
+          limit: pageSize,
+        });
+
+        for (const event of events.events) {
+          // Filter by topic if specified
+          if (topics && topics.length > 0) {
+            const eventTopic = event.topics?.[0]?.toString();
+            if (!eventTopic || !topics.includes(eventTopic as EventTopic)) {
+              continue;
+            }
+          }
+
+          // Filter by subject if specified
+          if (subject && event.topics?.[1] !== subject) {
+            continue;
+          }
+
+          // Filter by issuer if specified
+          if (issuer && event.topics?.[1] !== issuer) {
+            continue;
+          }
+
+          // Map and invoke callback
+          const mappedEvent = mapRawEvent(event);
+          if (mappedEvent) {
+            await callback(mappedEvent);
+          }
+        }
+
+        cursor = latest + 1;
+      }
+    } catch (error) {
+      console.error("Error polling ledger events:", error);
+    }
+  }, pollingIntervalMs);
+
+  return {
+    async unsubscribe(): Promise<void> {
+      isActive = false;
+      clearInterval(pollInterval);
+    },
+    isActive(): boolean {
+      return isActive;
+    },
+  };
+}
+
+/**
+ * Subscribes to contract events via GraphQL subscriptions from the indexer.
+ *
+ * This method uses the indexer's GraphQL subscriptions for real-time event streaming.
+ * Note: Event topic filtering via the indexer is implementation-dependent and may
+ * require server-side support.
+ *
+ * @param options - Configuration for GraphQL subscriptions
+ * @param callback - Callback invoked for each matching event
+ * @returns EventSubscription handle for unsubscribing
+ *
+ * @example
+ * ```ts
+ * import { subscribeToGraphQLEvents, EventTopics, EventCategories } from '@trustlink/contract';
+ *
+ * const unsub = await subscribeToGraphQLEvents(
+ *   {
+ *     graphqlUrl: 'wss://indexer.trustlink.io/graphql',
+ *     topics: EventCategories.ATTESTATION_LIFECYCLE,
+ *     subject: 'GBBD...',
+ *   },
+ *   (event) => console.log('Event:', event)
+ * );
+ * ```
+ */
+export async function subscribeToGraphQLEvents(
+  options: GraphQLSubscriptionOptions,
+  callback: EventCallback
+): Promise<EventSubscription> {
+  const {
+    graphqlUrl = process.env.VITE_INDEXER_WS_URL || "ws://localhost:4000/graphql",
+    topics: rawTopics,
+    subject,
+    issuer,
+    headers = {},
+    reconnectAttempts = 5,
+    reconnectDelayMs = 1000,
+  } = options;
+
+  // Validate topics if provided
+  const topics = rawTopics ? validateEventTopics(rawTopics) : null;
+
+  let isActive = true;
+  let ws: WebSocket | null = null;
+  let reconnectCount = 0;
+
+  const connect = (): Promise<void> => {
+    return new Promise((resolve, reject) => {
+      try {
+        ws = new WebSocket(graphqlUrl, "graphql-transport-ws");
+
+        ws.onopen = () => {
+          reconnectCount = 0;
+          ws!.send(JSON.stringify({ type: "connection_init", payload: {} }));
+          resolve();
+        };
+
+        ws.onmessage = async (event: MessageEvent) => {
+          if (!isActive) return;
+
+          let message: GraphQLSubscriptionMessage;
+          try {
+            message = JSON.parse(event.data as string);
+          } catch {
+            return;
+          }
+
+          if (message.type === "connection_ack") {
+            // Subscribe to relevant subscriptions based on topic filters
+            subscribeToRelevantTopics();
+          } else if (message.type === "next" && message.payload?.data) {
+            const payload = message.payload.data;
+
+            // Handle attestation events
+            if ("onAttestationCreated" in payload) {
+              const data = payload.onAttestationCreated as Record<string, unknown>;
+              if (
+                !topics ||
+                topics.length === 0 ||
+                topics.includes("created" as EventTopic)
+              ) {
+                if (!subject || data.subject === subject) {
+                  const mappedEvent: ContractEvent = {
+                    topic: "created" as EventTopic,
+                    ledger: 0,
+                    txHash: "",
+                    data,
+                    timestamp: new Date(),
+                    raw: {
+                      id: data.id as string,
+                      type: "contract",
+                      ledger: 0,
+                      txHash: "",
+                      topics: ["created"],
+                      data,
+                      timestamp: new Date(),
+                    },
+                  };
+                  await callback(mappedEvent);
+                }
+              }
+            }
+
+            if ("onAttestationRevoked" in payload) {
+              const data = payload.onAttestationRevoked as Record<string, unknown>;
+              if (
+                !topics ||
+                topics.length === 0 ||
+                topics.includes("revoked" as EventTopic)
+              ) {
+                if (!issuer || data.issuer === issuer) {
+                  const mappedEvent: ContractEvent = {
+                    topic: "revoked" as EventTopic,
+                    ledger: 0,
+                    txHash: "",
+                    data,
+                    timestamp: new Date(),
+                    raw: {
+                      id: data.id as string,
+                      type: "contract",
+                      ledger: 0,
+                      txHash: "",
+                      topics: ["revoked"],
+                      data,
+                      timestamp: new Date(),
+                    },
+                  };
+                  await callback(mappedEvent);
+                }
+              }
+            }
+
+            if ("onIssuerRegistered" in payload) {
+              const data = payload.onIssuerRegistered as Record<string, unknown>;
+              if (
+                !topics ||
+                topics.length === 0 ||
+                topics.includes("iss_reg" as EventTopic)
+              ) {
+                const mappedEvent: ContractEvent = {
+                  topic: "iss_reg" as EventTopic,
+                  ledger: 0,
+                  txHash: "",
+                  data,
+                  timestamp: new Date(),
+                  raw: {
+                    id: JSON.stringify(data),
+                    type: "contract",
+                    ledger: 0,
+                    txHash: "",
+                    topics: ["iss_reg"],
+                    data,
+                    timestamp: new Date(),
+                  },
+                };
+                await callback(mappedEvent);
+              }
+            }
+          }
+        };
+
+        ws.onerror = (error: Event) => {
+          if (isActive && reconnectCount < reconnectAttempts) {
+            reconnectCount++;
+            setTimeout(() => {
+              connect().catch(console.error);
+            }, reconnectDelayMs * Math.pow(2, reconnectCount - 1));
+          } else {
+            reject(new Error(`WebSocket error: ${error}`));
+          }
+        };
+
+        ws.onclose = () => {
+          if (isActive && reconnectCount < reconnectAttempts) {
+            reconnectCount++;
+            setTimeout(() => {
+              connect().catch(console.error);
+            }, reconnectDelayMs * Math.pow(2, reconnectCount - 1));
+          }
+        };
+      } catch (error) {
+        reject(error);
+      }
+    });
+  };
+
+  const subscribeToRelevantTopics = () => {
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+
+    // Subscribe to attestation created if relevant
+    if (!topics || topics.length === 0 || topics.includes("created" as EventTopic)) {
+      const subId = "sub_created_" + Date.now();
+      const query = subject
+        ? `subscription { onAttestationCreated(subject: "${subject}") { id subject issuer claimType } }`
+        : `subscription { onAttestationCreated { id subject issuer claimType } }`;
+
+      ws.send(
+        JSON.stringify({
+          id: subId,
+          type: "subscribe",
+          payload: { query },
+        })
+      );
+    }
+
+    // Subscribe to attestation revoked if relevant
+    if (!topics || topics.length === 0 || topics.includes("revoked" as EventTopic)) {
+      const subId = "sub_revoked_" + Date.now();
+      const query = issuer
+        ? `subscription { onAttestationRevoked(issuer: "${issuer}") { id issuer revokedAt } }`
+        : `subscription { onAttestationRevoked { id issuer revokedAt } }`;
+
+      ws.send(
+        JSON.stringify({
+          id: subId,
+          type: "subscribe",
+          payload: { query },
+        })
+      );
+    }
+
+    // Subscribe to issuer registered if relevant
+    if (!topics || topics.length === 0 || topics.includes("iss_reg" as EventTopic)) {
+      const subId = "sub_iss_reg_" + Date.now();
+      ws.send(
+        JSON.stringify({
+          id: subId,
+          type: "subscribe",
+          payload: { query: "subscription { onIssuerRegistered { issuer registeredAt } }" },
+        })
+      );
+    }
+  };
+
+  // Establish initial connection
+  await connect();
+
+  return {
+    async unsubscribe(): Promise<void> {
+      isActive = false;
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.close();
+      }
+    },
+    isActive(): boolean {
+      return isActive;
+    },
+  };
+}
+
+/**
+ * Maps a raw Soroban event to a normalized ContractEvent.
+ * This is internal and used by subscribeToDirectLedgerEvents.
+ */
+function mapRawEvent(rawEvent: any): ContractEvent | null {
+  try {
+    const topic = rawEvent.topics?.[0];
+    if (!topic) return null;
+
+    return {
+      topic: topic as EventTopic,
+      ledger: rawEvent.ledger || 0,
+      txHash: rawEvent.txHash || "",
+      data: rawEvent.value || {},
+      timestamp: new Date(),
+      raw: {
+        id: rawEvent.id || "",
+        type: rawEvent.type || "contract",
+        ledger: rawEvent.ledger || 0,
+        txHash: rawEvent.txHash || "",
+        topics: rawEvent.topics || [],
+        data: rawEvent.value || {},
+        timestamp: new Date(),
+      },
+    };
+  } catch {
+    return null;
+  }
+}

--- a/bindings/typescript/src/events.ts
+++ b/bindings/typescript/src/events.ts
@@ -1,0 +1,303 @@
+/**
+ * TrustLink Event Topics and Event Subscription Utilities
+ *
+ * Provides canonical event topic definitions, type-safe event subscriptions,
+ * and helpers for filtering contract events via the indexer or direct ledger watching.
+ */
+
+/**
+ * Canonical event topic constants matching TrustLink contract.
+ * All topics are ≤9 characters as required by Soroban symbol_short!().
+ */
+export const EventTopics = {
+  // ─── Attestation Lifecycle ────────────────────────────────────────────────────
+  CREATED: "created",
+  IMPORTED: "imported",
+  BRIDGED: "bridged",
+  REVOKED: "revoked",
+  RENEWED: "renewed",
+  UPDATED: "updated",
+  EXPIRED: "expired",
+  ENDORSED: "endorsed",
+  AMENDED: "amended",
+  DEL_REQ: "del_req",
+  XFER: "xfer",
+  ATT_XFER: "att_xfer",
+
+  // ─── Issuer Lifecycle ──────────────────────────────────────────────────────────
+  ISS_REG: "iss_reg",
+  ISS_TIER: "iss_tier",
+  ISS_REM: "iss_rem",
+
+  // ─── Admin & Governance ────────────────────────────────────────────────────────
+  ADM_INIT: "adm_init",
+  ADM_XFER: "adm_xfer",
+  ADM_ADD: "adm_add",
+  ADM_REM: "adm_rem",
+  ADM_PROP: "adm_prop",
+
+  // ─── Compliance & Requests ────────────────────────────────────────────────────
+  CLM_TYPE: "clm_type",
+  ATT_REQ: "att_req",
+  REQ_OK: "req_ok",
+  REQ_NO: "req_no",
+  REQ_CNCL: "req_cncl",
+  DEL_CRTD: "del_crtd",
+  DEL_RVKD: "del_rvkd",
+  WL_ON: "wl_on",
+  WL_ADD: "wl_add",
+  WL_REM: "wl_rem",
+
+  // ─── Multi-Sig & Proposals ────────────────────────────────────────────────────
+  MS_PROP: "ms_prop",
+  MS_SIGN: "ms_sign",
+  MS_ACTV: "ms_actv",
+  MS_CANCEL: "ms_cancel",
+
+  // ─── Dispute & Amendment ──────────────────────────────────────────────────────
+  DISPUTED: "disputed",
+  DSP_RES: "dsp_res",
+
+  // ─── Pause & Lifecycle ────────────────────────────────────────────────────────
+  PAUSED: "paused",
+  UNPAUSED: "unpaused",
+
+  // ─── Templates ────────────────────────────────────────────────────────────────
+  TMPL_CRT: "tmpl_crt",
+  TPL_DEL: "tpl_del",
+
+  // ─── Council Governance ───────────────────────────────────────────────────────
+  CNCL_INI: "cncl_ini",
+  PROP_NEW: "prop_new",
+  PROP_OK: "prop_ok",
+  PROP_EXE: "prop_exe",
+  TL_START: "tl_start",
+  EXP_HOOK: "exp_hook",
+} as const;
+
+/** Union type of all valid event topics */
+export type EventTopic = (typeof EventTopics)[keyof typeof EventTopics];
+
+/**
+ * Event topic categories for convenient subscription grouping.
+ * Use these to subscribe to related events by category.
+ */
+export const EventCategories = {
+  /** Attestation lifecycle: created, imported, bridged, revoked, renewed, updated, expired, endorsed, amended, xfer */
+  ATTESTATION_LIFECYCLE: [
+    EventTopics.CREATED,
+    EventTopics.IMPORTED,
+    EventTopics.BRIDGED,
+    EventTopics.REVOKED,
+    EventTopics.RENEWED,
+    EventTopics.UPDATED,
+    EventTopics.EXPIRED,
+    EventTopics.ENDORSED,
+    EventTopics.AMENDED,
+    EventTopics.XFER,
+  ] as const,
+
+  /** Issuer compliance: iss_reg, iss_tier, iss_rem, wl_on, wl_add, wl_rem, del_crtd, del_rvkd */
+  ISSUER_COMPLIANCE: [
+    EventTopics.ISS_REG,
+    EventTopics.ISS_TIER,
+    EventTopics.ISS_REM,
+    EventTopics.WL_ON,
+    EventTopics.WL_ADD,
+    EventTopics.WL_REM,
+    EventTopics.DEL_CRTD,
+    EventTopics.DEL_RVKD,
+  ] as const,
+
+  /** Request processing: att_req, req_ok, req_no, req_cncl */
+  REQUEST_LIFECYCLE: [
+    EventTopics.ATT_REQ,
+    EventTopics.REQ_OK,
+    EventTopics.REQ_NO,
+    EventTopics.REQ_CNCL,
+  ] as const,
+
+  /** Multi-sig operations: ms_prop, ms_sign, ms_actv, ms_cancel */
+  MULTISIG: [
+    EventTopics.MS_PROP,
+    EventTopics.MS_SIGN,
+    EventTopics.MS_ACTV,
+    EventTopics.MS_CANCEL,
+  ] as const,
+
+  /** Disputes and amendments: disputed, dsp_res, amended */
+  DISPUTE_AMENDMENT: [EventTopics.DISPUTED, EventTopics.DSP_RES, EventTopics.AMENDED] as const,
+
+  /** Administrative actions: adm_init, adm_xfer, adm_add, adm_rem, adm_prop, paused, unpaused */
+  ADMIN_ACTIONS: [
+    EventTopics.ADM_INIT,
+    EventTopics.ADM_XFER,
+    EventTopics.ADM_ADD,
+    EventTopics.ADM_REM,
+    EventTopics.ADM_PROP,
+    EventTopics.PAUSED,
+    EventTopics.UNPAUSED,
+  ] as const,
+
+  /** Council governance: cncl_ini, prop_new, prop_ok, prop_exe, tl_start */
+  COUNCIL_GOVERNANCE: [
+    EventTopics.CNCL_INI,
+    EventTopics.PROP_NEW,
+    EventTopics.PROP_OK,
+    EventTopics.PROP_EXE,
+    EventTopics.TL_START,
+  ] as const,
+
+  /** Indexed events (real-time in indexer): created, revoked, imported, bridged, ms_prop, ms_sign, ms_actv, iss_reg */
+  INDEXED_PRIORITY: [
+    EventTopics.CREATED,
+    EventTopics.REVOKED,
+    EventTopics.IMPORTED,
+    EventTopics.BRIDGED,
+    EventTopics.MS_PROP,
+    EventTopics.MS_SIGN,
+    EventTopics.MS_ACTV,
+    EventTopics.ISS_REG,
+  ] as const,
+
+  /** All topics */
+  ALL: Object.values(EventTopics),
+} as const;
+
+/**
+ * Options for event subscriptions.
+ * Allows filtering by topic and entity identifiers.
+ */
+export interface EventSubscriptionOptions {
+  /** Event topics to subscribe to. If empty, subscribes to all topics. */
+  topics?: EventTopic[];
+
+  /** Filter by subject address (for events with subject as indexed topic) */
+  subject?: string;
+
+  /** Filter by issuer address (for events with issuer as indexed topic) */
+  issuer?: string;
+
+  /** Polling interval in milliseconds for direct ledger watching (default: 5000) */
+  pollingIntervalMs?: number;
+
+  /** Maximum number of events to fetch per poll (default: 100) */
+  pageSize?: number;
+
+  /** Starting ledger for direct ledger watching (optional) */
+  startLedger?: number;
+}
+
+/**
+ * Validates that all provided topics are valid event topics.
+ *
+ * @param topics - Array of topics to validate
+ * @throws Error if any topic is invalid
+ * @returns The validated topics array
+ */
+export function validateEventTopics(topics: unknown[]): EventTopic[] {
+  const validTopics = new Set(Object.values(EventTopics));
+
+  for (const topic of topics) {
+    if (typeof topic !== "string" || !validTopics.has(topic as EventTopic)) {
+      throw new Error(`Invalid event topic: "${topic}". See EventTopics for valid values.`);
+    }
+  }
+
+  return topics as EventTopic[];
+}
+
+/**
+ * Normalizes event topic constants to their string representation.
+ * Useful for working with raw ledger event data where topics are strings.
+ *
+ * @param raw - Raw topic string from ledger event
+ * @returns Normalized topic, or null if not recognized
+ */
+export function normalizeEventTopic(raw: string): EventTopic | null {
+  const normalized = raw.toLowerCase().trim();
+  const validTopics = Object.values(EventTopics);
+  return validTopics.includes(normalized as EventTopic) ? (normalized as EventTopic) : null;
+}
+
+/**
+ * Returns all topics in a given category.
+ *
+ * @param category - The category key from EventCategories
+ * @returns Array of event topics in that category
+ */
+export function getTopicsInCategory(category: keyof typeof EventCategories): EventTopic[] {
+  const topics = EventCategories[category];
+  return Array.isArray(topics) ? (topics as EventTopic[]) : [topics as EventTopic];
+}
+
+/**
+ * Returns a human-readable description of an event topic.
+ * Useful for logging, debugging, and UI display.
+ *
+ * @param topic - The event topic
+ * @returns Description of what this topic represents
+ */
+export function getTopicDescription(topic: EventTopic): string {
+  const descriptions: Record<EventTopic, string> = {
+    [EventTopics.CREATED]: "Attestation created",
+    [EventTopics.IMPORTED]: "Attestation imported from external source",
+    [EventTopics.BRIDGED]: "Attestation bridged from another blockchain",
+    [EventTopics.REVOKED]: "Attestation revoked by issuer",
+    [EventTopics.RENEWED]: "Attestation expiration renewed",
+    [EventTopics.UPDATED]: "Attestation updated",
+    [EventTopics.EXPIRED]: "Attestation expired",
+    [EventTopics.ENDORSED]: "Attestation endorsed",
+    [EventTopics.AMENDED]: "Attestation metadata amended",
+    [EventTopics.DEL_REQ]: "Deletion requested",
+    [EventTopics.XFER]: "Attestation issuer transferred",
+    [EventTopics.ATT_XFER]: "Attestation transferred",
+    [EventTopics.ISS_REG]: "Issuer registered",
+    [EventTopics.ISS_TIER]: "Issuer tier updated",
+    [EventTopics.ISS_REM]: "Issuer removed",
+    [EventTopics.ADM_INIT]: "Admin initialized",
+    [EventTopics.ADM_XFER]: "Admin transferred",
+    [EventTopics.ADM_ADD]: "Admin added",
+    [EventTopics.ADM_REM]: "Admin removed",
+    [EventTopics.ADM_PROP]: "Admin transfer proposed",
+    [EventTopics.CLM_TYPE]: "Claim type registered",
+    [EventTopics.ATT_REQ]: "Attestation requested",
+    [EventTopics.REQ_OK]: "Request fulfilled",
+    [EventTopics.REQ_NO]: "Request rejected",
+    [EventTopics.REQ_CNCL]: "Request cancelled",
+    [EventTopics.DEL_CRTD]: "Delegation created",
+    [EventTopics.DEL_RVKD]: "Delegation revoked",
+    [EventTopics.WL_ON]: "Whitelist mode enabled",
+    [EventTopics.WL_ADD]: "Subject added to whitelist",
+    [EventTopics.WL_REM]: "Subject removed from whitelist",
+    [EventTopics.MS_PROP]: "Multi-sig proposal created",
+    [EventTopics.MS_SIGN]: "Multi-sig proposal cosigned",
+    [EventTopics.MS_ACTV]: "Multi-sig proposal activated",
+    [EventTopics.MS_CANCEL]: "Multi-sig proposal cancelled",
+    [EventTopics.DISPUTED]: "Dispute raised",
+    [EventTopics.DSP_RES]: "Dispute resolved",
+    [EventTopics.PAUSED]: "Contract paused",
+    [EventTopics.UNPAUSED]: "Contract unpaused",
+    [EventTopics.TMPL_CRT]: "Template created",
+    [EventTopics.TPL_DEL]: "Template deleted",
+    [EventTopics.CNCL_INI]: "Council initialized",
+    [EventTopics.PROP_NEW]: "Council proposal created",
+    [EventTopics.PROP_OK]: "Council proposal approved",
+    [EventTopics.PROP_EXE]: "Council proposal executed",
+    [EventTopics.TL_START]: "Timelock started",
+    [EventTopics.EXP_HOOK]: "Expiration hook triggered",
+  };
+
+  return descriptions[topic] || "Unknown event";
+}
+
+/**
+ * Type guard for event topics - narrows type from string to EventTopic.
+ *
+ * @param value - Value to check
+ * @returns True if value is a valid EventTopic
+ */
+export function isEventTopic(value: unknown): value is EventTopic {
+  if (typeof value !== "string") return false;
+  return Object.values(EventTopics).includes(value as EventTopic);
+}

--- a/bindings/typescript/src/index.ts
+++ b/bindings/typescript/src/index.ts
@@ -21,3 +21,5 @@
 export * from "./types";
 export * from "./client";
 export * from "./validation";
+export * from "./events";
+export * from "./eventSubscriptions";

--- a/docs/EVENT_TOPICS.md
+++ b/docs/EVENT_TOPICS.md
@@ -1,0 +1,537 @@
+# TrustLink Event Topics Reference
+
+This document defines the canonical event topic taxonomy used throughout TrustLink. All event topics are emitted by the smart contract and can be subscribed to via the indexer's GraphQL subscriptions or direct ledger event watching through the SDK.
+
+## Event Topic Structure
+
+Each event topic is a short symbol (≤9 characters) emitted as the first element of the contract event tuple. Event topics are organized into five primary categories:
+
+1. **Attestation Lifecycle** — creation, revocation, renewal, expiration, and status changes
+2. **Issuer Lifecycle** — registration, tier updates, removal
+3. **Admin & Governance** — initialization, transfers, additions, removals, council actions
+4. **Compliance & Requests** — attestation requests, claim type registration, delegation, whitelist management
+5. **Multi-Sig & Proposals** — proposal creation, signing, activation
+6. **Dispute & Amendment** — dispute lifecycle, attestation metadata changes
+
+---
+
+## Attestation Lifecycle Events
+
+### `created`
+Emitted when a new attestation is created.
+
+- **Topic:** `created`
+- **Indexed:** Yes (primary events watched by indexer)
+- **Topics in Event:** `(created, subject)`
+- **Data:** `(attestation_id, issuer, claim_type, timestamp, metadata)`
+- **Subject Filter:** Yes
+
+### `imported`
+Emitted when an attestation is imported from an external source.
+
+- **Topic:** `imported`
+- **Indexed:** Yes
+- **Topics in Event:** `(imported, subject)`
+- **Data:** `(attestation_id, issuer, claim_type, timestamp, expiration)`
+- **Subject Filter:** Yes
+
+### `bridged`
+Emitted when an attestation is bridged from another blockchain.
+
+- **Topic:** `bridged`
+- **Indexed:** Yes
+- **Topics in Event:** `(bridged, subject)`
+- **Data:** `(attestation_id, issuer, claim_type, source_chain, source_tx)`
+- **Subject Filter:** Yes
+
+### `revoked`
+Emitted when an attestation is revoked by its issuer.
+
+- **Topic:** `revoked`
+- **Indexed:** Yes
+- **Topics in Event:** `(revoked, issuer)`
+- **Data:** `(attestation_id, reason?)`
+- **Issuer Filter:** Yes
+
+### `renewed`
+Emitted when an attestation's expiration is extended.
+
+- **Topic:** `renewed`
+- **Indexed:** Yes
+- **Topics in Event:** `(renewed, issuer)`
+- **Data:** `(attestation_id, new_expiration?)`
+
+### `updated`
+Emitted when an attestation's expiration or status is updated.
+
+- **Topic:** `updated`
+- **Indexed:** Yes
+- **Topics in Event:** `(updated, issuer)`
+- **Data:** `(attestation_id, new_expiration?)`
+
+### `expired`
+Emitted when an attestation reaches its expiration time.
+
+- **Topic:** `expired`
+- **Indexed:** No (informational)
+- **Topics in Event:** `(expired, subject)`
+- **Data:** `(attestation_id)`
+
+### `endorsed`
+Emitted when a registered issuer endorses an existing attestation.
+
+- **Topic:** `endorsed`
+- **Indexed:** No
+- **Topics in Event:** `(endorsed, endorser)`
+- **Data:** `(attestation_id, timestamp)`
+
+### `amended`
+Emitted when an issuer amends the metadata of an existing attestation.
+
+- **Topic:** `amended`
+- **Indexed:** No
+- **Topics in Event:** `(amended, issuer)`
+- **Data:** `(attestation_id, timestamp)`
+
+### `del_req`
+Emitted when a subject requests deletion of an attestation.
+
+- **Topic:** `del_req`
+- **Indexed:** No
+- **Topics in Event:** `(del_req, subject)`
+- **Data:** `(attestation_id, timestamp)`
+
+### `xfer`
+Emitted when an attestation's issuer is changed by the admin.
+
+- **Topic:** `xfer`
+- **Indexed:** No
+- **Topics in Event:** `(xfer, old_issuer)`
+- **Data:** `(attestation_id, new_issuer)`
+
+### `att_xfer`
+Alternate transfer topic (see `xfer` for details).
+
+- **Topic:** `att_xfer`
+- **Indexed:** No
+
+---
+
+## Issuer Lifecycle Events
+
+### `iss_reg`
+Emitted when an issuer is registered.
+
+- **Topic:** `iss_reg`
+- **Indexed:** Yes
+- **Topics in Event:** `(iss_reg, issuer)`
+- **Data:** `(admin, timestamp)`
+
+### `iss_tier`
+Emitted when an issuer's tier is updated.
+
+- **Topic:** `iss_tier`
+- **Indexed:** No
+- **Topics in Event:** `(iss_tier, issuer)`
+- **Data:** `(tier)` — contains tier level and limits
+
+### `iss_rem`
+Emitted when an issuer is removed.
+
+- **Topic:** `iss_rem`
+- **Indexed:** No
+- **Topics in Event:** `(iss_rem, issuer)`
+- **Data:** `(admin, timestamp)`
+
+---
+
+## Admin & Governance Events
+
+### `adm_init`
+Emitted when the contract is initialized with an admin.
+
+- **Topic:** `adm_init`
+- **Indexed:** No
+- **Topics in Event:** `(adm_init,)`
+- **Data:** `(admin, timestamp)`
+
+### `adm_xfer`
+Emitted when admin authority is transferred.
+
+- **Topic:** `adm_xfer`
+- **Indexed:** No
+- **Topics in Event:** `(adm_xfer,)`
+- **Data:** `(old_admin, new_admin)`
+
+### `adm_add`
+Emitted when an additional admin is added.
+
+- **Topic:** `adm_add`
+- **Indexed:** No
+- **Topics in Event:** `(adm_add, by_admin)`
+- **Data:** `(new_admin, timestamp)`
+
+### `adm_rem`
+Emitted when an admin is removed.
+
+- **Topic:** `adm_rem`
+- **Indexed:** No
+- **Topics in Event:** `(adm_rem, by_admin)`
+- **Data:** `(removed_admin, timestamp)`
+
+### `adm_prop`
+Emitted when a proposer initiates an admin transfer proposal.
+
+- **Topic:** `adm_prop`
+- **Indexed:** No
+- **Topics in Event:** `(adm_prop, current_admin)`
+- **Data:** `(new_admin)`
+
+---
+
+## Compliance & Requests
+
+### `clm_type` / `clm_type`
+Emitted when a claim type is registered.
+
+- **Topic:** `clm_type`
+- **Indexed:** No
+- **Topics in Event:** `(clm_type, claim_type)`
+- **Data:** `(description)`
+
+### `att_req`
+Emitted when a subject submits an attestation request to an issuer.
+
+- **Topic:** `att_req`
+- **Indexed:** No
+- **Topics in Event:** `(att_req, issuer)`
+- **Data:** `(request_id, subject, claim_type, expires_at)`
+
+### `req_ok`
+Emitted when an attestation request is fulfilled.
+
+- **Topic:** `req_ok`
+- **Indexed:** No
+- **Topics in Event:** `(req_ok, issuer)`
+- **Data:** `(request_id, attestation_id)`
+
+### `req_no`
+Emitted when an attestation request is rejected.
+
+- **Topic:** `req_no`
+- **Indexed:** No
+- **Topics in Event:** `(req_no, issuer)`
+- **Data:** `(request_id, reason?)`
+
+### `req_cncl`
+Emitted when a subject cancels their own pending attestation request.
+
+- **Topic:** `req_cncl`
+- **Indexed:** No
+- **Topics in Event:** `(req_cncl, subject)`
+- **Data:** `(request_id)`
+
+### `del_crtd`
+Emitted when an issuer creates a delegation to a sub-issuer for a claim type.
+
+- **Topic:** `del_crtd`
+- **Indexed:** No
+- **Topics in Event:** `(del_crtd, delegator)`
+- **Data:** `(delegate, claim_type, expiration?)`
+
+### `del_rvkd`
+Emitted when a delegation is revoked.
+
+- **Topic:** `del_rvkd`
+- **Indexed:** No
+- **Topics in Event:** `(del_rvkd, delegator)`
+- **Data:** `(delegate, claim_type)`
+
+### `wl_on`
+Emitted when whitelist mode is enabled for an issuer.
+
+- **Topic:** `wl_on`
+- **Indexed:** No
+- **Topics in Event:** `(wl_on, issuer)`
+- **Data:** `()`
+
+### `wl_add`
+Emitted when a subject is added to an issuer's whitelist.
+
+- **Topic:** `wl_add`
+- **Indexed:** No
+- **Topics in Event:** `(wl_add, issuer)`
+- **Data:** `(subject)`
+
+### `wl_rem`
+Emitted when a subject is removed from an issuer's whitelist.
+
+- **Topic:** `wl_rem`
+- **Indexed:** No
+- **Topics in Event:** `(wl_rem, issuer)`
+- **Data:** `(subject)`
+
+---
+
+## Multi-Sig & Proposals
+
+### `ms_prop`
+Emitted when a multi-sig proposal is created.
+
+- **Topic:** `ms_prop`
+- **Indexed:** Yes
+- **Topics in Event:** `(ms_prop, subject)`
+- **Data:** `(proposal_id, proposer, threshold)`
+
+### `ms_sign`
+Emitted when a multi-sig proposal is cosigned.
+
+- **Topic:** `ms_sign`
+- **Indexed:** Yes
+- **Topics in Event:** `(ms_sign, signer)`
+- **Data:** `(proposal_id, signatures_so_far, threshold)`
+
+### `ms_actv`
+Emitted when a multi-sig proposal is activated (executed).
+
+- **Topic:** `ms_actv`
+- **Indexed:** Yes
+- **Topics in Event:** `(ms_actv,)`
+- **Data:** `(proposal_id, attestation_id)`
+
+### `ms_cancel`
+Emitted when a proposer cancels a multi-sig proposal.
+
+- **Topic:** `ms_cancel`
+- **Indexed:** No
+- **Topics in Event:** `(ms_cancel, proposer)`
+- **Data:** `(proposal_id)`
+
+---
+
+## Dispute & Amendment
+
+### `disputed`
+Emitted when a subject raises a dispute against an attestation.
+
+- **Topic:** `disputed`
+- **Indexed:** No
+- **Topics in Event:** `(disputed, subject)`
+- **Data:** `(attestation_id, reason, timestamp)`
+
+### `dsp_res`
+Emitted when a dispute is resolved.
+
+- **Topic:** `dsp_res`
+- **Indexed:** No
+- **Topics in Event:** `(dsp_res, resolver)`
+- **Data:** `(attestation_id, timestamp)`
+
+---
+
+## Pause & Lifecycle
+
+### `paused`
+Emitted when the contract is paused.
+
+- **Topic:** `paused`
+- **Indexed:** No
+- **Topics in Event:** `(paused,)`
+- **Data:** `(admin, timestamp)`
+
+### `unpaused`
+Emitted when the contract is unpaused.
+
+- **Topic:** `unpaused`
+- **Indexed:** No
+- **Topics in Event:** `(unpaused,)`
+- **Data:** `(admin, timestamp)`
+
+---
+
+## Templates
+
+### `tmpl_crt`
+Emitted when an issuer creates or overwrites a template.
+
+- **Topic:** `tmpl_crt`
+- **Indexed:** No
+- **Topics in Event:** `(tmpl_crt, issuer)`
+- **Data:** `(template_id)`
+
+### `tpl_del`
+Emitted when an issuer deletes an attestation template.
+
+- **Topic:** `tpl_del`
+- **Indexed:** No
+- **Topics in Event:** `(tpl_del, issuer)`
+- **Data:** `(template_id)`
+
+---
+
+## Council Governance
+
+### `cncl_ini`
+Emitted when the council is initialized.
+
+- **Topic:** `cncl_ini`
+- **Indexed:** No
+- **Topics in Event:** `(cncl_ini,)`
+- **Data:** `(quorum, member_count)`
+
+### `prop_new`
+Emitted when a council proposal is created.
+
+- **Topic:** `prop_new`
+- **Indexed:** No
+- **Topics in Event:** `(prop_new, proposer)`
+- **Data:** `(proposal_id)`
+
+### `prop_ok`
+Emitted when a council proposal is approved.
+
+- **Topic:** `prop_ok`
+- **Indexed:** No
+- **Topics in Event:** `(prop_ok, approver)`
+- **Data:** `(proposal_id)`
+
+### `prop_exe`
+Emitted when a council proposal is executed.
+
+- **Topic:** `prop_exe`
+- **Indexed:** No
+- **Topics in Event:** `(prop_exe,)`
+- **Data:** `(proposal_id)`
+
+### `tl_start`
+Emitted when a council proposal reaches quorum, starting the timelock clock.
+
+- **Topic:** `tl_start`
+- **Indexed:** No
+- **Topics in Event:** `(tl_start,)`
+- **Data:** `(proposal_id, quorum_reached_at)`
+
+### `exp_hook`
+Emitted when an expiration hook is triggered.
+
+- **Topic:** `exp_hook`
+- **Indexed:** No
+- **Topics in Event:** `(exp_hook, subject)`
+- **Data:** `(attestation_id, expiration)`
+
+---
+
+## Using Event Topics with SDKs
+
+### TypeScript SDK
+
+```typescript
+import { TrustLinkClient, EventTopics } from '@trustlink/sdk-typescript';
+
+const client = new TrustLinkClient({
+  contractId: 'C...',
+  rpcUrl: 'https://soroban-testnet.stellar.org',
+});
+
+// Subscribe to specific event topics
+const unsubscribe = await client.subscribeToEvents(
+  {
+    topics: [
+      EventTopics.CREATED,
+      EventTopics.REVOKED,
+      EventTopics.ISS_REG,
+    ],
+  },
+  (event) => {
+    console.log('Event:', event);
+  }
+);
+```
+
+### Python SDK
+
+```python
+from trustlink import TrustLinkClient, EventTopics
+
+client = TrustLinkClient(
+    contract_id='C...',
+    rpc_url='https://soroban-testnet.stellar.org',
+)
+
+# Subscribe to specific event topics
+client.subscribe_to_events(
+    topics=[
+        EventTopics.CREATED,
+        EventTopics.REVOKED,
+        EventTopics.ISS_REG,
+    ],
+    on_event=lambda event: print('Event:', event),
+)
+```
+
+### GraphQL Subscriptions
+
+```graphql
+subscription {
+  onAttestationCreated(topics: ["created", "imported", "bridged"]) {
+    id
+    subject
+    issuer
+    claimType
+  }
+}
+```
+
+---
+
+## Topic Grouping by Use Case
+
+### For Attestation Lifecycle Monitoring
+`created`, `imported`, `bridged`, `revoked`, `renewed`, `updated`, `expired`, `endorsed`, `amended`, `xfer`
+
+### For Issuer Compliance
+`iss_reg`, `iss_tier`, `iss_rem`, `wl_on`, `wl_add`, `wl_rem`, `del_crtd`, `del_rvkd`
+
+### For Request Processing
+`att_req`, `req_ok`, `req_no`, `req_cncl`
+
+### For Multi-Sig Operations
+`ms_prop`, `ms_sign`, `ms_actv`, `ms_cancel`
+
+### For Disputes & Amendments
+`disputed`, `dsp_res`, `amended`
+
+### For Administrative Actions
+`adm_init`, `adm_xfer`, `adm_add`, `adm_rem`, `adm_prop`, `paused`, `unpaused`
+
+### For Council Governance
+`cncl_ini`, `prop_new`, `prop_ok`, `prop_exe`, `tl_start`
+
+---
+
+## Indexer Event Processing
+
+The indexer currently prioritizes the following topics for real-time indexing:
+
+- `created`
+- `revoked`
+- `imported`
+- `bridged`
+- `ms_prop`
+- `ms_sign`
+- `ms_actv`
+- `iss_reg`
+- `rate_limit_set`
+
+Other events are logged but may not be immediately queryable via GraphQL subscriptions. Use direct ledger event watching via the SDK for comprehensive event monitoring.
+
+---
+
+## Best Practices
+
+1. **Always specify topic filters** when subscribing to reduce bandwidth and client-side processing.
+2. **Use topic categories** for related workflows (e.g., subscribe to all attestation lifecycle events together).
+3. **Combine with entity filters** (subject, issuer, etc.) when available for fine-grained control.
+4. **Monitor indexed topics** for real-time updates; use direct ledger watching for comprehensive history.
+5. **Handle duplicate events** — the same event may appear from both indexer and direct ledger watching.
+

--- a/examples/event-filtering/README.md
+++ b/examples/event-filtering/README.md
@@ -1,0 +1,289 @@
+# TrustLink Event Filtering Examples
+
+This directory contains examples demonstrating how to use TrustLink's event subscription features with topic filtering. Both TypeScript and Python examples are provided.
+
+## Overview
+
+TrustLink now supports unified event topic filtering across all SDKs and the indexer. Instead of subscribing to all events and filtering client-side, consumers can now specify which event topics they care about and receive only those events.
+
+## Key Features
+
+- **Topic Allowlists**: Subscribe to specific event topics instead of all events
+- **Event Categories**: Pre-defined topic groupings for common use cases
+- **Multiple Subscription Modes**: 
+  - GraphQL subscriptions via the indexer for real-time updates
+  - Direct ledger watching via Soroban RPC for comprehensive event coverage
+- **Flexible Filtering**: Combine topic filters with entity filters (subject, issuer)
+
+## Available Event Topics
+
+See [docs/EVENT_TOPICS.md](../../docs/EVENT_TOPICS.md) for the complete canonical event topic reference.
+
+### Common Topic Categories
+
+- **ATTESTATION_LIFECYCLE**: Attestation creation, revocation, expiration, etc.
+- **ISSUER_COMPLIANCE**: Issuer registration, tier updates, whitelist management
+- **REQUEST_LIFECYCLE**: Attestation requests, fulfillment, rejection
+- **MULTISIG**: Multi-sig proposals and signings
+- **DISPUTE_AMENDMENT**: Dispute handling and metadata amendments
+- **ADMIN_ACTIONS**: Admin initialization, transfers, and removals
+- **COUNCIL_GOVERNANCE**: Council proposals and timelock events
+
+## TypeScript Examples
+
+### Setup
+
+```bash
+npm install @trustlink/contract
+```
+
+### Running Examples
+
+```bash
+# Example 1: GraphQL subscriptions with topic filtering
+npx ts-node typescript-example.ts 1
+
+# Example 2: Direct ledger watching with categories
+npx ts-node typescript-example.ts 2
+
+# Example 3: Multi-topic subscription with filtering
+npx ts-node typescript-example.ts 3
+
+# Example 4: Comprehensive multi-category monitoring
+npx ts-node typescript-example.ts 4
+
+# Example 5: Error handling and retry logic
+npx ts-node typescript-example.ts 5
+```
+
+### Example: TypeScript GraphQL Subscription
+
+```typescript
+import { 
+  subscribeToGraphQLEvents, 
+  EventTopics, 
+  GraphQLSubscriptionOptions 
+} from "@trustlink/contract";
+
+const options: GraphQLSubscriptionOptions = {
+  graphqlUrl: "wss://indexer.trustlink.io/graphql",
+  topics: [EventTopics.CREATED, EventTopics.REVOKED],
+  subject: "GBBD5YHQVW53S3QQZVVTQ6S4RBFMU7GZGMG3MHEWJRUZRM5Y2I3R4D",
+};
+
+const subscription = await subscribeToGraphQLEvents(options, (event) => {
+  console.log(`Event: ${event.topic} at ledger ${event.ledger}`);
+});
+
+// Later: unsubscribe
+await subscription.unsubscribe();
+```
+
+### Example: TypeScript Direct Ledger Watching
+
+```typescript
+import { 
+  subscribeToDirectLedgerEvents,
+  EventCategories,
+  LedgerEventWatchOptions 
+} from "@trustlink/contract";
+
+const options: LedgerEventWatchOptions = {
+  rpcUrl: "https://soroban-testnet.stellar.org",
+  contractId: "C...",
+  networkPassphrase: "Test SDF Future Network ; October 2024",
+  topics: EventCategories.ATTESTATION_LIFECYCLE,
+  subject: "GBBD5...",
+};
+
+const subscription = await subscribeToDirectLedgerEvents(options, (event) => {
+  console.log(`Event: ${event.topic}`);
+});
+```
+
+## Python Examples
+
+### Setup
+
+```bash
+pip install trustlink
+```
+
+### Running Examples
+
+```bash
+# Example 1: GraphQL subscriptions with topic filtering
+python3 python-example.py 1
+
+# Example 2: Direct ledger watching with categories
+python3 python-example.py 2
+
+# Example 3: Multi-topic subscription with filtering
+python3 python-example.py 3
+
+# Example 4: Comprehensive multi-category monitoring
+python3 python-example.py 4
+
+# Example 5: Error handling and retry logic
+python3 python-example.py 5
+
+# Example 6: Explore available topics and categories
+python3 python-example.py 6
+```
+
+### Example: Python GraphQL Subscription
+
+```python
+import asyncio
+from trustlink import (
+    subscribe_to_graphql_events,
+    EventTopics,
+    GraphQLSubscriptionOptions,
+)
+
+async def main():
+    options = GraphQLSubscriptionOptions(
+        graphql_url="wss://indexer.trustlink.io/graphql",
+        topics=[EventTopics.CREATED, EventTopics.REVOKED],
+        subject="GBBD5YHQVW53S3QQZVVTQ6S4RBFMU7GZGMG3MHEWJRUZRM5Y2I3R4D",
+    )
+
+    async def on_event(event):
+        print(f"Event: {event.topic} at ledger {event.ledger}")
+
+    subscription = await subscribe_to_graphql_events(options, on_event)
+    
+    # Keep running until interrupted
+    try:
+        await asyncio.sleep(3600)
+    finally:
+        await subscription.unsubscribe()
+
+asyncio.run(main())
+```
+
+### Example: Python Direct Ledger Watching
+
+```python
+import asyncio
+from trustlink import (
+    subscribe_to_direct_ledger_events,
+    EventCategories,
+    LedgerEventWatchOptions,
+)
+
+async def main():
+    options = LedgerEventWatchOptions(
+        rpc_url="https://soroban-testnet.stellar.org",
+        contract_id="C...",
+        network_passphrase="Test SDF Future Network ; October 2024",
+        topics=EventCategories.ATTESTATION_LIFECYCLE,
+        subject="GBBD5...",
+    )
+
+    async def on_event(event):
+        print(f"Event: {event.topic}")
+
+    subscription = await subscribe_to_direct_ledger_events(options, on_event)
+
+asyncio.run(main())
+```
+
+## Environment Variables
+
+Set these environment variables to customize the examples:
+
+```bash
+# Indexer GraphQL WebSocket URL
+export INDEXER_WS_URL="wss://indexer.trustlink.io/graphql"
+
+# TrustLink contract ID
+export CONTRACT_ID="CDJVR36XC2HTUGDGSTHVUGMR3JTYHWQQFBOJGZAVDMJLQGZXVVGTJMZV"
+
+# Optional: Soroban RPC URL (defaults to testnet)
+export RPC_URL="https://soroban-testnet.stellar.org"
+
+# Optional: Network passphrase (defaults to testnet)
+export NETWORK_PASSPHRASE="Test SDF Future Network ; October 2024"
+```
+
+## Event Filtering Best Practices
+
+1. **Always specify topic filters** when possible to reduce bandwidth and client-side processing
+2. **Use event categories** for related workflows (e.g., all attestation lifecycle events together)
+3. **Combine with entity filters** (subject, issuer) for fine-grained control
+4. **Monitor indexed topics** for real-time updates via GraphQL subscriptions
+5. **Use direct ledger watching** for comprehensive historical event coverage
+6. **Handle duplicate events** — the same event may appear from both indexer and direct watching
+
+## Subscription Modes Comparison
+
+| Feature | GraphQL Subscriptions | Direct Ledger Watching |
+|---------|----------------------|------------------------|
+| Real-time updates | ✓ | ✓ (with polling) |
+| Topic filtering | ✓ | ✓ |
+| Entity filtering | Limited | ✓ |
+| Historical events | Limited | ✓ |
+| Bandwidth efficient | ✓ | ⚠️ (requires polling) |
+| Indexer dependent | ✓ | ✗ |
+| Comprehensive coverage | Limited | ✓ |
+
+## Common Use Cases
+
+### Monitor specific subject's attestations
+```typescript
+topics: [EventTopics.CREATED, EventTopics.REVOKED, EventTopics.EXPIRED],
+subject: userAddress
+```
+
+### Monitor issuer compliance
+```typescript
+topics: EventCategories.ISSUER_COMPLIANCE,
+issuer: issuerAddress
+```
+
+### Monitor request processing
+```typescript
+topics: EventCategories.REQUEST_LIFECYCLE
+```
+
+### Monitor all admin actions
+```typescript
+topics: EventCategories.ADMIN_ACTIONS
+```
+
+## Troubleshooting
+
+### Not receiving events
+
+1. Verify the indexer is running and events are being indexed
+2. Check that the contract ID matches your deployment
+3. Ensure topic names exactly match the canonical list (case-sensitive)
+4. Verify network passphrase matches the RPC endpoint
+
+### Missing events
+
+- GraphQL subscriptions may not capture all events if the indexer is lagging
+- Use direct ledger watching to ensure comprehensive event coverage
+- Check the `INDEXED_PRIORITY` category to see which events are prioritized
+
+### Connection issues
+
+- Check network connectivity to the RPC and indexer endpoints
+- Verify environment variables are set correctly
+- Review logs for authentication or rate-limiting errors
+
+## Related Documentation
+
+- [EVENT_TOPICS.md](../../docs/EVENT_TOPICS.md) — Complete event topic reference
+- [SDK Documentation](../../bindings/) — SDK reference and examples
+- [Indexer Documentation](../../indexer/) — Indexer setup and configuration
+
+## Support
+
+For issues or questions:
+
+1. Check the [EVENT_TOPICS.md](../../docs/EVENT_TOPICS.md) for complete topic documentation
+2. Review existing examples for similar use cases
+3. Check SDK documentation for API details
+4. Open an issue on the project repository

--- a/examples/event-filtering/python-example.py
+++ b/examples/event-filtering/python-example.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""
+TrustLink Event Filtering Example (Python)
+
+This example demonstrates how to subscribe to contract events with topic filtering
+using the TrustLink Python SDK. It shows both GraphQL subscriptions and direct ledger watching.
+"""
+
+import asyncio
+import os
+from trustlink import (
+    EventTopics,
+    EventCategories,
+    subscribe_to_direct_ledger_events,
+    subscribe_to_graphql_events,
+    LedgerEventWatchOptions,
+    GraphQLSubscriptionOptions,
+)
+
+
+# ─── Example 1: Subscribe to specific attestation events via GraphQL ────────
+
+
+async def example1_graphql_topic_filtering():
+    """Subscribe to specific attestation events via GraphQL with topic filtering."""
+    print("=== Example 1: GraphQL Subscriptions with Topic Filtering ===\n")
+
+    options = GraphQLSubscriptionOptions(
+        graphql_url=os.getenv("INDEXER_WS_URL", "wss://indexer.trustlink.io/graphql"),
+        # Only subscribe to attestation creation and revocation events
+        topics=[EventTopics.CREATED, EventTopics.REVOKED],
+        # Optional: filter by subject address
+        subject="GBBD5YHQVW53S3QQZVVTQ6S4RBFMU7GZGMG3MHEWJRUZRM5Y2I3R4D",
+    )
+
+    async def on_event(event):
+        print(f"Event received: {event.topic}")
+        print(f"  Ledger: {event.ledger}")
+        print(f"  Data: {event.data}")
+        print()
+
+    subscription = await subscribe_to_graphql_events(options, on_event)
+
+    # Unsubscribe after 30 seconds
+    await asyncio.sleep(30)
+    await subscription.unsubscribe()
+    print("Unsubscribed from GraphQL events")
+
+
+# ─── Example 2: Subscribe to category of events via direct ledger watching ──
+
+
+async def example2_direct_ledger_watching_with_categories():
+    """Subscribe to all attestation lifecycle events via direct ledger watching."""
+    print("=== Example 2: Direct Ledger Watching with Event Categories ===\n")
+
+    options = LedgerEventWatchOptions(
+        rpc_url="https://soroban-testnet.stellar.org",
+        contract_id=os.getenv("CONTRACT_ID", "C..."),
+        network_passphrase="Test SDF Future Network ; October 2024",
+        # Use a category from EventCategories for related events
+        topics=EventCategories.ATTESTATION_LIFECYCLE,
+        polling_interval_ms=5000,
+        page_size=100,
+    )
+
+    async def on_event(event):
+        print(f"Event: {event.topic} at ledger {event.ledger}")
+        print(f"  Timestamp: {event.timestamp.isoformat()}")
+        print()
+
+    subscription = await subscribe_to_direct_ledger_events(options, on_event)
+
+    # Keep subscription active for demonstration
+    print("Listening to attestation lifecycle events...")
+    print("Press Ctrl+C to stop\n")
+
+    try:
+        await asyncio.sleep(3600)  # Run for 1 hour
+    except KeyboardInterrupt:
+        await subscription.unsubscribe()
+        print("\nUnsubscribed")
+
+
+# ─── Example 3: Multi-topic subscription with filtering ──────────────────
+
+
+async def example3_multi_topic_with_filtering():
+    """Subscribe to issuer compliance events with topic filtering."""
+    print("=== Example 3: Multi-Topic Subscription with Filtering ===\n")
+
+    options = GraphQLSubscriptionOptions(
+        graphql_url=os.getenv("INDEXER_WS_URL"),
+        # Subscribe to issuer compliance events
+        topics=EventCategories.ISSUER_COMPLIANCE,
+        # Filter by specific issuer
+        issuer="GBRPYHIL2CI3WHPSKYXXRX7XQJ5RP4A5ECLYWWQSBHXVLZACVXULO5Z",
+    )
+
+    async def on_event(event):
+        print(f"Issuer compliance event: {event.topic}")
+        print(f"Data: {event.data}\n")
+
+    subscription = await subscribe_to_graphql_events(options, on_event)
+
+    await asyncio.sleep(60)
+    await subscription.unsubscribe()
+
+
+# ─── Example 4: Comprehensive event monitoring ────────────────────────────
+
+
+async def example4_comprehensive_monitoring():
+    """Monitor multiple event categories simultaneously."""
+    print("=== Example 4: Comprehensive Event Monitoring ===\n")
+
+    # 1. Monitor all attestation lifecycle changes
+    attestation_sub = await subscribe_to_direct_ledger_events(
+        LedgerEventWatchOptions(
+            rpc_url="https://soroban-testnet.stellar.org",
+            contract_id=os.getenv("CONTRACT_ID", "C..."),
+            network_passphrase="Test SDF Future Network ; October 2024",
+            topics=EventCategories.ATTESTATION_LIFECYCLE,
+            subject="GBBD5YHQVW53S3QQZVVTQ6S4RBFMU7GZGMG3MHEWJRUZRM5Y2I3R4D",
+        ),
+        lambda event: print(f"[ATTESTATION] {event.topic}"),
+    )
+
+    # 2. Monitor issuer compliance events
+    compliance_sub = await subscribe_to_direct_ledger_events(
+        LedgerEventWatchOptions(
+            rpc_url="https://soroban-testnet.stellar.org",
+            contract_id=os.getenv("CONTRACT_ID", "C..."),
+            network_passphrase="Test SDF Future Network ; October 2024",
+            topics=EventCategories.ISSUER_COMPLIANCE,
+            issuer="GBRPYHIL2CI3WHPSKYXXRX7XQJ5RP4A5ECLYWWQSBHXVLZACVXULO5Z",
+        ),
+        lambda event: print(f"[COMPLIANCE] {event.topic}"),
+    )
+
+    # 3. Monitor multi-sig operations
+    multisig_sub = await subscribe_to_direct_ledger_events(
+        LedgerEventWatchOptions(
+            rpc_url="https://soroban-testnet.stellar.org",
+            contract_id=os.getenv("CONTRACT_ID", "C..."),
+            network_passphrase="Test SDF Future Network ; October 2024",
+            topics=EventCategories.MULTISIG,
+        ),
+        lambda event: print(f"[MULTISIG] {event.topic}"),
+    )
+
+    print("Monitoring multiple event categories...")
+    print("Press Ctrl+C to stop\n")
+
+    try:
+        await asyncio.sleep(3600)
+    except KeyboardInterrupt:
+        print("\nCleaning up subscriptions...")
+        await attestation_sub.unsubscribe()
+        await compliance_sub.unsubscribe()
+        await multisig_sub.unsubscribe()
+
+
+# ─── Example 5: Error Handling and Retry Logic ─────────────────────────────
+
+
+async def example5_error_handling_and_retry():
+    """Demonstrate error handling and retry logic in event processing."""
+    print("=== Example 5: Error Handling and Retry Logic ===\n")
+
+    options = LedgerEventWatchOptions(
+        rpc_url="https://soroban-testnet.stellar.org",
+        contract_id=os.getenv("CONTRACT_ID", "C..."),
+        network_passphrase="Test SDF Future Network ; October 2024",
+        topics=[EventTopics.CREATED, EventTopics.REVOKED],
+        polling_interval_ms=5000,
+    )
+
+    retry_count = 0
+    max_retries = 3
+
+    async def on_event_with_retry(event):
+        nonlocal retry_count
+        try:
+            print(f"Processing event: {event.topic}")
+            # Your event processing logic here
+            retry_count = 0  # Reset on successful processing
+        except Exception as error:
+            retry_count += 1
+            print(f"Error processing event (attempt {retry_count}): {error}")
+
+            if retry_count >= max_retries:
+                print("Max retries exceeded, unsubscribing")
+                # In a real app, you'd unsubscribe here
+                raise
+
+    subscription = await subscribe_to_direct_ledger_events(options, on_event_with_retry)
+
+    await asyncio.sleep(60)
+    await subscription.unsubscribe()
+
+
+# ─── Example 6: Using EventTopics and EventCategories ─────────────────────
+
+
+async def example6_topic_exploration():
+    """Demonstrate exploring available topics and categories."""
+    print("=== Example 6: Topic Exploration ===\n")
+
+    # Print all available topics
+    print("All available topics:")
+    all_topics = EventTopics.all_topics()
+    for i, topic in enumerate(all_topics, 1):
+        print(f"  {i:2d}. {topic}")
+
+    print("\n" + "=" * 50)
+    print("\nEvent categories:")
+
+    print("\nATTESTATION_LIFECYCLE:")
+    for topic in EventCategories.ATTESTATION_LIFECYCLE:
+        print(f"  - {topic}")
+
+    print("\nISSUER_COMPLIANCE:")
+    for topic in EventCategories.ISSUER_COMPLIANCE:
+        print(f"  - {topic}")
+
+    print("\nREQUEST_LIFECYCLE:")
+    for topic in EventCategories.REQUEST_LIFECYCLE:
+        print(f"  - {topic}")
+
+    print("\nMULTISIG:")
+    for topic in EventCategories.MULTISIG:
+        print(f"  - {topic}")
+
+    print("\nDISPUTE_AMENDMENT:")
+    for topic in EventCategories.DISPUTE_AMENDMENT:
+        print(f"  - {topic}")
+
+    print("\nADMIN_ACTIONS:")
+    for topic in EventCategories.ADMIN_ACTIONS:
+        print(f"  - {topic}")
+
+    print("\nCOUNCIL_GOVERNANCE:")
+    for topic in EventCategories.COUNCIL_GOVERNANCE:
+        print(f"  - {topic}")
+
+
+# ─── Main: Run examples ────────────────────────────────────────────────────
+
+
+async def main():
+    """Main entry point for examples."""
+    print("TrustLink Event Filtering Examples\n")
+    print("Select an example to run:\n")
+    print("1. GraphQL Subscriptions with Topic Filtering")
+    print("2. Direct Ledger Watching with Event Categories")
+    print("3. Multi-Topic Subscription with Filtering")
+    print("4. Comprehensive Event Monitoring")
+    print("5. Error Handling and Retry Logic")
+    print("6. Topic Exploration\n")
+
+    import sys
+
+    example = sys.argv[1] if len(sys.argv) > 1 else "1"
+
+    try:
+        if example == "1":
+            await example1_graphql_topic_filtering()
+        elif example == "2":
+            await example2_direct_ledger_watching_with_categories()
+        elif example == "3":
+            await example3_multi_topic_with_filtering()
+        elif example == "4":
+            await example4_comprehensive_monitoring()
+        elif example == "5":
+            await example5_error_handling_and_retry()
+        elif example == "6":
+            await example6_topic_exploration()
+        else:
+            print(f"Unknown example: {example}")
+    except KeyboardInterrupt:
+        print("\n\nInterrupted by user")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/event-filtering/typescript-example.ts
+++ b/examples/event-filtering/typescript-example.ts
@@ -1,0 +1,261 @@
+/**
+ * TrustLink Event Filtering Example (TypeScript)
+ *
+ * This example demonstrates how to subscribe to contract events with topic filtering
+ * using the TrustLink SDK. It shows both GraphQL subscriptions and direct ledger watching.
+ */
+
+import {
+  TrustLinkClient,
+  EventTopics,
+  EventCategories,
+  subscribeToGraphQLEvents,
+  subscribeToDirectLedgerEvents,
+  GraphQLSubscriptionOptions,
+  LedgerEventWatchOptions,
+} from "@trustlink/contract";
+
+// ─── Example 1: Subscribe to specific attestation events via GraphQL ────────
+
+async function example1_GraphQLTopicFiltering() {
+  console.log("=== Example 1: GraphQL Subscriptions with Topic Filtering ===\n");
+
+  const options: GraphQLSubscriptionOptions = {
+    graphqlUrl: process.env.INDEXER_WS_URL || "wss://indexer.trustlink.io/graphql",
+    // Only subscribe to attestation creation and revocation events
+    topics: [EventTopics.CREATED, EventTopics.REVOKED],
+    // Optional: filter by subject address
+    subject: "GBBD5YHQVW53S3QQZVVTQ6S4RBFMU7GZGMG3MHEWJRUZRM5Y2I3R4D",
+  };
+
+  const subscription = await subscribeToGraphQLEvents(options, (event) => {
+    console.log(`Event received: ${event.topic}`);
+    console.log(`  Ledger: ${event.ledger}`);
+    console.log(`  Data: ${JSON.stringify(event.data)}`);
+    console.log();
+  });
+
+  // Unsubscribe after 30 seconds
+  setTimeout(() => {
+    subscription.unsubscribe();
+    console.log("Unsubscribed from GraphQL events");
+  }, 30000);
+}
+
+// ─── Example 2: Subscribe to category of events via direct ledger watching ──
+
+async function example2_DirectLedgerWatchingWithCategories() {
+  console.log("=== Example 2: Direct Ledger Watching with Event Categories ===\n");
+
+  // Subscribe to all attestation lifecycle events
+  const options: LedgerEventWatchOptions = {
+    rpcUrl: "https://soroban-testnet.stellar.org",
+    contractId: process.env.CONTRACT_ID || "C...",
+    networkPassphrase: "Test SDF Future Network ; October 2024",
+    // Use a category from EventCategories for related events
+    topics: EventCategories.ATTESTATION_LIFECYCLE,
+    pollingIntervalMs: 5000,
+    pageSize: 100,
+  };
+
+  const subscription = await subscribeToDirectLedgerEvents(options, (event) => {
+    console.log(`Event: ${event.topic} at ledger ${event.ledger}`);
+    console.log(`  Timestamp: ${event.timestamp.toISOString()}`);
+  });
+
+  // Keep subscription active for demonstration
+  console.log("Listening to attestation lifecycle events...");
+  console.log("Press Ctrl+C to stop\n");
+}
+
+// ─── Example 3: Multi-topic subscription with filtering ──────────────────
+
+async function example3_MultiTopicWithFiltering() {
+  console.log("=== Example 3: Multi-Topic Subscription with Filtering ===\n");
+
+  // Subscribe to compliance-related events
+  const options: GraphQLSubscriptionOptions = {
+    graphqlUrl: process.env.INDEXER_WS_URL,
+    // Subscribe to issuer compliance events
+    topics: EventCategories.ISSUER_COMPLIANCE,
+    // Filter by specific issuer
+    issuer: "GBRPYHIL2CI3WHPSKYXXRX7XQJ5RP4A5ECLYWWQSBHXVLZACVXULO5Z",
+  };
+
+  const subscription = await subscribeToGraphQLEvents(options, (event) => {
+    console.log(`Issuer compliance event: ${event.topic}`);
+    console.log(JSON.stringify(event.data, null, 2));
+    console.log();
+  });
+}
+
+// ─── Example 4: Comprehensive event monitoring ────────────────────────────
+
+async function example4_ComprehensiveMonitoring() {
+  console.log("=== Example 4: Comprehensive Event Monitoring ===\n");
+
+  // Create multiple subscriptions for different event categories
+
+  // 1. Monitor all attestation lifecycle changes
+  const attestationSub = await subscribeToDirectLedgerEvents(
+    {
+      rpcUrl: "https://soroban-testnet.stellar.org",
+      contractId: process.env.CONTRACT_ID || "C...",
+      networkPassphrase: "Test SDF Future Network ; October 2024",
+      topics: EventCategories.ATTESTATION_LIFECYCLE,
+      subject: "GBBD5YHQVW53S3QQZVVTQ6S4RBFMU7GZGMG3MHEWJRUZRM5Y2I3R4D",
+    },
+    (event) => {
+      console.log(`[ATTESTATION] ${event.topic}`);
+    }
+  );
+
+  // 2. Monitor issuer compliance events
+  const complianceSub = await subscribeToDirectLedgerEvents(
+    {
+      rpcUrl: "https://soroban-testnet.stellar.org",
+      contractId: process.env.CONTRACT_ID || "C...",
+      networkPassphrase: "Test SDF Future Network ; October 2024",
+      topics: EventCategories.ISSUER_COMPLIANCE,
+      issuer: "GBRPYHIL2CI3WHPSKYXXRX7XQJ5RP4A5ECLYWWQSBHXVLZACVXULO5Z",
+    },
+    (event) => {
+      console.log(`[COMPLIANCE] ${event.topic}`);
+    }
+  );
+
+  // 3. Monitor multi-sig operations
+  const multisigSub = await subscribeToDirectLedgerEvents(
+    {
+      rpcUrl: "https://soroban-testnet.stellar.org",
+      contractId: process.env.CONTRACT_ID || "C...",
+      networkPassphrase: "Test SDF Future Network ; October 2024",
+      topics: EventCategories.MULTISIG,
+    },
+    (event) => {
+      console.log(`[MULTISIG] ${event.topic}`);
+    }
+  );
+
+  console.log("Monitoring multiple event categories...");
+  console.log("Press Ctrl+C to stop\n");
+
+  // Cleanup on exit
+  process.on("SIGINT", async () => {
+    console.log("\nCleaning up subscriptions...");
+    await attestationSub.unsubscribe();
+    await complianceSub.unsubscribe();
+    await multisigSub.unsubscribe();
+    process.exit(0);
+  });
+}
+
+// ─── Example 5: Using the React Hook with Topic Filtering ──────────────────
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Enhanced React hook for attestation subscriptions with topic filtering.
+ * Demonstrates how to use the SDK subscription helpers in a React component.
+ */
+export function useEnhancedAttestationSubscription(
+  address: string | null,
+  topics?: string[],
+  onEvent?: (event: any) => void
+) {
+  const onEventRef = useRef(onEvent);
+  onEventRef.current = onEvent;
+
+  useEffect(() => {
+    if (!address) return;
+
+    let subscription: any;
+
+    (async () => {
+      subscription = await subscribeToGraphQLEvents(
+        {
+          graphqlUrl: (import.meta as { env: Record<string, string> }).env
+            .VITE_INDEXER_WS_URL,
+          topics: topics || EventCategories.ATTESTATION_LIFECYCLE,
+          subject: address,
+        },
+        (event) => {
+          onEventRef.current?.(event);
+        }
+      );
+    })();
+
+    return () => {
+      subscription?.unsubscribe();
+    };
+  }, [address, topics]);
+}
+
+// ─── Example 6: Error Handling and Retry Logic ─────────────────────────────
+
+async function example6_ErrorHandlingAndRetry() {
+  console.log("=== Example 6: Error Handling and Retry Logic ===\n");
+
+  const options: LedgerEventWatchOptions = {
+    rpcUrl: "https://soroban-testnet.stellar.org",
+    contractId: process.env.CONTRACT_ID || "C...",
+    networkPassphrase: "Test SDF Future Network ; October 2024",
+    topics: [EventTopics.CREATED, EventTopics.REVOKED],
+    pollingIntervalMs: 5000,
+  };
+
+  let retryCount = 0;
+  const maxRetries = 3;
+
+  const subscription = await subscribeToDirectLedgerEvents(options, (event) => {
+    try {
+      console.log(`Processing event: ${event.topic}`);
+      // Your event processing logic here
+      retryCount = 0; // Reset on successful processing
+    } catch (error) {
+      retryCount++;
+      console.error(`Error processing event (attempt ${retryCount}):`, error);
+
+      if (retryCount >= maxRetries) {
+        console.error("Max retries exceeded, unsubscribing");
+        subscription.unsubscribe();
+      }
+    }
+  });
+}
+
+// ─── Main: Run examples ────────────────────────────────────────────────────
+
+async function main() {
+  console.log("TrustLink Event Filtering Examples\n");
+  console.log("Select an example to run:\n");
+  console.log("1. GraphQL Subscriptions with Topic Filtering");
+  console.log("2. Direct Ledger Watching with Event Categories");
+  console.log("3. Multi-Topic Subscription with Filtering");
+  console.log("4. Comprehensive Event Monitoring");
+  console.log("6. Error Handling and Retry Logic\n");
+
+  const example = process.argv[2] || "1";
+
+  switch (example) {
+    case "1":
+      await example1_GraphQLTopicFiltering();
+      break;
+    case "2":
+      await example2_DirectLedgerWatchingWithCategories();
+      break;
+    case "3":
+      await example3_MultiTopicWithFiltering();
+      break;
+    case "4":
+      await example4_ComprehensiveMonitoring();
+      break;
+    case "6":
+      await example6_ErrorHandlingAndRetry();
+      break;
+    default:
+      console.log(`Unknown example: ${example}`);
+  }
+}
+
+main().catch(console.error);

--- a/indexer/src/graphql.ts
+++ b/indexer/src/graphql.ts
@@ -236,11 +236,34 @@ export function buildResolvers(db: PrismaClient, redis: Redis | null = null) {
     },
 
     Subscription: {
+      /**
+       * Subscribe to attestation creation events.
+       * 
+       * @param subject - Optional: filter by subject address
+       * @param topics - Optional: allowlist of event topics to receive. 
+       *                 If provided, only 'created' is relevant for this subscription.
+       *                 Useful for consolidated topic-filtered subscriptions.
+       */
       onAttestationCreated: {
-        subscribe: (_: unknown, args: { subject?: string }) => {
+        subscribe: (_: unknown, args: { subject?: string; topics?: string[] }) => {
           const iter = pubsub.asyncIterableIterator<{
             onAttestationCreated: ReturnType<typeof mapAttestation>;
           }>(ATTESTATION_CREATED);
+
+          // If topics filter is provided and "created" is not in the list, return empty
+          if (args.topics && !args.topics.includes("created")) {
+            return {
+              [Symbol.asyncIterator]() {
+                return this;
+              },
+              async next(): Promise<IteratorResult<unknown>> {
+                return { done: true, value: undefined };
+              },
+              async return() {
+                return iter.return?.() ?? { done: true as const, value: undefined };
+              },
+            };
+          }
 
           if (!args.subject) return iter;
 
@@ -267,11 +290,34 @@ export function buildResolvers(db: PrismaClient, redis: Redis | null = null) {
         }) => payload.onAttestationCreated,
       },
 
+      /**
+       * Subscribe to attestation revocation events.
+       * 
+       * @param issuer - Optional: filter by issuer address
+       * @param topics - Optional: allowlist of event topics to receive.
+       *                 If provided, only 'revoked' is relevant for this subscription.
+       *                 Useful for consolidated topic-filtered subscriptions.
+       */
       onAttestationRevoked: {
-        subscribe: (_: unknown, args: { issuer?: string }) => {
+        subscribe: (_: unknown, args: { issuer?: string; topics?: string[] }) => {
           const iter = pubsub.asyncIterableIterator<{
             onAttestationRevoked: { id: string; issuer: string; revokedAt: string };
           }>(ATTESTATION_REVOKED);
+
+          // If topics filter is provided and "revoked" is not in the list, return empty
+          if (args.topics && !args.topics.includes("revoked")) {
+            return {
+              [Symbol.asyncIterator]() {
+                return this;
+              },
+              async next(): Promise<IteratorResult<unknown>> {
+                return { done: true, value: undefined };
+              },
+              async return() {
+                return iter.return?.() ?? { done: true as const, value: undefined };
+              },
+            };
+          }
 
           if (!args.issuer) return iter;
 
@@ -298,11 +344,36 @@ export function buildResolvers(db: PrismaClient, redis: Redis | null = null) {
         }) => payload.onAttestationRevoked,
       },
 
+      /**
+       * Subscribe to issuer registration events.
+       * 
+       * @param topics - Optional: allowlist of event topics to receive.
+       *                 If provided, only 'iss_reg' is relevant for this subscription.
+       *                 Useful for consolidated topic-filtered subscriptions.
+       */
       onIssuerRegistered: {
-        subscribe: () =>
-          pubsub.asyncIterableIterator<{
+        subscribe: (_: unknown, args: { topics?: string[] }) => {
+          const iter = pubsub.asyncIterableIterator<{
             onIssuerRegistered: { issuer: string; registeredAt: string };
-          }>(ISSUER_REGISTERED),
+          }>(ISSUER_REGISTERED);
+
+          // If topics filter is provided and "iss_reg" is not in the list, return empty
+          if (args.topics && !args.topics.includes("iss_reg")) {
+            return {
+              [Symbol.asyncIterator]() {
+                return this;
+              },
+              async next(): Promise<IteratorResult<unknown>> {
+                return { done: true, value: undefined };
+              },
+              async return() {
+                return iter.return?.() ?? { done: true as const, value: undefined };
+              },
+            };
+          }
+
+          return iter;
+        },
         resolve: (payload: {
           onIssuerRegistered: { issuer: string; registeredAt: string };
         }) => payload.onIssuerRegistered,


### PR DESCRIPTION
### Summary

Added topic-based event subscription filtering and a canonical event taxonomy to provide consistent event filtering across the SDK and indexer.

### Changes

* Documented a canonical list of contract event topics derived from `src/events.rs`.
* Extended the SDK's event subscription helpers to accept a topic allowlist for selective subscriptions.
* Aligned SDK filtering with the indexer's GraphQL subscription filter model for consistent behavior.
* Updated documentation with examples for subscribing to specific event topics via both GraphQL subscriptions and direct ledger event helpers.

### Result

This PR enables consumers to subscribe only to relevant event types, reducing client-side filtering overhead while establishing a unified event taxonomy shared between the SDK and indexer.

Closes #1030 