### PR TITLE
chore: add error-variant CI check, docs index, LICENSE, and code of conduct

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,16 @@ jobs:
       - name: Run cargo audit
         run: cargo audit --deny warnings
 
+  enum-completeness:
+    name: Enum Completeness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Verify Error variants referenced in src/ are defined
+        run: python3 scripts/check_error_variants.py
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**conduct@trustlink.io**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thanks for your interest in contributing! This guide covers everything you need to go from zero to a merged PR.
 
+Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md). Reports of unacceptable behavior can be sent to **conduct@trustlink.io**.
+
 ## Local Development Setup
 
 TrustLink uses [pre-commit](https://pre-commit.com) to enforce formatting and linting before every commit.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024–2026 TrustLink contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ endif
         deploy invoke \
         testnet mainnet local \
         bindings check-bindings \
-        check-size check-wasm-size rollback \
+        check-size check-wasm-size check-error-variants rollback \
         indexer-dev indexer-build indexer-logs \
         changelog-preview test-changelog-preview \
         help
@@ -95,6 +95,7 @@ help:
 	@echo "make rollback       - Redeploy a verified WASM hash to a specified network"
 	@echo "make bindings       - Generate TypeScript bindings from compiled WASM"
 	@echo "make check-bindings - Fail if committed bindings are out of date"
+	@echo "make check-error-variants - Fail if Error::Variant refs in src/ are undefined"
 	@echo "make deploy         - Build, optimize, and deploy to NETWORK (default: testnet)"
 	@echo "                      Requires: ADMIN_SECRET=<secret>  SOURCE=<key-alias>"
 	@echo "                      Example:  make deploy NETWORK=testnet SOURCE=deployer"
@@ -244,6 +245,10 @@ check-bindings: bindings
 	@echo "Checking bindings are up to date..."
 	git diff --exit-code bindings/typescript/ || \
 		(echo "ERROR: TypeScript bindings are out of date. Run 'make bindings' and commit the result." && exit 1)
+
+## Fail if any Error::Variant reference in src/ is missing from src/errors.rs
+check-error-variants:
+	python3 scripts/check_error_variants.py
 
 # ── Signing key alias (used by deploy and verify) ─────────────────────────────
 # SOURCE is the stellar key alias (not the raw secret) passed to stellar CLI.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![CI](https://github.com/afurious/TrustLink/actions/workflows/ci.yml/badge.svg)](https://github.com/afurious/TrustLink/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/afurious/TrustLink/branch/main/graph/badge.svg)](https://codecov.io/gh/afurious/TrustLink)
 [![Security Audit](https://img.shields.io/badge/Security%20Audit-In%20Progress-yellow)](./AUDIT_SCOPE.md)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+
+**[Documentation index](docs/README.md)** · **[Contributing](CONTRIBUTING.md)** · **[Code of Conduct](CODE_OF_CONDUCT.md)** · **[License](LICENSE)**
 
 TrustLink is a Soroban smart contract that provides a reusable trust layer for the Stellar blockchain. It enables trusted issuers, bridge contracts, and administrators to create, import, manage, and revoke attestations about wallet addresses, allowing other contracts and applications to verify claims before executing financial operations.
 
@@ -10,7 +13,7 @@ TrustLink is a Soroban smart contract that provides a reusable trust layer for t
 
 TrustLink solves the problem of decentralized identity verification and trust establishment on-chain. Instead of each application building its own KYC/verification system, TrustLink provides a shared attestation infrastructure that can be queried by any smart contract or dApp.
 
-**New here? Start with the [5-Minute Quickstart](docs/quickstart.md)** — go from zero to verifying a testnet attestation using only the TypeScript SDK, in under 15 commands.
+**New here? Start with the [5-Minute Quickstart](docs/quickstart.md)** — go from zero to verifying a testnet attestation using only the TypeScript SDK, in under 15 commands. Browse the full docs catalog in the **[documentation index](docs/README.md)**.
 
 ### Key Features
 
@@ -1063,7 +1066,7 @@ A blank [template](docs/adr/ADR-000-template.md) is available for new decisions.
 
 ## License
 
-MIT
+This project is licensed under the [MIT License](LICENSE).
 
 ## Changelog
 
@@ -1071,7 +1074,7 @@ See [CHANGELOG.md](CHANGELOG.md) for a history of notable changes.
 
 ## Contributing
 
-Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, code style requirements, and the PR process.
+Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, code style requirements, and the PR process. By participating, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Support
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,76 @@
+# TrustLink Documentation
+
+Index of project docs. Architecture Decision Records live under [`adr/`](adr/) and have [their own index](adr/README.md).
+
+## Getting started
+
+| Doc | Description |
+|-----|-------------|
+| [quickstart.md](quickstart.md) | 5-minute path from zero to a verified testnet attestation |
+| [stellar-concepts.md](stellar-concepts.md) | Stellar & Soroban basics for new contributors |
+| [glossary.md](glossary.md) | Domain terms (attestation, issuer, subject, bridge, etc.) |
+| [integration-guide.md](integration-guide.md) | Integrating TrustLink from Rust and TypeScript |
+| [migration-guide.md](migration-guide.md) | Upgrading across TrustLink versions |
+| [troubleshooting.md](troubleshooting.md) | Common failures and FAQ |
+| [e2e-request-flow-guide.md](e2e-request-flow-guide.md) | End-to-end attestation request flow walkthrough |
+| [video-tutorial-guide.md](video-tutorial-guide.md) | Companion commands and snippets for the video tutorial |
+| [video-tutorial-script.md](video-tutorial-script.md) | Narration script for the TrustLink video tutorial |
+
+## Architecture
+
+| Doc | Description |
+|-----|-------------|
+| [architecture.md](architecture.md) | High-level system design and component overview |
+| [storage-layout.md](storage-layout.md) | On-chain storage keys, TTL policy, and RPC read examples |
+| [storage-backward-compatibility.md](storage-backward-compatibility.md) | Keeping storage layouts compatible across upgrades |
+| [storage-migration-issue-266-attestation-origin.md](storage-migration-issue-266-attestation-origin.md) | Migration plan for attestation origin (issue #266) |
+| [formal/README.md](formal/README.md) | Formal specifications overview |
+| [formal/VERIFICATION.md](formal/VERIFICATION.md) | How to run and interpret formal verification |
+| [formal/multisig_state_machine.md](formal/multisig_state_machine.md) | Multi-sig proposal lifecycle specification |
+| [formal/multisig_state_machine.tla](formal/multisig_state_machine.tla) | TLA+ model of the multi-sig state machine |
+| [formal/Makefile](formal/Makefile) | Make targets for formal specs |
+| [formal/check-spec.sh](formal/check-spec.sh) | Helper script to check formal specs |
+
+## Security & compliance
+
+| Doc | Description |
+|-----|-------------|
+| [security.md](security.md) | Trust hierarchy, threat model, and security model |
+| [security-review.md](security-review.md) | Pre-audit findings and remediation status |
+| [bug-bounty.md](bug-bounty.md) | Bug bounty scope, severity tiers, and safe harbor |
+| [compliance.md](compliance.md) | GDPR / privacy considerations (erasure, minimization) |
+| [dependency-security.md](dependency-security.md) | Dependency review and supply-chain policy |
+| [reentrancy-audit.md](reentrancy-audit.md) | Reentrancy review notes for TrustLink |
+| [sanctions-screening.md](sanctions-screening.md) | Sanctions and PEP screening integration guidance |
+| [slsa-provenance.md](slsa-provenance.md) | Verifying build provenance (SLSA) |
+
+## Operations
+
+| Doc | Description |
+|-----|-------------|
+| [mainnet-checklist.md](mainnet-checklist.md) | Pre-mainnet deployment checklist |
+| [mainnet-runbook.md](mainnet-runbook.md) | Mainnet deployment runbook |
+| [monitoring.md](monitoring.md) | Event streaming and alerting |
+| [key-rotation-runbook.md](key-rotation-runbook.md) | Rotating admin and operational keys |
+| [disaster-recovery.md](disaster-recovery.md) | Disaster recovery procedures |
+| [disaster-recovery-drill-results.md](disaster-recovery-drill-results.md) | DR drill results and evidence |
+| [canary-deployment.md](canary-deployment.md) | Canary deployment strategy for the indexer |
+| [rpc-failover-list.md](rpc-failover-list.md) | Recommended RPC provider failover list |
+| [release-workflow.md](release-workflow.md) | Release Please / conventional-commit release flow |
+| [indexer-idempotency.md](indexer-idempotency.md) | Indexer idempotency and event resilience |
+| [performance.md](performance.md) | Contract performance benchmarks and storage costs |
+| [performance-load-testing.md](performance-load-testing.md) | Indexer GraphQL API load testing |
+| [mutation-testing.md](mutation-testing.md) | Mutation testing guide |
+| [snapshot-testing.md](snapshot-testing.md) | Snapshot testing for contract behaviour |
+
+## SDKs & bindings
+
+| Doc | Description |
+|-----|-------------|
+| [bindings-generation.md](bindings-generation.md) | Generating and updating TypeScript contract bindings |
+
+## Architecture Decision Records
+
+Significant design choices are recorded as ADRs. See the full index:
+
+**[docs/adr/README.md](adr/README.md)**

--- a/scripts/check_error_variants.py
+++ b/scripts/check_error_variants.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Verify every Error::Variant reference in src/ is defined in src/errors.rs.
+
+Companion to StorageKey completeness checks: catches the same class of
+"referenced but never defined" breakage for contract Error variants.
+
+Exit 0 on success; exit 1 and print missing variants on failure.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+ERRORS_RS = SRC / "errors.rs"
+
+# Match enum variant definitions: `VariantName = N,` (with optional doc comments above).
+VARIANT_DEF = re.compile(r"^\s*([A-Z][A-Za-z0-9]*)\s*=\s*\d+\s*,?\s*$", re.MULTILINE)
+
+# Match Error::Variant in code and docs (Error::X, types::Error::X, crate::types::Error::X).
+VARIANT_REF = re.compile(
+    r"(?:(?:crate::)?(?:types::)?)?Error::([A-Z][A-Za-z0-9]*)"
+)
+
+
+def defined_variants(text: str) -> set[str]:
+    return set(VARIANT_DEF.findall(text))
+
+
+def referenced_variants(src_dir: Path) -> dict[str, list[str]]:
+    """Map variant name -> list of 'path:line' locations (excluding errors.rs defs)."""
+    refs: dict[str, list[str]] = {}
+    for path in sorted(src_dir.rglob("*.rs")):
+        if path.resolve() == ERRORS_RS.resolve():
+            continue
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            for match in VARIANT_REF.finditer(line):
+                name = match.group(1)
+                rel = path.relative_to(ROOT)
+                refs.setdefault(name, []).append(f"{rel}:{lineno}")
+    return refs
+
+
+def main() -> int:
+    if not ERRORS_RS.is_file():
+        print(f"error: missing {ERRORS_RS}", file=sys.stderr)
+        return 1
+
+    defined = defined_variants(ERRORS_RS.read_text(encoding="utf-8"))
+    if not defined:
+        print("error: no Error variants found in src/errors.rs", file=sys.stderr)
+        return 1
+
+    refs = referenced_variants(SRC)
+    missing = sorted(name for name in refs if name not in defined)
+
+    print(f"Defined Error variants: {len(defined)}")
+    print(f"Referenced Error variants: {len(refs)}")
+
+    if missing:
+        print("\nERROR: Error variants referenced in src/ but not defined in src/errors.rs:\n")
+        for name in missing:
+            print(f"  Error::{name}")
+            for loc in refs[name][:5]:
+                print(f"    - {loc}")
+            if len(refs[name]) > 5:
+                print(f"    - ... and {len(refs[name]) - 5} more")
+        print(
+            "\nAdd the missing variant(s) to the Error enum in src/errors.rs "
+            "(or fix the reference)."
+        )
+        return 1
+
+    print("OK: every Error::Variant reference in src/ resolves to a defined variant.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -55,4 +55,32 @@ pub enum Error {
     LimitExceeded = 29,
     /// The proposal has been cancelled by the proposer.
     ProposalCancelled = 30,
+    /// A pending attestation request already exists for this subject/issuer/claim.
+    DuplicateRequest = 31,
+    /// The attestation request was already fulfilled, rejected, or cancelled.
+    RequestAlreadyProcessed = 32,
+    /// The attestation request TTL has elapsed.
+    RequestExpired = 33,
+    /// Metadata is present but is not a valid hex-encoded hash (when hash-only mode is on).
+    InvalidMetadata = 34,
+    /// Metadata does not satisfy the claim type's registered constraints.
+    ConstraintViolation = 35,
+    /// Claim type is not in the registry when registration is required.
+    NotRegisteredClaimType = 36,
+    /// Cannot remove the last remaining admin from the council.
+    LastAdminCannotBeRemoved = 37,
+    /// Issuer cannot delegate a claim type to themselves.
+    CannotDelegateToSelf = 38,
+    /// The admin-council proposal has already been executed.
+    CouncilProposalExecuted = 39,
+    /// The admin has already approved this council proposal.
+    AlreadyApproved = 40,
+    /// The council proposal timelock has not elapsed yet.
+    TimelockNotReady = 41,
+    /// No active dispute exists for this attestation.
+    NotDisputed = 42,
+    /// A dispute is already open for this attestation.
+    AlreadyDisputed = 43,
+    /// The configured fee token address is invalid or unusable.
+    InvalidFeeToken = 45,
 }


### PR DESCRIPTION
closes #989 
closes #990 
closes #991 
closes #993

## Summary

Closes four audit follow-ups: a CI guard for undefined `Error` variants, a docs index, a root MIT license, and a Contributor Covenant code of conduct.

### Task 1 — Error variant completeness check
- Added `scripts/check_error_variants.py`, which scans `src/**/*.rs` for `Error::Variant` / `types::Error::Variant` references and asserts each exists in `src/errors.rs`.
- Wired into CI as the `enum-completeness` job in `.github/workflows/ci.yml`, and as `make check-error-variants`.
- Defined the 14 previously referenced-but-missing variants in `src/errors.rs` (codes 31–43, 45) so the new guard is green and would have caught the audit breakage going forward. Pairs with the separate StorageKey completeness check.

### Task 2 — Docs index
- Added `docs/README.md` organizing all non-ADR docs by category (getting started, architecture, security & compliance, operations, SDKs) with one-line descriptions.
- Linked ADRs to the existing `docs/adr/README.md` index (ADR files themselves are excluded from this index per acceptance criteria).
- Linked the index from the top of the root README and the overview section.
- Coverage: every file under `docs/` except `docs/adr/` is reachable from `docs/README.md` (42 files).

### Task 3 — LICENSE
- Added root `LICENSE` (MIT), matching `Cargo.toml` (`license = "MIT"`) and common Soroban/Stellar practice.
- No per-file SPDX headers were added — the repo has no existing SPDX convention.
- Linked from the README top section (badge + nav) and the License section.

### Task 4 — Code of Conduct
- Added `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1).
- Enforcement contact: `conduct@trustlink.io`.
- Linked from `CONTRIBUTING.md` (top) and the root README (nav + Contributing section).

## Test plan
- [ ] `python3 scripts/check_error_variants.py` (or `make check-error-variants`) exits 0
- [ ] Temporarily reference `Error::FakeVariant` in `src/` and confirm the script fails
- [ ] Confirm CI job `Enum Completeness` appears in the workflow
- [ ] Spot-check `docs/README.md` links; confirm no non-ADR doc is missing
- [ ] Confirm `LICENSE` and `CODE_OF_CONDUCT.md` exist at repo root and are linked from README / CONTRIBUTING