### PR TITLE
feat: add version compatibility guard for state-changing entry points

### DIFF
--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -342,6 +342,28 @@ pub fn create_attestation_valid_from(
     create_attestation_internal(env, issuer, subject, claim_type, expiration, metadata, None, tags, Some(valid_from))
 }
 
+/// Same as [`create_attestation`], but demonstrates the version-guard
+/// pattern from issue #952: if `expected_version` is `Some`, it must match
+/// the contract's currently deployed version (as returned by `get_version()`)
+/// or the call is rejected with `Error::VersionMismatch` before any other
+/// validation runs. Passing `None` behaves exactly like `create_attestation`.
+///
+/// See [`crate::validation::Validation::require_version_match`] for the full
+/// pattern documentation aimed at SDK authors.
+pub fn create_attestation_versioned(
+    env: &Env,
+    issuer: Address,
+    subject: Address,
+    claim_type: String,
+    expiration: Option<u64>,
+    metadata: Option<String>,
+    tags: Option<Vec<String>>,
+    expected_version: Option<String>,
+) -> Result<String, Error> {
+    Validation::require_version_match(env, &expected_version)?;
+    create_attestation_internal(env, issuer, subject, claim_type, expiration, metadata, None, tags, None)
+}
+
 pub fn create_attestation_jurisdiction(
     env: &Env,
     issuer: Address,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -55,4 +55,9 @@ pub enum Error {
     LimitExceeded = 29,
     /// The proposal has been cancelled by the proposer.
     ProposalCancelled = 30,
+    /// The caller's `expected_version` argument does not match the contract's
+    /// currently deployed version, as returned by `get_version()`. Returned
+    /// by state-changing entry points that opt into the version-guard
+    /// pattern documented on [`crate::validation::Validation::require_version_match`].
+    VersionMismatch = 31,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,6 +391,31 @@ impl TrustLinkContract {
         attestation::create_attestation_valid_from(&env, issuer, subject, claim_type, expiration, metadata, tags, valid_from)
     }
 
+    /// Same as `create_attestation`, but demonstrates the version-guard
+    /// pattern from issue #952. When `expected_version` is `Some`, it is
+    /// checked against `get_version()` before any other validation runs; a
+    /// mismatch returns `Error::VersionMismatch` instead of proceeding with
+    /// possibly-different semantics than the caller assumed. Pass `None` to
+    /// skip the check.
+    ///
+    /// # Errors
+    /// - [`Error::VersionMismatch`] — `expected_version` is `Some` and does
+    ///   not match the contract's currently deployed version.
+    pub fn create_attestation_versioned(
+        env: Env,
+        issuer: Address,
+        subject: Address,
+        claim_type: String,
+        expiration: Option<u64>,
+        metadata: Option<String>,
+        tags: Option<Vec<String>>,
+        expected_version: Option<String>,
+    ) -> Result<String, Error> {
+        attestation::create_attestation_versioned(
+            &env, issuer, subject, claim_type, expiration, metadata, tags, expected_version,
+        )
+    }
+
     pub fn create_attestation_jurisdiction(
         env: Env,
         issuer: Address,

--- a/src/test.rs
+++ b/src/test.rs
@@ -515,6 +515,75 @@ fn test_create_attestation_rejects_self_attestation() {
     assert_eq!(client.get_subject_attestations(&issuer, &0, &10).len(), 0);
 }
 
+// ── Issue #952: client version-compatibility guard ───────────────────────────
+
+#[test]
+fn test_create_attestation_versioned_accepts_matching_expected_version() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, issuer, client) = setup(&env);
+    let subject = Address::generate(&env);
+    let claim_type = String::from_str(&env, "KYC_PASSED");
+
+    let deployed_version = client.get_version();
+
+    let id = client.create_attestation_versioned(
+        &issuer,
+        &subject,
+        &claim_type,
+        &None,
+        &None,
+        &None,
+        &Some(deployed_version),
+    );
+    assert_eq!(client.get_attestation(&id).issuer, issuer);
+}
+
+#[test]
+fn test_create_attestation_versioned_accepts_no_expected_version() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, issuer, client) = setup(&env);
+    let subject = Address::generate(&env);
+    let claim_type = String::from_str(&env, "KYC_PASSED");
+
+    // Backward compatible: omitting expected_version skips the guard entirely.
+    let id = client.create_attestation_versioned(
+        &issuer, &subject, &claim_type, &None, &None, &None, &None,
+    );
+    assert_eq!(client.get_attestation(&id).issuer, issuer);
+}
+
+#[test]
+fn test_create_attestation_versioned_rejects_mismatched_expected_version() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, issuer, client) = setup(&env);
+    let subject = Address::generate(&env);
+    let claim_type = String::from_str(&env, "KYC_PASSED");
+
+    let stale_version = String::from_str(&env, "0.0.1-stale");
+    let deployed_version = client.get_version();
+    assert_ne!(stale_version, deployed_version);
+
+    let result = client.try_create_attestation_versioned(
+        &issuer,
+        &subject,
+        &claim_type,
+        &None,
+        &None,
+        &None,
+        &Some(stale_version),
+    );
+    assert_eq!(result, Err(Ok(types::Error::VersionMismatch)));
+
+    // Nothing was created as a result of the rejected call.
+    assert_eq!(client.get_subject_attestations(&subject, &0, &10).len(), 0);
+}
+
 #[test]
 fn test_create_attestation_rejects_past_expiration() {
     let env = Env::default();

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -90,6 +90,51 @@ impl Validation {
         Ok(())
     }
 
+    /// Pre-flight interface/version compatibility guard for state-changing
+    /// entry points (issue #952).
+    ///
+    /// `get_version()`/`get_contract_metadata()` expose the deployed
+    /// contract's version, but nothing on the write path previously
+    /// validated a caller's *expected* version before executing a
+    /// state-changing call. After a contract upgrade that changes a
+    /// function's argument shape or semantics, an out-of-date SDK could
+    /// submit a transaction that either fails confusingly or, worse,
+    /// succeeds with different semantics than the caller assumed.
+    ///
+    /// ## Pattern for SDK authors
+    ///
+    /// Entry points that want this guard accept an additional
+    /// `expected_version: Option<String>` parameter (see
+    /// `create_attestation_versioned` for a worked example) and call this
+    /// function first, before any other validation or state mutation. SDKs
+    /// should:
+    ///
+    /// 1. Call `get_version()` once after deploying/connecting, and cache it.
+    /// 2. Pass that cached value as `expected_version` on subsequent
+    ///    state-changing calls that accept it.
+    /// 3. On [`Error::VersionMismatch`], refresh the cached version via
+    ///    `get_version()`, regenerate the call using the SDK version that
+    ///    matches, and prompt the caller to retry — rather than assuming the
+    ///    original call's argument shape and semantics still apply.
+    ///
+    /// Passing `None` skips the check entirely, preserving backward
+    /// compatibility for callers that don't yet track contract versions.
+    ///
+    /// # Errors
+    /// - [`Error::NotInitialized`] — the contract has no stored version yet.
+    /// - [`Error::VersionMismatch`] — `expected_version` is `Some` and does
+    ///   not match the contract's currently deployed version.
+    pub fn require_version_match(env: &Env, expected_version: &Option<String>) -> Result<(), Error> {
+        let Some(expected) = expected_version else {
+            return Ok(());
+        };
+        let actual = Storage::get_version(env).ok_or(Error::NotInitialized)?;
+        if expected != &actual {
+            return Err(Error::VersionMismatch);
+        }
+        Ok(())
+    }
+
     /// Validate a `claim_type` string.
     ///
     /// # Rules


### PR DESCRIPTION
## Summary

Closes #952.

The contract exposes `get_version()`/`get_contract_metadata()`, but nothing on the write path validated that a calling client's expected interface version matched the deployed contract's version before executing a state-changing call. After a contract upgrade that changes a function's expected argument shape or semantics, an out-of-date SDK could submit a transaction that either fails confusingly or, worse, succeeds with different semantics than the caller assumed.

## Changes

- `src/errors.rs`: add `Error::VersionMismatch`.
- `src/validation.rs`: add `Validation::require_version_match(env, expected_version)`, documented as the pattern for SDK authors — entry points accept an optional `expected_version: Option<String>` and validate it before any other checks; `None` skips the guard entirely, so it's fully backward compatible.
- `src/attestation.rs` + `src/lib.rs`: add `create_attestation_versioned`, a worked-example entry point with the same signature as `create_attestation` plus `expected_version`, demonstrating the pattern end-to-end without touching the existing `create_attestation` signature (so no existing callers/tests break).
- `src/test.rs`: add three tests — matching version succeeds, mismatched version returns `VersionMismatch` with no state changed, and omitting `expected_version` (`None`) behaves exactly like the existing `create_attestation`.

## Test plan

- [x] `test_create_attestation_versioned_accepts_matching_expected_version`
- [x] `test_create_attestation_versioned_accepts_no_expected_version`
- [x] `test_create_attestation_versioned_rejects_mismatched_expected_version`
