### PR TITLE
docs: document generate_id same-second collision behavior + test

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -1972,6 +1972,51 @@ fn test_id_determinism_same_inputs_same_id() {
     assert_eq!(id1, id2, "identical inputs must always produce the same ID");
 }
 
+/// Issue #951: `generate_id`'s second-granularity timestamp means two
+/// distinct, legitimate creation attempts for the same
+/// (issuer, subject, claim_type) triple collide if they land in the same
+/// ledger-close second — e.g. a direct `create_attestation` call racing a
+/// `fulfill_request` call for the same underlying claim. This test
+/// demonstrates that documented behavior, plus the documented workaround
+/// (retrying on a later ledger).
+#[test]
+fn test_same_second_collision_between_direct_create_and_fulfilled_request() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, issuer, client) = setup(&env);
+    let subject = Address::generate(&env);
+    let claim_type = String::from_str(&env, "KYC_PASSED");
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+
+    // Subject requests an attestation from the issuer.
+    let request_id = client.request_attestation(&subject, &issuer, &claim_type);
+
+    // In the same ledger-close second, the issuer separately creates a
+    // native attestation for the same (issuer, subject, claim_type) triple —
+    // a genuinely distinct action, unrelated to the pending request.
+    client.create_attestation(&issuer, &subject, &claim_type, &None, &None, &None);
+
+    // Fulfilling the request now derives the *same* ID (same issuer,
+    // subject, claim_type, and second), so it collides with the attestation
+    // created above and is rejected — even though it is not a retry of the
+    // same action.
+    let result = client.try_fulfill_request(&issuer, &request_id, &None);
+    assert_eq!(result, Err(Ok(types::Error::DuplicateAttestation)));
+
+    // The pending request itself is untouched by the failed fulfillment.
+    assert_eq!(client.get_request(&request_id).status, types::RequestStatus::Pending);
+
+    // Documented workaround: retrying on the next ledger changes the
+    // timestamp fed into generate_id, so a fresh request/fulfill pair for
+    // the same triple no longer collides.
+    env.ledger().with_mut(|li| li.timestamp = 1_001);
+    let request_id_2 = client.request_attestation(&subject, &issuer, &claim_type);
+    let fulfilled_id = client.fulfill_request(&issuer, &request_id_2, &None);
+    assert_eq!(client.get_attestation(&fulfilled_id).issuer, issuer);
+}
+
 /// No collisions across 100 generated IDs (varying subjects, issuers, claim types, timestamps).
 #[test]
 fn test_id_no_collisions_across_100_combinations() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -461,6 +461,36 @@ impl Attestation {
         String::from_bytes(env, &hex)
     }
 
+    /// Derives a deterministic attestation ID from `(issuer, subject, claim_type, timestamp)`.
+    ///
+    /// # Same-second collisions (issue #951)
+    ///
+    /// `timestamp` is the Stellar ledger close time, which has **second**
+    /// granularity. Two distinct creation attempts for the same
+    /// `(issuer, subject, claim_type)` triple that land in the same
+    /// ledger-close second — for example, a direct [`create_attestation`]
+    /// call racing a [`fulfill_request`] call for the same underlying claim —
+    /// derive the *same* ID. Whichever call is applied first succeeds; the
+    /// second is rejected with [`Error::DuplicateAttestation`], even though
+    /// from the caller's perspective these may be two genuinely different
+    /// attestation attempts rather than a retry of the same one.
+    ///
+    /// This is a deliberate trade-off: the ID intentionally excludes fields
+    /// like `metadata` so that it stays fully derivable off-chain (e.g. by
+    /// [`crate::attestation::simulate_create_attestation`]) from only the
+    /// four inputs above, and so that legitimate retries of the *same*
+    /// attempt are naturally idempotent rather than creating duplicates. No
+    /// nonce is added, since that would make the ID non-deterministic from
+    /// the caller's point of view and break that off-chain derivability.
+    ///
+    /// If a caller genuinely needs two distinct attestations for the same
+    /// triple within one ledger-close second, they must vary `claim_type`
+    /// (e.g. suffix it with a synthetic differentiator) or retry on the next
+    /// ledger, which advances `timestamp`. `metadata` cannot be used as a
+    /// differentiator, since it is not part of the hashed payload.
+    ///
+    /// [`create_attestation`]: crate::attestation::create_attestation
+    /// [`fulfill_request`]: crate::request::fulfill_request
     pub fn generate_id(
         env: &Env,
         issuer: &Address,


### PR DESCRIPTION
## Summary

Closes #951.

`Attestation::generate_id` derives a deterministic ID from `(issuer, subject, claim_type, timestamp)`, where `timestamp` is the Stellar ledger close time — second granularity. Two legitimate, distinct creation attempts for the same `(issuer, subject, claim_type)` triple within the same ledger-close second (e.g. a direct `create_attestation` call racing a `fulfill_request` call for the same underlying claim) collide and the second fails with `DuplicateAttestation`, even though these may be two genuinely different attestation attempts rather than a retry of the same one.

## Why documentation instead of a nonce

A nonce would resolve the collision, but `generate_id`'s inputs are relied on elsewhere to be fully derivable off-chain from just `(issuer, subject, claim_type, timestamp)` — most notably `simulate_create_attestation`, which lets UIs predict the ID before submitting a transaction. Adding a nonce (nondeterministic or storage-backed) would break that derivability and the existing on-chain ID format for very little practical benefit, since true same-second collisions require two distinct actions to land in the same ~5s ledger close, and are already fully recoverable (retry next ledger).

## Changes

- `src/types.rs`: add a detailed doc comment on `Attestation::generate_id` explaining the collision, why it's a deliberate trade-off, and what callers should do if they hit it (vary `claim_type`, or retry on a later ledger — `metadata` cannot be used as a differentiator since it isn't part of the hashed payload, correcting the original issue's suggested workaround).
- `src/test.rs`: add `test_same_second_collision_between_direct_create_and_fulfilled_request`, which reproduces the exact race from the issue (a pending request fulfilled after a same-second direct `create_attestation` for the same triple) and demonstrates the documented workaround (retrying on the next ledger succeeds).

## Test plan

- [x] Added `test_same_second_collision_between_direct_create_and_fulfilled_request`, which asserts the collision returns `Error::DuplicateAttestation`, that the pending request is left untouched, and that retrying one ledger later succeeds.
