### PR TITLE
Feat/attestation bundling

### DIFF
--- a/bindings/python/trustlink/__init__.py
+++ b/bindings/python/trustlink/__init__.py
@@ -6,6 +6,7 @@ from .types import (
     Attestation,
     AttestationStatus,
     AttestationTemplate,
+    AttestationBundle,
     ClaimTypeInfo,
     ContractConfig,
     ContractMetadata,
@@ -33,6 +34,16 @@ from .event_subscriptions import (
     subscribe_to_graphql_events,
     EventSubscription,
 )
+from .bundle_helpers import (
+    BundleOptions,
+    verify_attestations_in_same_bundle,
+    verify_bundle_claim_types,
+    verify_bundle_size,
+    verify_bundle_subjects,
+    verify_bundle_issuer,
+    get_bundle_summary,
+    group_attestations_by_bundle,
+)
 
 __version__ = "0.1.0"
 __all__ = [
@@ -41,6 +52,7 @@ __all__ = [
     "Attestation",
     "AttestationStatus",
     "AttestationTemplate",
+    "AttestationBundle",
     "ClaimTypeInfo",
     "ContractConfig",
     "ContractMetadata",
@@ -63,4 +75,12 @@ __all__ = [
     "subscribe_to_direct_ledger_events",
     "subscribe_to_graphql_events",
     "EventSubscription",
+    "BundleOptions",
+    "verify_attestations_in_same_bundle",
+    "verify_bundle_claim_types",
+    "verify_bundle_size",
+    "verify_bundle_subjects",
+    "verify_bundle_issuer",
+    "get_bundle_summary",
+    "group_attestations_by_bundle",
 ]

--- a/bindings/python/trustlink/bundle_helpers.py
+++ b/bindings/python/trustlink/bundle_helpers.py
@@ -1,0 +1,218 @@
+"""TrustLink Bundle Helpers — Python SDK
+
+Helper methods for creating and verifying attestation bundles.
+Bundles allow issuing multiple related attestations atomically with a shared bundle ID.
+"""
+
+from typing import List, Optional, Dict, Any
+from .types import Attestation, AttestationBundle
+
+
+class BundleOptions:
+    """Options for creating an attestation bundle."""
+    
+    def __init__(
+        self,
+        issuer: str,
+        subject: str,
+        claim_types: List[str],
+        expiration: Optional[int] = None,
+        metadata: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+    ):
+        """Initialize bundle creation options.
+        
+        Args:
+            issuer: Issuer address (must be authorized)
+            subject: Subject address receiving the attestations
+            claim_types: List of claim types to issue (order determines bundle ID)
+            expiration: Optional expiration time (applied to all attestations)
+            metadata: Optional metadata (shared across attestations)
+            tags: Optional tags (applied to all attestations)
+        """
+        self.issuer = issuer
+        self.subject = subject
+        self.claim_types = claim_types
+        self.expiration = expiration
+        self.metadata = metadata
+        self.tags = tags
+
+
+def verify_attestations_in_same_bundle(
+    attestations: List[Attestation],
+) -> Optional[str]:
+    """Verify that a set of attestations belong to the same bundle.
+    
+    Args:
+        attestations: Array of attestations to verify
+        
+    Returns:
+        The common bundle ID if all share one, or None if not all in same bundle
+        
+    Example:
+        >>> bundle_id = verify_attestations_in_same_bundle(attestations)
+        >>> if bundle_id:
+        ...     print(f"All attestations are from bundle: {bundle_id}")
+    """
+    if not attestations:
+        return None
+    
+    first_bundle_id = attestations[0].get("bundle_id")
+    if not first_bundle_id:
+        return None
+    
+    for attestation in attestations:
+        if attestation.get("bundle_id") != first_bundle_id:
+            return None
+    
+    return first_bundle_id
+
+
+def verify_bundle_claim_types(
+    bundle: AttestationBundle,
+    expected_claim_types: List[str],
+) -> bool:
+    """Verify a bundle contains expected claim types.
+    
+    Args:
+        bundle: The bundle to verify
+        expected_claim_types: Expected claim types (order matters)
+        
+    Returns:
+        True if bundle contains exactly the expected claim types in order
+        
+    Example:
+        >>> is_expected = verify_bundle_claim_types(
+        ...     bundle,
+        ...     ["KYC_PASSED", "AGE_VERIFIED"]
+        ... )
+        >>> print(f"Bundle has expected claim types: {is_expected}")
+    """
+    if len(bundle["claim_types"]) != len(expected_claim_types):
+        return False
+    
+    for i, claim_type in enumerate(bundle["claim_types"]):
+        if claim_type != expected_claim_types[i]:
+            return False
+    
+    return True
+
+
+def verify_bundle_size(bundle: AttestationBundle, expected_count: int) -> bool:
+    """Verify a bundle contains expected number of attestations.
+    
+    Args:
+        bundle: The bundle to verify
+        expected_count: Expected number of attestations
+        
+    Returns:
+        True if bundle has exactly the expected number of attestations
+        
+    Example:
+        >>> is_expected = verify_bundle_size(bundle, 3)
+        >>> print(f"Bundle has expected size: {is_expected}")
+    """
+    return (
+        len(bundle["attestation_ids"]) == expected_count
+        and len(bundle["claim_types"]) == expected_count
+    )
+
+
+def verify_bundle_subjects(
+    bundle: AttestationBundle,
+    attestations: List[Attestation],
+) -> bool:
+    """Verify all attestations in a bundle are for the same subject.
+    
+    Args:
+        bundle: The bundle metadata
+        attestations: The attestations to verify
+        
+    Returns:
+        True if all attestations are issued to the bundle's subject
+    """
+    if not attestations:
+        return True
+    
+    for attestation in attestations:
+        if attestation["subject"] != bundle["subject"]:
+            return False
+    
+    return True
+
+
+def verify_bundle_issuer(
+    bundle: AttestationBundle,
+    attestations: List[Attestation],
+) -> bool:
+    """Verify all attestations in a bundle are from the same issuer.
+    
+    Args:
+        bundle: The bundle metadata
+        attestations: The attestations to verify
+        
+    Returns:
+        True if all attestations are from the bundle's issuer
+    """
+    if not attestations:
+        return True
+    
+    for attestation in attestations:
+        if attestation["issuer"] != bundle["issuer"]:
+            return False
+    
+    return True
+
+
+def get_bundle_summary(bundle: AttestationBundle) -> Dict[str, Any]:
+    """Get a human-readable summary of a bundle.
+    
+    Args:
+        bundle: The bundle to summarize
+        
+    Returns:
+        Dictionary with bundle summary information
+        
+    Example:
+        >>> summary = get_bundle_summary(bundle)
+        >>> print(f"Bundle {summary['id']} from {summary['issuer']}")
+        >>> print(f"  To: {summary['subject']}")
+        >>> print(f"  Claims: {', '.join(summary['claim_types'])}")
+        >>> print(f"  Valid: {summary['all_valid']}")
+    """
+    return {
+        "id": bundle["id"],
+        "issuer": bundle["issuer"],
+        "subject": bundle["subject"],
+        "claim_types": bundle["claim_types"],
+        "attestation_count": len(bundle["attestation_ids"]),
+        "all_valid": bundle["all_valid"],
+        "created_at": bundle["timestamp"],
+    }
+
+
+def group_attestations_by_bundle(
+    attestations: List[Attestation],
+) -> Dict[Optional[str], List[Attestation]]:
+    """Group attestations by their bundle ID.
+    
+    Args:
+        attestations: List of attestations to group
+        
+    Returns:
+        Dictionary mapping bundle IDs to lists of attestations
+        
+    Example:
+        >>> groups = group_attestations_by_bundle(attestations)
+        >>> for bundle_id, atts in groups.items():
+        ...     print(f"Bundle {bundle_id}: {len(atts)} attestations")
+    """
+    groups: Dict[Optional[str], List[Attestation]] = {}
+    
+    for attestation in attestations:
+        bundle_id = attestation.get("bundle_id")
+        if bundle_id not in groups:
+            groups[bundle_id] = []
+        groups[bundle_id].append(attestation)
+    
+    return groups

--- a/bindings/python/trustlink/types.py
+++ b/bindings/python/trustlink/types.py
@@ -19,6 +19,18 @@ class Attestation(TypedDict):
     bridged: bool
     source_chain: Optional[str]
     source_tx: Optional[str]
+    bundle_id: Optional[str]
+
+
+class AttestationBundle(TypedDict):
+    """Bundle of attestations issued atomically."""
+    id: str
+    issuer: str
+    subject: str
+    claim_types: List[str]
+    timestamp: int
+    attestation_ids: List[str]
+    all_valid: bool
 
 
 class ClaimTypeInfo(TypedDict):

--- a/bindings/typescript/src/bundleHelpers.ts
+++ b/bindings/typescript/src/bundleHelpers.ts
@@ -1,0 +1,227 @@
+/**
+ * TrustLink Bundle Helpers — TypeScript SDK
+ *
+ * Helper methods for creating and verifying attestation bundles.
+ * Bundles allow issuing multiple related attestations atomically with a shared bundle ID.
+ */
+
+import { TrustLinkClient } from "./client";
+import type { Attestation, AttestationBundle } from "./types";
+
+/**
+ * Options for creating an attestation bundle.
+ */
+export interface CreateBundleOptions {
+  /** Issuer address (must be authorized) */
+  issuer: string;
+  /** Subject address receiving the attestations */
+  subject: string;
+  /** List of claim types to issue (order determines bundle ID) */
+  claimTypes: string[];
+  /** Optional expiration time (applied to all attestations) */
+  expiration?: bigint;
+  /** Optional metadata (shared across attestations in bundle) */
+  metadata?: string;
+  /** Optional tags (applied to all attestations) */
+  tags?: string[];
+}
+
+/**
+ * Helper to create a bundle of attestations with a shared bundle ID.
+ *
+ * @param client - TrustLink client instance
+ * @param options - Bundle creation options
+ * @returns The bundle ID on success
+ *
+ * @example
+ * ```typescript
+ * const bundleId = await createAttestationBundle(client, {
+ *   issuer: issuerAddress,
+ *   subject: subjectAddress,
+ *   claimTypes: ["KYC_PASSED", "AGE_VERIFIED", "JURISDICTION_US"],
+ *   expiration: BigInt(Math.floor(Date.now() / 1000)) + BigInt(365 * 24 * 60 * 60),
+ * });
+ * ```
+ */
+export async function createAttestationBundle(
+  client: TrustLinkClient,
+  options: CreateBundleOptions
+): Promise<string> {
+  return client.createAttestationBundle(
+    options.issuer,
+    options.subject,
+    options.claimTypes,
+    options.expiration ?? null,
+    options.metadata ?? null,
+    options.tags ?? null
+  );
+}
+
+/**
+ * Retrieve a bundle and all its attestations.
+ *
+ * @param client - TrustLink client instance
+ * @param bundleId - The bundle ID to retrieve
+ * @returns Object with bundle metadata and attestations
+ *
+ * @example
+ * ```typescript
+ * const bundleInfo = await getBundleWithAttestations(client, bundleId);
+ * console.log(`Bundle has ${bundleInfo.attestations.length} attestations`);
+ * console.log(`All valid: ${bundleInfo.bundle.all_valid}`);
+ * ```
+ */
+export async function getBundleWithAttestations(
+  client: TrustLinkClient,
+  bundleId: string
+): Promise<{ bundle: AttestationBundle; attestations: Attestation[] }> {
+  const [bundle, attestations] = await Promise.all([
+    client.getBundle(bundleId),
+    client.getBundleAttestations(bundleId),
+  ]);
+
+  return { bundle, attestations };
+}
+
+/**
+ * Check if a bundle and all its attestations are valid (not revoked).
+ *
+ * @param client - TrustLink client instance
+ * @param bundleId - The bundle ID to check
+ * @returns True if all attestations in the bundle are valid
+ *
+ * @example
+ * ```typescript
+ * const isValid = await verifyBundleValidity(client, bundleId);
+ * if (isValid) {
+ *   console.log("Bundle is fully valid");
+ * } else {
+ *   console.log("One or more attestations in bundle have been revoked");
+ * }
+ * ```
+ */
+export async function verifyBundleValidity(
+  client: TrustLinkClient,
+  bundleId: string
+): Promise<boolean> {
+  return client.isBundleValid(bundleId);
+}
+
+/**
+ * Get all bundles created by an issuer.
+ *
+ * @param client - TrustLink client instance
+ * @param issuer - Issuer address
+ * @returns Array of bundle IDs created by the issuer
+ *
+ * @example
+ * ```typescript
+ * const bundleIds = await getIssuerBundles(client, issuerAddress);
+ * console.log(`Issuer has created ${bundleIds.length} bundles`);
+ * ```
+ */
+export async function getIssuerBundles(
+  client: TrustLinkClient,
+  issuer: string
+): Promise<string[]> {
+  return client.getIssuerBundles(issuer);
+}
+
+/**
+ * Get all bundles issued to a subject.
+ *
+ * @param client - TrustLink client instance
+ * @param subject - Subject address
+ * @returns Array of bundle IDs issued to the subject
+ *
+ * @example
+ * ```typescript
+ * const bundleIds = await getSubjectBundles(client, subjectAddress);
+ * console.log(`Subject has received ${bundleIds.length} bundles`);
+ * ```
+ */
+export async function getSubjectBundles(
+  client: TrustLinkClient,
+  subject: string
+): Promise<string[]> {
+  return client.getSubjectBundles(subject);
+}
+
+/**
+ * Verify that a set of attestations belong to the same bundle.
+ *
+ * @param attestations - Array of attestations to verify
+ * @returns The common bundle ID if all share one, or null if not all in same bundle
+ *
+ * @example
+ * ```typescript
+ * const bundleId = verifyAttestationsInSameBundle(attestations);
+ * if (bundleId) {
+ *   console.log(`All attestations are from bundle: ${bundleId}`);
+ * } else {
+ *   console.log("Attestations are not all from the same bundle");
+ * }
+ * ```
+ */
+export function verifyAttestationsInSameBundle(
+  attestations: Attestation[]
+): string | null {
+  if (attestations.length === 0) return null;
+
+  const firstBundleId = attestations[0].bundle_id;
+  if (!firstBundleId) return null;
+
+  for (const attestation of attestations) {
+    if (attestation.bundle_id !== firstBundleId) {
+      return null;
+    }
+  }
+
+  return firstBundleId;
+}
+
+/**
+ * Verify a bundle contains expected claim types.
+ *
+ * @param bundle - The bundle to verify
+ * @param expectedClaimTypes - Expected claim types (order matters)
+ * @returns True if bundle contains exactly the expected claim types in order
+ *
+ * @example
+ * ```typescript
+ * const isExpected = verifyBundleClaimTypes(bundle, ["KYC_PASSED", "AGE_VERIFIED"]);
+ * console.log(`Bundle has expected claim types: ${isExpected}`);
+ * ```
+ */
+export function verifyBundleClaimTypes(
+  bundle: AttestationBundle,
+  expectedClaimTypes: string[]
+): boolean {
+  if (bundle.claim_types.length !== expectedClaimTypes.length) return false;
+
+  for (let i = 0; i < bundle.claim_types.length; i++) {
+    if (bundle.claim_types[i] !== expectedClaimTypes[i]) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Verify a bundle contains expected number of attestations.
+ *
+ * @param bundle - The bundle to verify
+ * @param expectedCount - Expected number of attestations
+ * @returns True if bundle has exactly the expected number of attestations
+ *
+ * @example
+ * ```typescript
+ * const isExpected = verifyBundleSize(bundle, 3);
+ * console.log(`Bundle has expected size: ${isExpected}`);
+ * ```
+ */
+export function verifyBundleSize(bundle: AttestationBundle, expectedCount: number): boolean {
+  return (
+    bundle.attestation_ids.length === expectedCount &&
+    bundle.claim_types.length === expectedCount
+  );
+}

--- a/bindings/typescript/src/index.ts
+++ b/bindings/typescript/src/index.ts
@@ -23,3 +23,4 @@ export * from "./client";
 export * from "./validation";
 export * from "./events";
 export * from "./eventSubscriptions";
+export * from "./bundleHelpers";

--- a/bindings/typescript/src/types.ts
+++ b/bindings/typescript/src/types.ts
@@ -62,6 +62,8 @@ export interface Attestation {
   revocation_reason: string | null;
   /** True when the subject has requested GDPR deletion. */
   deleted: boolean;
+  /** Optional: shared bundle ID if this attestation was created as part of a bundle. */
+  bundle_id: string | null;
 }
 
 export interface AuditEntry {
@@ -69,6 +71,23 @@ export interface AuditEntry {
   actor: string;
   timestamp: bigint;
   details: string | null;
+}
+
+export interface AttestationBundle {
+  /** Unique bundle identifier */
+  id: string;
+  /** Issuer who created the bundle */
+  issuer: string;
+  /** Subject to whom all attestations were issued */
+  subject: string;
+  /** List of claim types in the bundle (fixed order) */
+  claim_types: string[];
+  /** Timestamp when the bundle was created */
+  timestamp: bigint;
+  /** IDs of all attestations in this bundle */
+  attestation_ids: string[];
+  /** Whether all attestations in the bundle are still valid */
+  all_valid: boolean;
 }
 
 export interface ClaimTypeInfo {

--- a/examples/bundles/README.md
+++ b/examples/bundles/README.md
@@ -1,0 +1,262 @@
+# TrustLink Attestation Bundles
+
+This directory contains examples demonstrating how to use TrustLink's attestation bundling feature.
+
+## Overview
+
+Attestation bundles allow issuing multiple related claims atomically as a single transaction. All attestations in a bundle share a common bundle ID, enabling verifiers to confirm that a set of claims were issued together as one coherent unit.
+
+**Key Benefits:**
+- **Atomicity**: All claims in a bundle succeed or fail together (no partial states)
+- **Correlation**: Verifiers can confirm claims were issued as a cohesive set
+- **Efficiency**: Reduced transaction overhead for issuing related claims
+- **Auditability**: Audit logs track bundle membership for each attestation
+
+## Use Cases
+
+### 1. KYC Bundle
+A KYC (Know Your Customer) check that simultaneously establishes multiple verified claims:
+
+```
+Bundle ID: abc123...
+├─ KYC_PASSED
+├─ AGE_VERIFIED
+├─ JURISDICTION_US
+└─ IDENTITY_VERIFIED
+```
+
+Instead of 4 separate transactions with no guarantee all succeed, all 4 attestations are created atomically.
+
+### 2. Compliance Bundle
+Regulatory compliance certifications issued together:
+
+```
+Bundle ID: def456...
+├─ PCI_DSS_COMPLIANT
+├─ SOC_2_CERTIFIED
+├─ ISO_27001_APPROVED
+└─ GDPR_COMPLIANT
+```
+
+### 3. Academic Bundle
+University credentials issued in one transaction:
+
+```
+Bundle ID: ghi789...
+├─ DEGREE_BACHELOR
+├─ MAJOR_COMPUTER_SCIENCE
+├─ GPA_3_8
+└─ GRADUATION_DATE_2024
+```
+
+## How Bundles Work
+
+### Creating a Bundle
+
+```typescript
+// TypeScript
+import { TrustLinkClient, createAttestationBundle } from "@trustlink/contract";
+
+const client = new TrustLinkClient({
+  contractId: "C...",
+  rpcUrl: "https://soroban-testnet.stellar.org",
+});
+
+const bundleId = await createAttestationBundle(client, {
+  issuer: issuerAddress,
+  subject: subjectAddress,
+  claimTypes: ["KYC_PASSED", "AGE_VERIFIED", "JURISDICTION_US"],
+  expiration: BigInt(Math.floor(Date.now() / 1000)) + BigInt(365 * 24 * 60 * 60),
+  metadata: '{"kyc_level":"enhanced","checked_at":"2024-01-15"}',
+});
+
+console.log(`Bundle created: ${bundleId}`);
+```
+
+```python
+# Python
+from trustlink import TrustLinkClient, BundleOptions
+
+client = TrustLinkClient(
+    contract_id="C...",
+    rpc_url="https://soroban-testnet.stellar.org",
+)
+
+bundle_options = BundleOptions(
+    issuer=issuer_address,
+    subject=subject_address,
+    claim_types=["KYC_PASSED", "AGE_VERIFIED", "JURISDICTION_US"],
+    expiration=int(time.time()) + (365 * 24 * 60 * 60),
+    metadata='{"kyc_level":"enhanced","checked_at":"2024-01-15"}',
+)
+
+bundle_id = client.create_attestation_bundle(
+    bundle_options.issuer,
+    bundle_options.subject,
+    bundle_options.claim_types,
+    bundle_options.expiration,
+    bundle_options.metadata,
+    bundle_options.tags,
+)
+```
+
+### Verifying Bundle Membership
+
+Verifiers can confirm that a set of attestations were issued together:
+
+```typescript
+// TypeScript
+import {
+  getBundleWithAttestations,
+  verifyBundleValidity,
+  verifyAttestationsInSameBundle,
+} from "@trustlink/contract";
+
+// Get all attestations in a bundle
+const { bundle, attestations } = await getBundleWithAttestations(client, bundleId);
+
+console.log(`Bundle ${bundle.id} contains ${attestations.length} attestations`);
+console.log(`All valid: ${bundle.all_valid}`);
+
+// Verify all attestations share the same bundle
+const commonBundleId = verifyAttestationsInSameBundle(attestations);
+if (commonBundleId === bundleId) {
+  console.log("✓ All attestations are from the same bundle");
+}
+
+// Check if bundle is still valid (not revoked)
+const isValid = await verifyBundleValidity(client, bundleId);
+console.log(`Bundle valid: ${isValid}`);
+```
+
+```python
+# Python
+from trustlink import (
+    verify_attestations_in_same_bundle,
+    verify_bundle_claim_types,
+    get_bundle_summary,
+)
+
+# Verify all attestations share the same bundle
+bundle_id = verify_attestations_in_same_bundle(attestations)
+if bundle_id:
+    print(f"✓ All attestations are from bundle: {bundle_id}")
+
+# Verify expected claim types
+if verify_bundle_claim_types(bundle, ["KYC_PASSED", "AGE_VERIFIED"]):
+    print("✓ Bundle contains expected claim types")
+
+# Get bundle summary
+summary = get_bundle_summary(bundle)
+print(f"Bundle {summary['id']} from {summary['issuer']}")
+print(f"  Claims: {', '.join(summary['claim_types'])}")
+print(f"  Valid: {summary['all_valid']}")
+```
+
+### Querying Bundles
+
+```typescript
+// Get all bundles created by an issuer
+const issuerBundles = await client.getIssuerBundles(issuerAddress);
+console.log(`Issuer created ${issuerBundles.length} bundles`);
+
+// Get all bundles issued to a subject
+const subjectBundles = await client.getSubjectBundles(subjectAddress);
+console.log(`Subject received ${subjectBundles.length} bundles`);
+
+// Get bundle by ID
+const bundle = await client.getBundle(bundleId);
+console.log(`Bundle contains: ${bundle.claim_types.join(", ")}`);
+```
+
+```python
+# Get all bundles created by an issuer
+issuer_bundles = client.get_issuer_bundles(issuer_address)
+print(f"Issuer created {len(issuer_bundles)} bundles")
+
+# Get all bundles issued to a subject
+subject_bundles = client.get_subject_bundles(subject_address)
+print(f"Subject received {len(subject_bundles)} bundles")
+
+# Get bundle by ID
+bundle = client.get_bundle(bundle_id)
+print(f"Bundle contains: {', '.join(bundle['claim_types'])}")
+```
+
+## Bundle Properties
+
+Each attestation in a bundle has:
+- **bundle_id**: Shared identifier linking all attestations in the bundle
+- **timestamp**: When the bundle was created (same for all attestations)
+- **claim_type**: Individual claim type for this attestation
+
+The bundle metadata includes:
+- **id**: Deterministic bundle ID (SHA256 hash of issuer + subject + claim_types + timestamp)
+- **issuer**: Address that created the bundle
+- **subject**: Address receiving the attestations
+- **claim_types**: List of claim types (in creation order)
+- **attestation_ids**: List of individual attestation IDs (matches claim_types order)
+- **all_valid**: Flag indicating if all attestations are still valid (updated when any is revoked)
+- **timestamp**: Creation timestamp
+
+## Important Considerations
+
+### Bundle ID Determinism
+
+Bundle IDs are generated deterministically from:
+- Issuer address
+- Subject address
+- Ordered list of claim types
+- Timestamp
+
+This means:
+- Same issuer + subject + claim_types issued at the same timestamp = same bundle ID
+- Changing claim order or contents changes the bundle ID
+- Changing the timestamp creates a different bundle
+
+### Atomicity Guarantee
+
+- All attestations in a bundle are created in a single Soroban transaction
+- Either all succeed or all fail
+- No partial bundle states possible
+- Rate limiting and storage limits are enforced at the bundle level
+
+### Revocation
+
+- Individual attestations in a bundle can be revoked independently
+- When any attestation is revoked, the bundle's `all_valid` flag is updated to `false`
+- Verifiers should check both the bundle validity and individual attestation status
+
+### Storage Limits
+
+- Maximum 50 attestations per bundle
+- Bundle creation respects per-issuer and per-subject attestation limits
+- Each attestation in bundle counts against storage quotas
+
+## SDK Examples
+
+- `typescript-example.ts` - Complete TypeScript examples
+- `python-example.py` - Complete Python examples
+
+## Testing Bundles
+
+See the contract test files for comprehensive bundle testing:
+- Bundle creation with various claim type combinations
+- Verification of bundle membership
+- Revocation scenarios
+- Edge cases (max bundle size, duplicate attestations, etc.)
+
+## Best Practices
+
+1. **Group Related Claims**: Bundle claims that logically belong together
+2. **Verify Metadata**: Always verify bundle claim_types match expectations
+3. **Check Validity**: Regularly verify bundle validity, especially before relying on claims
+4. **Audit Logs**: Review attestation audit logs to understand bundle membership
+5. **Error Handling**: Handle potential errors in bundle creation (validation failures, rate limits)
+
+## Related Documentation
+
+- [EVENT_TOPICS.md](../../docs/EVENT_TOPICS.md) - Event taxonomy including bundle_created event
+- [TrustLink Contract](../../src/) - Smart contract source code
+- [TypeScript SDK](../../bindings/typescript/) - TypeScript bindings
+- [Python SDK](../../bindings/python/) - Python bindings

--- a/examples/bundles/python-example.py
+++ b/examples/bundles/python-example.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""
+TrustLink Attestation Bundles Example (Python)
+
+This example demonstrates how to create and verify attestation bundles.
+Bundles allow issuing multiple related attestations atomically with a shared bundle ID.
+"""
+
+import asyncio
+import os
+import sys
+import json
+from datetime import datetime, timedelta
+
+from trustlink import (
+    TrustLinkClient,
+    verify_attestations_in_same_bundle,
+    verify_bundle_claim_types,
+    verify_bundle_size,
+    verify_bundle_subjects,
+    verify_bundle_issuer,
+    get_bundle_summary,
+    group_attestations_by_bundle,
+)
+
+
+# ─── Example 1: Create a KYC Bundle ────────────────────────────────────────
+
+
+async def example1_create_kyc_bundle():
+    """Create a bundle with KYC-related claims."""
+    print("=== Example 1: Create a KYC Bundle ===\n")
+
+    client = TrustLinkClient(
+        contract_id=os.getenv("CONTRACT_ID", "C..."),
+        rpc_url="https://soroban-testnet.stellar.org",
+    )
+
+    issuer_address = os.getenv("ISSUER_ADDRESS", "GBRPYHIL2CI3...")
+    subject_address = os.getenv("SUBJECT_ADDRESS", "GBBD5YHQVW53...")
+
+    # Create a bundle with KYC-related claims
+    expiration = int((datetime.now() + timedelta(days=365)).timestamp())
+
+    bundle_id = client.create_attestation_bundle(
+        issuer=issuer_address,
+        subject=subject_address,
+        claim_types=["KYC_PASSED", "AGE_VERIFIED", "JURISDICTION_US"],
+        expiration=expiration,
+        metadata=json.dumps({
+            "kyc_level": "enhanced",
+            "checked_at": datetime.now().isoformat(),
+            "check_method": "video_call",
+        }),
+    )
+
+    print(f"✓ Bundle created: {bundle_id}")
+    print(f"  Contains 3 attestations: KYC_PASSED, AGE_VERIFIED, JURISDICTION_US\n")
+
+
+# ─── Example 2: Verify Bundle Membership ──────────────────────────────────
+
+
+async def example2_verify_bundle_membership():
+    """Verify bundle membership and get bundle details."""
+    print("=== Example 2: Verify Bundle Membership ===\n")
+
+    client = TrustLinkClient(
+        contract_id=os.getenv("CONTRACT_ID", "C..."),
+        rpc_url="https://soroban-testnet.stellar.org",
+    )
+
+    bundle_id = sys.argv[2] if len(sys.argv) > 2 else "bundle_id_here"
+
+    # Get bundle details
+    bundle = client.get_bundle(bundle_id)
+
+    print(f"Bundle: {bundle['id']}")
+    print(f"  Issuer: {bundle['issuer']}")
+    print(f"  Subject: {bundle['subject']}")
+    print(f"  Created: {datetime.fromtimestamp(bundle['timestamp']).isoformat()}")
+    print(f"  Claim Types: {', '.join(bundle['claim_types'])}")
+    print(f"  Attestation Count: {len(bundle['attestation_ids'])}")
+    print(f"  All Valid: {bundle['all_valid']}\n")
+
+    # Get attestations in bundle
+    attestations = client.get_bundle_attestations(bundle_id)
+
+    # Verify all attestations are from the same bundle
+    common_bundle_id = verify_attestations_in_same_bundle(attestations)
+    if common_bundle_id == bundle_id:
+        print("✓ All attestations are from the same bundle\n")
+    else:
+        print("✗ Attestations are not all from the same bundle\n")
+
+    # Show individual attestations
+    print("Individual Attestations:")
+    for att in attestations:
+        print(f"  - {att['claim_type']}: {att['id']}")
+        print(f"    Issuer: {att['issuer']}")
+        print(f"    Valid: {not att['revoked']}")
+    print()
+
+
+# ─── Example 3: Verify Bundle Integrity ───────────────────────────────────
+
+
+async def example3_verify_bundle_integrity():
+    """Verify bundle integrity and claim types."""
+    print("=== Example 3: Verify Bundle Integrity ===\n")
+
+    client = TrustLinkClient(
+        contract_id=os.getenv("CONTRACT_ID", "C..."),
+        rpc_url="https://soroban-testnet.stellar.org",
+    )
+
+    bundle_id = sys.argv[2] if len(sys.argv) > 2 else "bundle_id_here"
+
+    # Check bundle validity
+    is_valid = client.is_bundle_valid(bundle_id)
+    print(f"Bundle is valid: {is_valid}")
+
+    # Get bundle details
+    bundle = client.get_bundle(bundle_id)
+
+    # Verify expected claim types
+    expected_claims = ["KYC_PASSED", "AGE_VERIFIED", "JURISDICTION_US"]
+    has_expected_claims = verify_bundle_claim_types(bundle, expected_claims)
+    print(f"Has expected claim types: {has_expected_claims}")
+
+    # Verify bundle size
+    expected_size = 3
+    has_expected_size = verify_bundle_size(bundle, expected_size)
+    print(f"Has expected size ({expected_size}): {has_expected_size}\n")
+
+
+# ─── Example 4: Query Bundles ──────────────────────────────────────────────
+
+
+async def example4_query_bundles():
+    """Query bundles by issuer and subject."""
+    print("=== Example 4: Query Bundles ===\n")
+
+    client = TrustLinkClient(
+        contract_id=os.getenv("CONTRACT_ID", "C..."),
+        rpc_url="https://soroban-testnet.stellar.org",
+    )
+
+    issuer_address = os.getenv("ISSUER_ADDRESS", "GBRPYHIL2CI3...")
+    subject_address = os.getenv("SUBJECT_ADDRESS", "GBBD5YHQVW53...")
+
+    # Get all bundles created by issuer
+    issuer_bundles = client.get_issuer_bundles(issuer_address)
+    print(f"Bundles created by issuer: {len(issuer_bundles)}")
+    for bundle_id in issuer_bundles[:5]:
+        print(f"  - {bundle_id}")
+    print()
+
+    # Get all bundles issued to subject
+    subject_bundles = client.get_subject_bundles(subject_address)
+    print(f"Bundles issued to subject: {len(subject_bundles)}")
+    for bundle_id in subject_bundles[:5]:
+        print(f"  - {bundle_id}")
+    print()
+
+
+# ─── Example 5: Compliance Bundle Scenario ────────────────────────────────
+
+
+async def example5_compliance_bundle():
+    """Create a compliance bundle with multiple certifications."""
+    print("=== Example 5: Compliance Bundle Scenario ===\n")
+
+    client = TrustLinkClient(
+        contract_id=os.getenv("CONTRACT_ID", "C..."),
+        rpc_url="https://soroban-testnet.stellar.org",
+    )
+
+    compliance_issuer = os.getenv("COMPLIANCE_ISSUER", "GBRPYHIL2CI3...")
+    organization_address = os.getenv("ORG_ADDRESS", "GBBD5YHQVW53...")
+
+    # Create a compliance bundle with multiple certifications
+    expiration = int((datetime.now() + timedelta(days=365)).timestamp())
+
+    bundle_id = client.create_attestation_bundle(
+        issuer=compliance_issuer,
+        subject=organization_address,
+        claim_types=["SOC_2_CERTIFIED", "ISO_27001_APPROVED", "PCI_DSS_COMPLIANT", "GDPR_COMPLIANT"],
+        expiration=expiration,
+        metadata=json.dumps({
+            "audit_date": datetime.now().isoformat(),
+            "audit_firm": "Big Four Auditor",
+            "compliance_level": "critical_infrastructure",
+        }),
+    )
+
+    print(f"✓ Compliance bundle created: {bundle_id}")
+    print(f"  Contains 4 compliance certifications")
+    print(f"  All issued atomically to ensure consistency\n")
+
+    # Verify the compliance bundle
+    bundle = client.get_bundle(bundle_id)
+    print("Compliance Attestations:")
+    for i, claim_type in enumerate(bundle["claim_types"], 1):
+        print(f"  {i}. {claim_type}")
+        print(f"     ID: {bundle['attestation_ids'][i-1]}")
+    print()
+
+
+# ─── Example 6: Bundle Analysis ────────────────────────────────────────────
+
+
+async def example6_bundle_analysis():
+    """Analyze and group attestations by bundle."""
+    print("=== Example 6: Bundle Analysis ===\n")
+
+    client = TrustLinkClient(
+        contract_id=os.getenv("CONTRACT_ID", "C..."),
+        rpc_url="https://soroban-testnet.stellar.org",
+    )
+
+    subject_address = os.getenv("SUBJECT_ADDRESS", "GBBD5YHQVW53...")
+
+    # Get all bundles for a subject
+    bundle_ids = client.get_subject_bundles(subject_address)
+    print(f"Subject has received {len(bundle_ids)} bundles\n")
+
+    if not bundle_ids:
+        print("No bundles found for this subject")
+        return
+
+    # Analyze each bundle
+    for bundle_id in bundle_ids[:3]:
+        print(f"Bundle: {bundle_id}")
+        bundle = client.get_bundle(bundle_id)
+        summary = get_bundle_summary(bundle)
+
+        print(f"  Issuer: {summary['issuer']}")
+        print(f"  Claims: {', '.join(summary['claim_types'])}")
+        print(f"  Count: {summary['attestation_count']}")
+        print(f"  Valid: {summary['all_valid']}")
+        print(f"  Created: {datetime.fromtimestamp(summary['created_at']).isoformat()}")
+        print()
+
+
+# ─── Example 7: Error Handling ─────────────────────────────────────────────
+
+
+async def example7_error_handling():
+    """Demonstrate error handling."""
+    print("=== Example 7: Error Handling ===\n")
+
+    client = TrustLinkClient(
+        contract_id=os.getenv("CONTRACT_ID", "C..."),
+        rpc_url="https://soroban-testnet.stellar.org",
+    )
+
+    issuer_address = os.getenv("ISSUER_ADDRESS", "GBRPYHIL2CI3...")
+    subject_address = os.getenv("SUBJECT_ADDRESS", "GBBD5YHQVW53...")
+
+    try:
+        # Try to create a bundle with too many claims (should fail)
+        too_many_claims = [f"CLAIM_{i}" for i in range(60)]
+        client.create_attestation_bundle(
+            issuer=issuer_address,
+            subject=subject_address,
+            claim_types=too_many_claims,
+        )
+    except Exception as error:
+        print(f"✓ Caught expected error: {error}")
+        print(f"  Bundle size is limited to 50 attestations\n")
+
+    try:
+        # Try to create a bundle with same issuer and subject (should fail)
+        client.create_attestation_bundle(
+            issuer=issuer_address,
+            subject=issuer_address,  # Same as issuer - invalid
+            claim_types=["CLAIM_TYPE"],
+        )
+    except Exception as error:
+        print(f"✓ Caught expected error: {error}")
+        print(f"  Issuers cannot create attestations for themselves\n")
+
+
+# ─── Main: Run examples ────────────────────────────────────────────────────
+
+
+async def main():
+    """Main entry point for examples."""
+    print("TrustLink Attestation Bundles Examples\n")
+    print("Select an example to run:\n")
+    print("1. Create a KYC Bundle")
+    print("2. Verify Bundle Membership")
+    print("3. Verify Bundle Integrity")
+    print("4. Query Bundles")
+    print("5. Compliance Bundle Scenario")
+    print("6. Bundle Analysis")
+    print("7. Error Handling\n")
+
+    example = sys.argv[1] if len(sys.argv) > 1 else "1"
+
+    try:
+        if example == "1":
+            await example1_create_kyc_bundle()
+        elif example == "2":
+            await example2_verify_bundle_membership()
+        elif example == "3":
+            await example3_verify_bundle_integrity()
+        elif example == "4":
+            await example4_query_bundles()
+        elif example == "5":
+            await example5_compliance_bundle()
+        elif example == "6":
+            await example6_bundle_analysis()
+        elif example == "7":
+            await example7_error_handling()
+        else:
+            print(f"Unknown example: {example}")
+    except Exception as error:
+        print(f"Error: {error}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/bundles/typescript-example.ts
+++ b/examples/bundles/typescript-example.ts
@@ -1,0 +1,272 @@
+/**
+ * TrustLink Attestation Bundles Example (TypeScript)
+ *
+ * This example demonstrates how to create and verify attestation bundles.
+ * Bundles allow issuing multiple related attestations atomically with a shared bundle ID.
+ */
+
+import {
+  TrustLinkClient,
+  createAttestationBundle,
+  getBundleWithAttestations,
+  verifyBundleValidity,
+  verifyAttestationsInSameBundle,
+  verifyBundleClaimTypes,
+  verifyBundleSize,
+  getIssuerBundles,
+  getSubjectBundles,
+} from "@trustlink/contract";
+
+// ─── Example 1: Create a KYC Bundle ────────────────────────────────────────
+
+async function example1_CreateKycBundle() {
+  console.log("=== Example 1: Create a KYC Bundle ===\n");
+
+  const client = new TrustLinkClient({
+    contractId: process.env.CONTRACT_ID || "C...",
+    rpcUrl: "https://soroban-testnet.stellar.org",
+  });
+
+  const issuerAddress = process.env.ISSUER_ADDRESS || "GBRPYHIL2CI3...";
+  const subjectAddress = process.env.SUBJECT_ADDRESS || "GBBD5YHQVW53...";
+
+  // Create a bundle with KYC-related claims
+  const bundleId = await createAttestationBundle(client, {
+    issuer: issuerAddress,
+    subject: subjectAddress,
+    claimTypes: ["KYC_PASSED", "AGE_VERIFIED", "JURISDICTION_US"],
+    expiration: BigInt(Math.floor(Date.now() / 1000)) + BigInt(365 * 24 * 60 * 60),
+    metadata: JSON.stringify({
+      kyc_level: "enhanced",
+      checked_at: new Date().toISOString(),
+      check_method: "video_call",
+    }),
+  });
+
+  console.log(`✓ Bundle created: ${bundleId}`);
+  console.log(`  Contains 3 attestations: KYC_PASSED, AGE_VERIFIED, JURISDICTION_US\n`);
+}
+
+// ─── Example 2: Verify Bundle Membership ──────────────────────────────────
+
+async function example2_VerifyBundleMembership() {
+  console.log("=== Example 2: Verify Bundle Membership ===\n");
+
+  const client = new TrustLinkClient({
+    contractId: process.env.CONTRACT_ID || "C...",
+    rpcUrl: "https://soroban-testnet.stellar.org",
+  });
+
+  const bundleId = process.argv[3] || "bundle_id_here";
+
+  // Get bundle and its attestations
+  const { bundle, attestations } = await getBundleWithAttestations(client, bundleId);
+
+  console.log(`Bundle: ${bundle.id}`);
+  console.log(`  Issuer: ${bundle.issuer}`);
+  console.log(`  Subject: ${bundle.subject}`);
+  console.log(`  Created: ${new Date(Number(bundle.timestamp) * 1000).toISOString()}`);
+  console.log(`  Claim Types: ${bundle.claim_types.join(", ")}`);
+  console.log(`  Attestation Count: ${attestations.length}`);
+  console.log(`  All Valid: ${bundle.all_valid}\n`);
+
+  // Verify all attestations are from the same bundle
+  const commonBundleId = verifyAttestationsInSameBundle(attestations);
+  if (commonBundleId === bundleId) {
+    console.log("✓ All attestations are from the same bundle\n");
+  } else {
+    console.log("✗ Attestations are not all from the same bundle\n");
+  }
+
+  // Show individual attestations
+  console.log("Individual Attestations:");
+  for (const att of attestations) {
+    console.log(`  - ${att.claim_type}: ${att.id}`);
+    console.log(`    Issuer: ${att.issuer}`);
+    console.log(`    Valid: ${!att.revoked}`);
+  }
+  console.log();
+}
+
+// ─── Example 3: Verify Bundle Integrity ───────────────────────────────────
+
+async function example3_VerifyBundleIntegrity() {
+  console.log("=== Example 3: Verify Bundle Integrity ===\n");
+
+  const client = new TrustLinkClient({
+    contractId: process.env.CONTRACT_ID || "C...",
+    rpcUrl: "https://soroban-testnet.stellar.org",
+  });
+
+  const bundleId = process.argv[3] || "bundle_id_here";
+
+  // Check bundle validity
+  const isValid = await verifyBundleValidity(client, bundleId);
+  console.log(`Bundle is valid: ${isValid}`);
+
+  // Get bundle details
+  const bundle = await client.getBundle(bundleId);
+
+  // Verify expected claim types
+  const expectedClaims = ["KYC_PASSED", "AGE_VERIFIED", "JURISDICTION_US"];
+  const hasExpectedClaims = verifyBundleClaimTypes(bundle, expectedClaims);
+  console.log(`Has expected claim types: ${hasExpectedClaims}`);
+
+  // Verify bundle size
+  const expectedSize = 3;
+  const hasExpectedSize = verifyBundleSize(bundle, expectedSize);
+  console.log(`Has expected size (${expectedSize}): ${hasExpectedSize}\n`);
+}
+
+// ─── Example 4: Query Bundles ──────────────────────────────────────────────
+
+async function example4_QueryBundles() {
+  console.log("=== Example 4: Query Bundles ===\n");
+
+  const client = new TrustLinkClient({
+    contractId: process.env.CONTRACT_ID || "C...",
+    rpcUrl: "https://soroban-testnet.stellar.org",
+  });
+
+  const issuerAddress = process.env.ISSUER_ADDRESS || "GBRPYHIL2CI3...";
+  const subjectAddress = process.env.SUBJECT_ADDRESS || "GBBD5YHQVW53...";
+
+  // Get all bundles created by issuer
+  const issuerBundles = await getIssuerBundles(client, issuerAddress);
+  console.log(`Bundles created by issuer: ${issuerBundles.length}`);
+  for (const bundleId of issuerBundles.slice(0, 5)) {
+    console.log(`  - ${bundleId}`);
+  }
+  console.log();
+
+  // Get all bundles issued to subject
+  const subjectBundles = await getSubjectBundles(client, subjectAddress);
+  console.log(`Bundles issued to subject: ${subjectBundles.length}`);
+  for (const bundleId of subjectBundles.slice(0, 5)) {
+    console.log(`  - ${bundleId}`);
+  }
+  console.log();
+}
+
+// ─── Example 5: Compliance Bundle Scenario ────────────────────────────────
+
+async function example5_ComplianceBundle() {
+  console.log("=== Example 5: Compliance Bundle Scenario ===\n");
+
+  const client = new TrustLinkClient({
+    contractId: process.env.CONTRACT_ID || "C...",
+    rpcUrl: "https://soroban-testnet.stellar.org",
+  });
+
+  const complianceIssuer = process.env.COMPLIANCE_ISSUER || "GBRPYHIL2CI3...";
+  const organizationAddress = process.env.ORG_ADDRESS || "GBBD5YHQVW53...";
+
+  // Create a compliance bundle with multiple certifications
+  const bundleId = await createAttestationBundle(client, {
+    issuer: complianceIssuer,
+    subject: organizationAddress,
+    claimTypes: ["SOC_2_CERTIFIED", "ISO_27001_APPROVED", "PCI_DSS_COMPLIANT", "GDPR_COMPLIANT"],
+    expiration: BigInt(Math.floor(Date.now() / 1000)) + BigInt(365 * 24 * 60 * 60),
+    metadata: JSON.stringify({
+      audit_date: new Date().toISOString(),
+      audit_firm: "Big Four Auditor",
+      compliance_level: "critical_infrastructure",
+    }),
+  });
+
+  console.log(`✓ Compliance bundle created: ${bundleId}`);
+  console.log(`  Contains 4 compliance certifications`);
+  console.log(`  All issued atomically to ensure consistency\n`);
+
+  // Verify the compliance bundle
+  const bundle = await client.getBundle(bundleId);
+  console.log("Compliance Attestations:");
+  for (let i = 0; i < bundle.claim_types.length; i++) {
+    console.log(`  ${i + 1}. ${bundle.claim_types[i]}`);
+    console.log(`     ID: ${bundle.attestation_ids[i]}`);
+  }
+  console.log();
+}
+
+// ─── Example 6: Error Handling ────────────────────────────────────────────
+
+async function example6_ErrorHandling() {
+  console.log("=== Example 6: Error Handling ===\n");
+
+  const client = new TrustLinkClient({
+    contractId: process.env.CONTRACT_ID || "C...",
+    rpcUrl: "https://soroban-testnet.stellar.org",
+  });
+
+  const issuerAddress = process.env.ISSUER_ADDRESS || "GBRPYHIL2CI3...";
+  const subjectAddress = process.env.SUBJECT_ADDRESS || "GBBD5YHQVW53...";
+
+  try {
+    // Try to create a bundle with too many claims (should fail)
+    const tooManyClaims = Array.from({ length: 60 }, (_, i) => `CLAIM_${i}`);
+    await createAttestationBundle(client, {
+      issuer: issuerAddress,
+      subject: subjectAddress,
+      claimTypes: tooManyClaims,
+    });
+  } catch (error: any) {
+    console.log(`✓ Caught expected error: ${error.message}`);
+    console.log(`  Bundle size is limited to 50 attestations\n`);
+  }
+
+  try {
+    // Try to create a bundle with same issuer and subject (should fail)
+    await createAttestationBundle(client, {
+      issuer: issuerAddress,
+      subject: issuerAddress, // Same as issuer - invalid
+      claimTypes: ["CLAIM_TYPE"],
+    });
+  } catch (error: any) {
+    console.log(`✓ Caught expected error: ${error.message}`);
+    console.log(`  Issuers cannot create attestations for themselves\n`);
+  }
+}
+
+// ─── Main: Run examples ────────────────────────────────────────────────────
+
+async function main() {
+  console.log("TrustLink Attestation Bundles Examples\n");
+  console.log("Select an example to run:\n");
+  console.log("1. Create a KYC Bundle");
+  console.log("2. Verify Bundle Membership");
+  console.log("3. Verify Bundle Integrity");
+  console.log("4. Query Bundles");
+  console.log("5. Compliance Bundle Scenario");
+  console.log("6. Error Handling\n");
+
+  const example = process.argv[2] || "1";
+
+  try {
+    switch (example) {
+      case "1":
+        await example1_CreateKycBundle();
+        break;
+      case "2":
+        await example2_VerifyBundleMembership();
+        break;
+      case "3":
+        await example3_VerifyBundleIntegrity();
+        break;
+      case "4":
+        await example4_QueryBundles();
+        break;
+      case "5":
+        await example5_ComplianceBundle();
+        break;
+      case "6":
+        await example6_ErrorHandling();
+        break;
+      default:
+        console.log(`Unknown example: ${example}`);
+    }
+  } catch (error) {
+    console.error("Error:", error);
+  }
+}
+
+main();

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -1,0 +1,273 @@
+//! Attestation bundle creation and management.
+//!
+//! Bundles allow issuing multiple related attestations atomically with a shared bundle ID,
+//! enabling verifiers to confirm a set of claims were issued as one coherent unit.
+
+use soroban_sdk::{Env, Address, String, Vec, Bytes};
+
+use crate::attestation::{store_attestation, charge_attestation_fee, check_rate_limit};
+use crate::storage::Storage;
+use crate::types::{
+    Attestation, AttestationBundle, AttestationOrigin, AuditAction, AuditEntry, Error, Validation,
+};
+use crate::validation::{validate_native_expiration, validate_tags, validate_jurisdiction};
+
+/// Maximum number of attestations allowed in a single bundle.
+const MAX_BUNDLE_SIZE: u32 = 50;
+
+/// Generate a deterministic bundle ID from issuer, subject, claim_types, and timestamp.
+pub fn generate_bundle_id(
+    env: &Env,
+    issuer: &Address,
+    subject: &Address,
+    claim_types: &Vec<String>,
+    timestamp: u64,
+) -> String {
+    let mut payload = Bytes::new(env);
+    payload.append(&Bytes::from_slice(env, b"bundle:"));
+    payload.append(&issuer.clone().to_xdr(env));
+    payload.append(&subject.clone().to_xdr(env));
+    
+    // Ensure deterministic ordering by iterating claim_types in order
+    for claim_type in claim_types.iter() {
+        payload.append(&claim_type.clone().to_xdr(env));
+    }
+    
+    payload.append(&timestamp.to_xdr(env));
+    Attestation::hash_payload(env, &payload)
+}
+
+/// Create multiple attestations atomically as a bundle.
+///
+/// All attestations are created in a single transaction with Soroban's atomicity guarantee.
+/// Each attestation is tagged with the same bundle_id, allowing verifiers to confirm they
+/// were issued together. If any claim_type fails validation, the entire bundle fails.
+///
+/// # Arguments
+/// * `env` - Soroban environment
+/// * `issuer` - Address of the issuer (must be authorized)
+/// * `subject` - Address receiving the attestations
+/// * `claim_types` - Ordered list of claim types to issue (determines bundle ID)
+/// * `expiration` - Optional expiration time (applied to all attestations in bundle)
+/// * `metadata` - Optional metadata (can differ per claim type via indexer if needed, or shared)
+/// * `tags` - Optional tags (applied to all attestations)
+///
+/// # Returns
+/// * `Ok(bundle_id)` - The bundle ID on success
+/// * `Err(Error)` - Validation or storage error; entire bundle fails atomically
+pub fn create_attestation_bundle(
+    env: &Env,
+    issuer: Address,
+    subject: Address,
+    claim_types: Vec<String>,
+    expiration: Option<u64>,
+    metadata: Option<String>,
+    tags: Option<Vec<String>>,
+) -> Result<String, Error> {
+    issuer.require_auth();
+    Validation::require_issuer(env, &issuer)?;
+    Validation::require_not_paused(env)?;
+    
+    // Validate bundle size
+    if claim_types.is_empty() || claim_types.len() > MAX_BUNDLE_SIZE as usize {
+        return Err(Error::LimitExceeded);
+    }
+
+    // Validate all claim types are registered before starting
+    for claim_type in claim_types.iter() {
+        Validation::validate_claim_type(claim_type)?;
+        Validation::require_registered_claim_type(env, claim_type)?;
+    }
+
+    // Validate metadata and tags (once, shared for all in bundle)
+    Validation::validate_metadata(env, &metadata)?;
+    Validation::validate_metadata_hash_only(env, &metadata)?;
+    validate_tags(&tags)?;
+    validate_native_expiration(env, expiration)?;
+
+    // Cannot create attestations from issuer to self
+    if issuer == subject {
+        return Err(Error::Unauthorized);
+    }
+
+    // Check whitelist mode
+    if Storage::is_whitelist_mode(env, &issuer) && !Storage::is_whitelisted(env, &issuer, &subject) {
+        return Err(Error::SubjectNotWhitelisted);
+    }
+
+    let timestamp = env.ledger().timestamp();
+    let bundle_id = generate_bundle_id(env, &issuer, &subject, &claim_types, timestamp);
+
+    // Check if bundle already exists (prevent duplicates)
+    if Storage::has_bundle(env, &bundle_id) {
+        return Err(Error::DuplicateAttestation);
+    }
+
+    let limits = Storage::get_limits(env);
+    let issuer_count = Storage::get_issuer_attestations(env, &issuer).len();
+    let subject_count = Storage::get_subject_attestations(env, &subject).len();
+
+    // Verify storage limits can accommodate entire bundle
+    if issuer_count.saturating_add(claim_types.len()) > limits.max_attestations_per_issuer {
+        return Err(Error::LimitExceeded);
+    }
+    if subject_count.saturating_add(claim_types.len()) > limits.max_attestations_per_subject {
+        return Err(Error::LimitExceeded);
+    }
+
+    // Check rate limits for each claim type before creating any attestations
+    for claim_type in claim_types.iter() {
+        check_rate_limit(env, &issuer, claim_type)?;
+    }
+
+    // Build attestation list for the bundle
+    let mut attestation_ids: Vec<String> = Vec::new(env);
+    let mut attestations: Vec<Attestation> = Vec::new(env);
+
+    // Create attestation record for each claim type
+    for claim_type in claim_types.iter() {
+        let attestation_id = Attestation::generate_id(env, &issuer, &subject, claim_type, timestamp);
+
+        // Check for duplicate attestations
+        if Storage::has_attestation(env, &attestation_id) {
+            return Err(Error::DuplicateAttestation);
+        }
+
+        let attestation = Attestation {
+            id: attestation_id.clone(),
+            issuer: issuer.clone(),
+            subject: subject.clone(),
+            claim_type: claim_type.clone(),
+            timestamp,
+            expiration,
+            revoked: false,
+            deleted: false,
+            metadata: metadata.clone(),
+            jurisdiction: None,
+            valid_from: None,
+            origin: AttestationOrigin::Native,
+            source_chain: None,
+            source_tx: None,
+            tags: tags.clone(),
+            revocation_reason: None,
+            bundle_id: Some(bundle_id.clone()),
+        };
+
+        attestations.push_back(attestation);
+        attestation_ids.push_back(attestation_id);
+    }
+
+    // Store all attestations and create bundle metadata
+    let mut new_issuer_ids: Vec<String> = Vec::new(env);
+
+    for attestation in attestations.iter() {
+        // Store attestation with bundle_id
+        store_attestation(env, &attestation);
+        
+        // Add to subject's attestation index
+        Storage::add_subject_attestation(env, &attestation.subject, &attestation.id);
+        Storage::add_valid_attestation(env, &attestation.subject, &attestation.id);
+        crate::storage::ChunkedIndex::add_subject(env, &attestation.subject, &attestation.id);
+
+        // Queue for issuer index batch write
+        new_issuer_ids.push_back(attestation.id.clone());
+
+        // Audit log
+        Storage::append_audit_entry(
+            env,
+            &attestation.id,
+            &AuditEntry {
+                action: AuditAction::Created,
+                actor: issuer.clone(),
+                timestamp,
+                details: Some(format_bundle_audit_detail(env, &bundle_id)),
+            },
+        );
+
+        // Emit individual attestation_created event (for backward compatibility)
+        crate::events::Events::attestation_created(env, &attestation);
+    }
+
+    // Batch write issuer index
+    Storage::add_issuer_attestations_bulk(env, &issuer, &new_issuer_ids);
+    crate::storage::ChunkedIndex::add_issuer_bulk(env, &issuer, &new_issuer_ids);
+
+    // Update stats
+    let bundle_size = attestation_ids.len() as u64;
+    Storage::increment_issuer_stats(env, &issuer, bundle_size);
+    Storage::increment_total_attestations(env, bundle_size);
+
+    // Set issuance timestamps
+    Storage::set_last_issuance_time(env, &issuer, timestamp);
+    for claim_type in claim_types.iter() {
+        if Storage::get_claim_type_rate_limit(env, claim_type).is_some() {
+            Storage::set_last_issuance_time_by_claim_type(env, &issuer, claim_type, timestamp);
+        }
+    }
+
+    // Create bundle metadata record
+    let bundle = AttestationBundle {
+        id: bundle_id.clone(),
+        issuer: issuer.clone(),
+        subject: subject.clone(),
+        claim_types: claim_types.clone(),
+        timestamp,
+        attestation_ids: attestation_ids.clone(),
+        all_valid: true,
+    };
+
+    Storage::set_bundle(env, &bundle);
+    Storage::add_issuer_bundle(env, &issuer, &bundle_id);
+    Storage::add_subject_bundle(env, &subject, &bundle_id);
+
+    // Charge fees for all attestations in the bundle
+    for _ in 0..bundle_size {
+        charge_attestation_fee(env, &issuer)?;
+    }
+
+    // Emit bundle_created event
+    crate::events::Events::bundle_created(env, &bundle);
+
+    Ok(bundle_id)
+}
+
+/// Get all attestations belonging to a bundle.
+pub fn get_bundle_attestations(
+    env: &Env,
+    bundle_id: &String,
+) -> Result<Vec<Attestation>, Error> {
+    let bundle = Storage::get_bundle(env, bundle_id)?;
+
+    let mut attestations: Vec<Attestation> = Vec::new(env);
+    for attestation_id in bundle.attestation_ids.iter() {
+        if let Ok(attestation) = Storage::get_attestation(env, &attestation_id) {
+            attestations.push_back(attestation);
+        }
+    }
+
+    Ok(attestations)
+}
+
+/// Check if all attestations in a bundle are still valid (not revoked).
+pub fn is_bundle_valid(env: &Env, bundle_id: &String) -> Result<bool, Error> {
+    let mut bundle = Storage::get_bundle(env, bundle_id)?;
+
+    for attestation_id in bundle.attestation_ids.iter() {
+        if let Ok(attestation) = Storage::get_attestation(env, &attestation_id) {
+            if attestation.revoked || attestation.deleted {
+                bundle.all_valid = false;
+                Storage::set_bundle(env, &bundle);
+                return Ok(false);
+            }
+        }
+    }
+
+    Ok(bundle.all_valid)
+}
+
+/// Format audit entry details to note bundle membership.
+fn format_bundle_audit_detail(env: &Env, bundle_id: &String) -> String {
+    let mut detail = String::from_str(env, "Created as part of bundle: ");
+    detail.append(bundle_id);
+    detail
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -33,6 +33,7 @@ const TOPIC_WL_ON: Symbol = symbol_short!("wl_on");
 const TOPIC_WL_ADD: Symbol = symbol_short!("wl_add");
 const TOPIC_WL_REM: Symbol = symbol_short!("wl_rem");
 const TOPIC_TPL_DEL: Symbol = symbol_short!("tpl_del");
+const TOPIC_BUNDLE: Symbol = symbol_short!("bundle");
 
 pub struct Events;
 
@@ -483,6 +484,21 @@ impl Events {
         env.events().publish(
             (symbol_short!("tl_start"),),
             (proposal_id, quorum_reached_at),
+        );
+    }
+}
+
+    /// Emitted when a bundle of attestations is created.
+    pub fn bundle_created(env: &Env, bundle: &crate::types::AttestationBundle) {
+        env.events().publish(
+            (TOPIC_BUNDLE, bundle.subject.clone()),
+            (
+                bundle.id.clone(),
+                bundle.issuer.clone(),
+                bundle.claim_types.clone(),
+                bundle.timestamp,
+                bundle.attestation_ids.clone(),
+            ),
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ extern crate std;
 
 mod admin;
 mod attestation;
+mod bundle;
 mod errors;
 mod events;
 mod multisig;
@@ -435,6 +436,18 @@ impl TrustLinkContract {
         expiration: Option<u64>,
     ) -> Result<Vec<String>, Error> {
         attestation::create_attestations_batch(&env, issuer, subjects, claim_type, expiration)
+    }
+
+    pub fn create_attestation_bundle(
+        env: Env,
+        issuer: Address,
+        subject: Address,
+        claim_types: Vec<String>,
+        expiration: Option<u64>,
+        metadata: Option<String>,
+        tags: Option<Vec<String>>,
+    ) -> Result<String, Error> {
+        bundle::create_attestation_bundle(&env, issuer, subject, claim_types, expiration, metadata, tags)
     }
 
     pub fn revoke_attestation(env: Env, issuer: Address, attestation_id: String, reason: Option<String>) -> Result<(), Error> {
@@ -1101,3 +1114,27 @@ impl TrustLinkContract {
         Storage::get_template(&env, &issuer, &template_id).ok_or(Error::NotFound)
     }
 }
+
+    // -----------------------------------------------------------------------
+    // Bundle Queries
+    // -----------------------------------------------------------------------
+
+    pub fn get_bundle(env: Env, bundle_id: String) -> Result<crate::types::AttestationBundle, Error> {
+        Storage::get_bundle(&env, &bundle_id)
+    }
+
+    pub fn get_bundle_attestations(env: Env, bundle_id: String) -> Result<Vec<Attestation>, Error> {
+        bundle::get_bundle_attestations(&env, &bundle_id)
+    }
+
+    pub fn is_bundle_valid(env: Env, bundle_id: String) -> Result<bool, Error> {
+        bundle::is_bundle_valid(&env, &bundle_id)
+    }
+
+    pub fn get_issuer_bundles(env: Env, issuer: Address) -> Vec<String> {
+        Storage::get_issuer_bundles(&env, &issuer)
+    }
+
+    pub fn get_subject_bundles(env: Env, subject: Address) -> Vec<String> {
+        Storage::get_subject_bundles(&env, &subject)
+    }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -66,6 +66,12 @@ pub enum StorageKey {
     ProposalIndex(Address),
     /// Configurable TTL in days for multisig proposals (default: 7).
     MultisigTtl,
+    /// Bundle metadata keyed by bundle ID.
+    AttestationBundle(String),
+    /// List of bundles created by an issuer.
+    IssuerBundles(Address),
+    /// List of bundles issued to a subject.
+    SubjectBundles(Address),
 }
 
 /// Composite key for per-issuer-per-claim-type last issuance timestamps.
@@ -1370,5 +1376,66 @@ impl ChunkedIndex {
 
     pub fn get_issuer_all(env: &Env, issuer: &Address) -> Vec<String> {
         Self::get_issuer_ids(env, issuer)
+    }
+}
+
+    // ── Attestation Bundles ──────────────────────────────────────────────────
+
+    /// Store metadata for a bundle of attestations.
+    pub fn set_bundle(env: &Env, bundle: &crate::types::AttestationBundle) {
+        let key = StorageKey::AttestationBundle(bundle.id.clone());
+        let ttl = get_ttl_lifetime(env);
+        env.storage().persistent().set(&key, bundle);
+        env.storage().persistent().extend_ttl(&key, ttl, ttl);
+    }
+
+    /// Retrieve bundle metadata by ID.
+    pub fn get_bundle(env: &Env, bundle_id: &String) -> Option<crate::types::AttestationBundle> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::AttestationBundle(bundle_id.clone()))
+    }
+
+    /// Check if a bundle exists.
+    pub fn has_bundle(env: &Env, bundle_id: &String) -> bool {
+        env.storage()
+            .persistent()
+            .has(&StorageKey::AttestationBundle(bundle_id.clone()))
+    }
+
+    /// Add a bundle ID to an issuer's bundle list.
+    pub fn add_issuer_bundle(env: &Env, issuer: &Address, bundle_id: &String) {
+        let key = StorageKey::IssuerBundles(issuer.clone());
+        let ttl = get_ttl_lifetime(env);
+        let mut list: Vec<String> = env.storage().persistent().get(&key).unwrap_or(Vec::new(env));
+        list.push_back(bundle_id.clone());
+        env.storage().persistent().set(&key, &list);
+        env.storage().persistent().extend_ttl(&key, ttl, ttl);
+    }
+
+    /// Get list of all bundles created by an issuer.
+    pub fn get_issuer_bundles(env: &Env, issuer: &Address) -> Vec<String> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::IssuerBundles(issuer.clone()))
+            .unwrap_or(Vec::new(env))
+    }
+
+    /// Add a bundle ID to a subject's bundle list.
+    pub fn add_subject_bundle(env: &Env, subject: &Address, bundle_id: &String) {
+        let key = StorageKey::SubjectBundles(subject.clone());
+        let ttl = get_ttl_lifetime(env);
+        let mut list: Vec<String> = env.storage().persistent().get(&key).unwrap_or(Vec::new(env));
+        list.push_back(bundle_id.clone());
+        env.storage().persistent().set(&key, &list);
+        env.storage().persistent().extend_ttl(&key, ttl, ttl);
+    }
+
+    /// Get list of all bundles issued to a subject.
+    pub fn get_subject_bundles(env: &Env, subject: &Address) -> Vec<String> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::SubjectBundles(subject.clone()))
+            .unwrap_or(Vec::new(env))
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -256,6 +256,29 @@ pub struct Attestation {
     pub tags: Option<Vec<String>>,
     pub revocation_reason: Option<String>,
     pub deleted: bool,
+    /// Optional: shared bundle ID if this attestation was created as part of a bundle.
+    /// Allows verifiers to confirm a set of claims were issued atomically.
+    pub bundle_id: Option<String>,
+}
+
+/// Metadata for a bundle of attestations issued atomically.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AttestationBundle {
+    /// Unique bundle identifier (SHA256 of issuer + subject + claim_types + timestamp)
+    pub id: String,
+    /// Issuer who created the bundle
+    pub issuer: Address,
+    /// Subject to whom all attestations in the bundle were issued
+    pub subject: Address,
+    /// List of claim types in the bundle (fixed order for deterministic ID)
+    pub claim_types: Vec<String>,
+    /// Timestamp when the bundle was created
+    pub timestamp: u64,
+    /// IDs of all attestations in this bundle (in same order as claim_types)
+    pub attestation_ids: Vec<String>,
+    /// Whether all attestations in the bundle are still valid (none revoked)
+    pub all_valid: bool,
 }
 
 #[contracttype]


### PR DESCRIPTION
### Summary

Added support for atomic attestation bundles, enabling multiple related claims to be issued together and linked with a shared bundle ID.

### Changes

* Introduced `create_attestation_bundle` to issue multiple attestations in a single transaction.
* Assigned a shared bundle ID to all attestations created within the same bundle for correlation.
* Leveraged Soroban transaction atomicity to ensure all claims are issued together or none are created.
* Added tests verifying atomic bundle creation and bundle ID validation across related attestations.

### Result

This PR enables coherent, atomic issuance of related credential claims, allowing verifiers to confirm that multiple attestations originated from the same trusted issuance event.

Closes #1031 