### PR TITLE
fix: enforce require_not_paused in cancel_multisig_proposal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -820,6 +820,7 @@ impl TrustLinkContract {
         proposal_id: String,
     ) -> Result<(), Error> {
         proposer.require_auth();
+        Validation::require_not_paused(&env)?;
 
         let mut proposal = Storage::get_multisig_proposal(&env, &proposal_id)?;
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -4470,6 +4470,35 @@ mod pause_tests {
         let result = client.try_propose_attestation(&issuer, &subject, &claim, &required, &2);
         assert_eq!(result, Err(Ok(Error::ContractPaused)));
     }
+
+    /// Issue #950: cancel_multisig_proposal was missing the require_not_paused
+    /// check that every other mutating entry point performs, so a paused
+    /// contract could still have its open proposals cancelled.
+    #[test]
+    fn test_paused_blocks_cancel_multisig_proposal() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, issuer, client) = setup(&env);
+        let issuer2 = Address::generate(&env);
+        client.register_issuer(&admin, &issuer2);
+
+        let subject = Address::generate(&env);
+        let claim = String::from_str(&env, "KYC_PASSED");
+        let mut required = soroban_sdk::Vec::new(&env);
+        required.push_back(issuer.clone());
+        required.push_back(issuer2.clone());
+
+        let proposal_id = client.propose_attestation(&issuer, &subject, &claim, &required, &2);
+
+        client.pause(&admin);
+
+        let result = client.try_cancel_multisig_proposal(&issuer, &proposal_id);
+        assert_eq!(result, Err(Ok(Error::ContractPaused)));
+
+        // Proposal must remain uncancelled while the contract is paused.
+        let proposal = client.get_multisig_proposal(&proposal_id);
+        assert!(!proposal.cancelled);
+    }
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Closes #950.

`cancel_multisig_proposal` was the only mutating entry point audited alongside `create_attestation`, `revoke_attestation`, `propose_attestation`, and `delegate` that was missing the `Validation::require_not_paused` guard those functions call as one of their first checks. As a result, an admin-initiated contract pause did not block proposal cancellation, which is inconsistent with the documented "pause blocks all write operations" guarantee already covered for other entry points (#326).

## Changes

- Add `Validation::require_not_paused(&env)?;` to `cancel_multisig_proposal` in `src/lib.rs`, in the same position (right after `require_auth()`) used by every other mutating function.
- Extend the existing `pause_tests` module in `src/test.rs` with `test_paused_blocks_cancel_multisig_proposal`, which creates a proposal, pauses the contract, asserts `cancel_multisig_proposal` returns `Error::ContractPaused`, and asserts the proposal remains uncancelled.

## Test plan

- [x] Added `test_paused_blocks_cancel_multisig_proposal` to `src/test.rs::pause_tests`, mirroring the existing pattern used by the other pause tests in that module.
