### PR TITLE
Add indexer consistency checks, ms_sign fix, and project governance

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,46 +1,139 @@
-### What I changed
+# TrustLink Project Governance
 
-1. Added new example crate at:
-- `examples/governance/`
+This document describes how the **TrustLink open-source project** is governed:
+who maintains it, how decisions are made, and how new maintainers are added.
 
-2. Implemented governance contract:
-- `examples/governance/src/lib.rs`
-- Features:
-  - `initialize(env, admin, trustlink_contract)`
-  - `set_trustlink(env, admin, trustlink_contract)`
-  - `set_eligibility_claims(env, admin, claims)` where `claims` is `Vec<String>`
-  - `vote(env, voter, proposal_id, support)` checks TrustLink before recording a vote
-  - `is_eligible(env, voter)` helper that supports multiple claim types via OR logic
-  - vote tracking keyed by `(proposal_id, voter)` to prevent duplicate votes
-  - basic tallying (`for` / `against`) and `voted` event emission
+It covers project governance only. On-chain admin/multi-sig policy for the
+deployed TrustLink contract is separate and is documented in the contract ADRs
+and deployment runbooks.
 
-3. Added multiple-claim support exactly as requested:
-- Accepts claim list like `VOTER_ELIGIBLE`, `MEMBER_VERIFIED`
-- Voter is eligible if at least one configured claim is valid in TrustLink
-- Empty configured claim list blocks voting for safety
+## Maintainers
 
-4. Added tests:
-- `examples/governance/src/lib.rs` test module includes:
-  - voting blocked for ineligible address
-  - voting allowed for eligible address
-  - multiple claim types supported (eligible via second claim)
-  - duplicate vote blocked
+Maintainers are trusted stewards of the repository. They are responsible for
+keeping TrustLink healthy, secure, and usable for integrators.
 
-5. Added example crate manifest:
-- `examples/governance/Cargo.toml`
+### Roles
 
-6. Added example documentation:
-- `examples/governance/README.md`
-- Explains contract pattern and how claim-based gating works
+| Role | Responsibilities |
+| --- | --- |
+| **Core maintainer** | Merge rights on the default branch; final call on breaking changes, releases, and security disclosures; keeps CI and release automation green. |
+| **Area maintainer** | Owns a subsystem (contract, indexer, SDKs, docs/security) and reviews PRs in that area; may merge within their CODEOWNERS paths after review. |
+| **Triager** | Labels issues/PRs, routes work, closes duplicates, and keeps the backlog actionable. Does not merge by default. |
 
-7. Linked from main README:
-- Added governance example link/section in README.md so it is discoverable
+Current ownership routing lives in [`.github/CODEOWNERS`](.github/CODEOWNERS).
+Teams listed there are the starting point for review assignment:
 
-### Notes on acceptance criteria
+- Contract (`/src/`) — `@Haroldwonder/contract-team`
+- SDKs (`/sdk/`) — `@Haroldwonder/sdk-team`
+- Security docs — `@Haroldwonder/security-team`
+- Compliance docs — `@Haroldwonder/compliance-team`
 
-- Governance contract compiles and tests pass: implemented with Soroban pattern matching existing examples.
-- Voting blocked for ineligible addresses: covered in contract logic and tests.
-- Multiple claim types supported: implemented via configured `Vec<String>` and tested.
-- Linked from README: documented and linked in root README.
+### Responsibilities of all maintainers
 
-If you want, I can run the workspace tests now (`cargo test` in root and in `examples/governance`) and report exact results/output.
+- Review PRs in a timely manner and request changes when quality, security, or
+  clarity is insufficient.
+- Uphold the contribution standards in [`CONTRIBUTING.md`](CONTRIBUTING.md) and
+  the security process in [`SECURITY.md`](SECURITY.md).
+- Prefer reversible, well-tested changes; require tests for bug fixes that
+  exercise the failing path.
+- Never merge their own unreviewed changes to security-sensitive contract or
+  indexer paths without a second maintainer approval.
+- Keep secrets, keys, and production credentials out of the repository.
+
+## Decision-making
+
+TrustLink uses a lightweight consensus model with written design records for
+non-trivial changes.
+
+### Day-to-day changes
+
+Routine work (bug fixes, docs, small features, dependency bumps) is decided
+through pull request review:
+
+1. Author opens a PR with a clear summary and test plan.
+2. Required CODEOWNERS / CI checks pass.
+3. At least one maintainer with ownership of the affected path approves.
+4. The approving maintainer (or core maintainer) merges.
+
+Disagreement on a routine PR is resolved by discussion on the PR. If consensus
+is not reached within a few business days, a core maintainer decides and records
+the rationale on the PR.
+
+### Substantial changes (RFC / ADR)
+
+Changes that alter public APIs, storage layout, trust assumptions, indexer
+semantics, or release policy require a written proposal **before**
+implementation lands on the default branch.
+
+Use the Architecture Decision Record process under [`docs/adr/`](docs/adr/):
+
+1. Open an issue or draft PR describing the problem, options, and recommendation
+   (start from [`docs/adr/ADR-000-template.md`](docs/adr/ADR-000-template.md)).
+2. Label it for design review and notify the relevant area maintainers.
+3. Allow a comment period of at least **7 days** for non-urgent proposals
+   (shorter only for active security incidents).
+4. A core maintainer accepts, rejects, or requests revision. Accepted decisions
+   are committed as a numbered ADR under `docs/adr/`.
+5. Implementation PRs link back to the ADR.
+
+Security-sensitive decisions follow [`SECURITY.md`](SECURITY.md) disclosure
+timelines and may be discussed privately until a fix is released.
+
+### Releases
+
+Release cadence, versioning, and automation are documented in
+[`RELEASE.md`](RELEASE.md). Core maintainers own tagging and publishing
+artifacts; area maintainers are responsible for release notes in their domains.
+
+## Adding and removing maintainers
+
+### Adding a maintainer
+
+Candidates are usually active contributors who have demonstrated judgment
+through sustained, high-quality participation (reviews, fixes, design input).
+
+Process:
+
+1. An existing core maintainer nominates the candidate in a private maintainer
+   channel or via email, summarizing contributions and the proposed role/area.
+2. Other core maintainers consent (lazy consensus: no sustained objection within
+   **7 days**). Area-maintainer additions also need consent from an existing
+   maintainer of that area when one exists.
+3. The nominee accepts and confirms they can uphold this governance document and
+   the security policy.
+4. Access is granted (GitHub team membership / CODEOWNERS update as needed) and
+   announced in a public issue or discussion.
+
+### Stepping down
+
+Maintainers may step down at any time by notifying the other core maintainers.
+Access is removed promptly; past contributions remain credited in git history.
+
+### Emeritus and inactivity
+
+Maintainers who are unreachable for **90 days** without notice may be moved to
+emeritus status (no merge rights) after an attempt to contact them. Emeritus
+maintainers can be restored by the same process used for new maintainers.
+
+### Removal for cause
+
+Core maintainers may revoke maintainer status for repeated violation of project
+standards, security negligence, or harmful conduct. Removal requires agreement
+of at least two core maintainers (or a majority when more than two exist) and a
+written internal record of the reason.
+
+## Scope boundaries
+
+| In scope of this document | Out of scope |
+| --- | --- |
+| Repository permissions, review policy, release stewardship | On-chain admin keys and multi-sig thresholds for a given deployment |
+| ADR / RFC process for the open-source project | Network-specific operational runbooks (see `docs/mainnet-*.md`) |
+| How CODEOWNERS teams map to review | Customer / deployment-specific governance contracts under `examples/` |
+
+## Related documents
+
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — how to contribute code and docs
+- [`SECURITY.md`](SECURITY.md) — vulnerability reporting and disclosure
+- [`docs/adr/`](docs/adr/) — architecture decision records
+- [`RELEASE.md`](RELEASE.md) — release process
+- [`.github/CODEOWNERS`](.github/CODEOWNERS) — review routing

--- a/docs/e2e-request-flow-guide.md
+++ b/docs/e2e-request-flow-guide.md
@@ -8,7 +8,30 @@ The end-to-end (E2E) test suite validates the complete attestation request workf
 
 ```
 sdk/typescript/e2e/attestation-request-flow.e2e.test.ts
+sdk/typescript/e2e/trustlink.e2e.test.ts
+sdk/typescript/e2e/contract-indexer-consistency.e2e.test.ts
 ```
+
+| File | Scope |
+| --- | --- |
+| `attestation-request-flow.e2e.test.ts` | Request → fulfill → verify workflow |
+| `trustlink.e2e.test.ts` | Core SDK happy path against local Quickstart |
+| `contract-indexer-consistency.e2e.test.ts` | Same attestation ID: live contract state vs indexer GraphQL |
+
+### Contract ↔ indexer consistency
+
+`contract-indexer-consistency.e2e.test.ts` closes the gap where contract and
+indexer were only tested independently. It:
+
+1. Creates a happy-path attestation on the local Soroban network
+2. Waits for the indexer to process the `created` event
+3. Loads the attestation via `get_attestation` on the contract
+4. Queries the indexer's GraphQL API for the same ID
+5. Asserts field-for-field equality (`id`, `issuer`, `subject`, `claimType`,
+   `timestamp`, `expiration`, `isRevoked`, `metadata`)
+
+Requires the indexer GraphQL endpoint (default `http://localhost:4000/graphql`,
+override with `INDEXER_GRAPHQL_URL`).
 
 ## Workflow Steps
 

--- a/indexer/.env.example
+++ b/indexer/.env.example
@@ -30,6 +30,12 @@ OTEL_EXPORTER_OTLP_ENDPOINT=
 # How often to run archival job (hours)
 ARCHIVAL_INTERVAL_HOURS=6
 
+# ── Reconciliation (indexer ↔ contract drift detection) ───────────────────────
+# How often to sample indexed attestations against live RPC state (minutes)
+RECONCILE_INTERVAL_MINUTES=60
+# How many recent attestations to compare each run
+RECONCILE_SAMPLE_SIZE=50
+
 # Archive destination (local path, s3://, or gs://)
 # Local: /archive/trustlink-events or /mnt/archive
 # S3:    s3://trustlink-events-archive

--- a/indexer/README.md
+++ b/indexer/README.md
@@ -203,6 +203,8 @@ RawEvent table (hot) ──[older than N days]──> Archive files (cold)
 | Variable                  | Type   | Default                         | Description                                             |
 | ------------------------- | ------ | ------------------------------- | ------------------------------------------------------- |
 | `ARCHIVAL_INTERVAL_HOURS` | int    | `6`                             | How often to run archival job (hours)                   |
+| `RECONCILE_INTERVAL_MINUTES` | int | `60`                            | How often to reconcile indexed rows vs live contract    |
+| `RECONCILE_SAMPLE_SIZE`   | int    | `50`                            | How many recent attestations to compare each run        |
 | `ARCHIVE_PATH`            | string | `s3://trustlink-events-archive` | Destination for archived files (S3, GCS, or local path) |
 
 #### Database Configuration

--- a/indexer/src/indexer.ts
+++ b/indexer/src/indexer.ts
@@ -1,7 +1,7 @@
 import { PrismaClient } from "@prisma/client";
 import { rpc as SorobanRpc, scValToNative } from "@stellar/stellar-sdk";
 import type { Redis } from "ioredis";
-import { pubsub, ATTESTATION_CREATED, cacheInvalidate } from "./graphql";
+import { pubsub, ATTESTATION_CREATED, ATTESTATION_REVOKED, ISSUER_REGISTERED, cacheInvalidate } from "./graphql";
 import {
   attestationsTotal,
   revocationsTotal,
@@ -13,6 +13,8 @@ import {
 } from "./metrics";
 import { dispatchWebhooks } from "./webhooks";
 import { scheduleArchivalJob } from "./archival";
+import { scheduleReconciliationJob } from "./reconciliation";
+import { handleMsSign } from "./ms-sign";
 
 const CONTRACT_ID = process.env.CONTRACT_ID!;
 const RPC_URL = process.env.RPC_URL ?? "https://soroban-testnet.stellar.org";
@@ -49,6 +51,22 @@ export async function startIndexer(db: PrismaClient, redis: Redis | null = null)
     10,
   );
   scheduleArchivalJob(db, ARCHIVAL_INTERVAL_HOURS);
+
+  // Cross-check indexed rows against live contract state on a schedule
+  const RECONCILE_INTERVAL_MINUTES = parseInt(
+    process.env.RECONCILE_INTERVAL_MINUTES ?? "60",
+    10,
+  );
+  const RECONCILE_SAMPLE_SIZE = parseInt(
+    process.env.RECONCILE_SAMPLE_SIZE ?? "50",
+    10,
+  );
+  scheduleReconciliationJob(db, {
+    intervalMinutes: RECONCILE_INTERVAL_MINUTES,
+    sampleSize: RECONCILE_SAMPLE_SIZE,
+    contractId: CONTRACT_ID,
+    rpcUrl: RPC_URL,
+  });
 
   // ── Backfill ───────────────────────────────────────────────────────────────
   const checkpoint = await db.checkpoint.findUnique({ where: { id: 1 } });
@@ -153,7 +171,9 @@ async function processRange(
 
 // ── Event handler ─────────────────────────────────────────────────────────────
 
-async function handleEvent(
+/** Exported for unit tests that exercise real event-handler code paths. */
+export /** Exported for unit tests that exercise real event-handler code paths. */
+export async function handleEvent(
   db: PrismaClient,
   ev: SorobanRpc.Api.EventResponse,
   redis: Redis | null
@@ -198,12 +218,11 @@ async function handleEvent(
   }
 
   if (topicStr === "ms_sign") {
+    // Event: topics = [ms_sign, signer], data = [proposal_id, signatures_so_far, threshold]
     const proposalId = String(data[0]);
     const signatureCount = Number(data[1]);
-    await db.multisigProposal.update({
-      where: { id: proposalId },
-      data: { signatureCount, signers: updatedSigners },
-    });
+    const signer = ev.topic[1] ? String(scValToNative(ev.topic[1])) : "";
+    await handleMsSign(db, proposalId, signatureCount, signer);
     return;
   }
 

--- a/indexer/src/ms-sign-handler.test.ts
+++ b/indexer/src/ms-sign-handler.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Regression tests for the ms_sign handler.
+ *
+ * The production handler previously referenced an undefined `updatedSigners`
+ * variable, which crashed at runtime. These tests process a realistic ms_sign
+ * payload through the actual `handleMsSign` function (the same code path
+ * `handleEvent` calls) so that class of regression cannot silently reappear.
+ *
+ * Acceptance: fails against the buggy handler; passes once the fix lands.
+ */
+
+import { Keypair, nativeToScVal, Address, xdr, scValToNative } from "@stellar/stellar-sdk";
+import { handleMsSign } from "./ms-sign";
+
+function makeMockDb() {
+  return {
+    multisigProposal: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  };
+}
+
+/**
+ * Build a realistic ms_sign event payload matching the contract's publish shape:
+ *   topics = [ms_sign, signer]
+ *   data   = [proposal_id, signatures_so_far, threshold]
+ * then parse it the same way handleEvent does before calling handleMsSign.
+ */
+function parseMsSignEvent(proposalId: string, signatureCount: number, threshold: number, signer: string) {
+  const topic = [
+    nativeToScVal("ms_sign", { type: "symbol" }),
+    Address.fromString(signer).toScVal(),
+  ];
+  const value = xdr.ScVal.scvVec([
+    nativeToScVal(proposalId, { type: "string" }),
+    nativeToScVal(signatureCount, { type: "u32" }),
+    nativeToScVal(threshold, { type: "u32" }),
+  ]);
+
+  const topicStr = scValToNative(topic[0]) as string;
+  const data = scValToNative(value) as unknown[];
+  const parsedSigner = topic[1] ? String(scValToNative(topic[1])) : "";
+
+  return {
+    topicStr,
+    proposalId: String(data[0]),
+    signatureCount: Number(data[1]),
+    threshold: Number(data[2]),
+    signer: parsedSigner,
+  };
+}
+
+describe("ms_sign handleMsSign regression (undefined updatedSigners)", () => {
+  it("parses a realistic ms_sign payload and updates signer count without throwing", async () => {
+    const proposer = Keypair.random().publicKey();
+    const signerB = Keypair.random().publicKey();
+    const parsed = parseMsSignEvent("prop-abc", 2, 2, signerB);
+
+    expect(parsed.topicStr).toBe("ms_sign");
+    expect(parsed.proposalId).toBe("prop-abc");
+    expect(parsed.signatureCount).toBe(2);
+    expect(parsed.signer).toBe(signerB);
+
+    const db = makeMockDb();
+    db.multisigProposal.findUnique.mockResolvedValue({ signers: [proposer] });
+    db.multisigProposal.update.mockResolvedValue({});
+
+    await expect(
+      handleMsSign(db as never, parsed.proposalId, parsed.signatureCount, parsed.signer),
+    ).resolves.toBeUndefined();
+
+    expect(db.multisigProposal.findUnique).toHaveBeenCalledWith({
+      where: { id: "prop-abc" },
+      select: { signers: true },
+    });
+    expect(db.multisigProposal.update).toHaveBeenCalledWith({
+      where: { id: "prop-abc" },
+      data: {
+        signatureCount: 2,
+        signers: [proposer, signerB],
+      },
+    });
+  });
+
+  it("is idempotent when the same signer co-signs again", async () => {
+    const signer = Keypair.random().publicKey();
+    const parsed = parseMsSignEvent("prop-abc", 1, 2, signer);
+    const db = makeMockDb();
+    db.multisigProposal.findUnique.mockResolvedValue({ signers: [signer] });
+    db.multisigProposal.update.mockResolvedValue({});
+
+    await expect(
+      handleMsSign(db as never, parsed.proposalId, parsed.signatureCount, parsed.signer),
+    ).resolves.toBeUndefined();
+
+    expect(db.multisigProposal.update).toHaveBeenCalledWith({
+      where: { id: "prop-abc" },
+      data: {
+        signatureCount: 1,
+        signers: [signer],
+      },
+    });
+  });
+
+  it("skips update when proposal is missing (out-of-order ms_sign)", async () => {
+    const parsed = parseMsSignEvent(
+      "missing-prop",
+      2,
+      2,
+      Keypair.random().publicKey(),
+    );
+    const db = makeMockDb();
+    db.multisigProposal.findUnique.mockResolvedValue(null);
+
+    await expect(
+      handleMsSign(db as never, parsed.proposalId, parsed.signatureCount, parsed.signer),
+    ).resolves.toBeUndefined();
+
+    expect(db.multisigProposal.update).not.toHaveBeenCalled();
+  });
+});

--- a/indexer/src/ms-sign.ts
+++ b/indexer/src/ms-sign.ts
@@ -1,0 +1,35 @@
+/**
+ * ms_sign event handler — kept in its own module so unit tests can exercise
+ * the real production logic without importing the full indexer loop.
+ */
+
+import type { PrismaClient } from "@prisma/client";
+
+/**
+ * Apply a multisig co-sign event to the indexed proposal row.
+ *
+ * Event shape (from contract):
+ *   topics = [ms_sign, signer]
+ *   data   = [proposal_id, signatures_so_far, threshold]
+ */
+export async function handleMsSign(
+  db: PrismaClient,
+  proposalId: string,
+  signatureCount: number,
+  signer: string,
+): Promise<void> {
+  const existing = await db.multisigProposal.findUnique({
+    where: { id: proposalId },
+    select: { signers: true },
+  });
+  if (!existing) return; // out-of-order: wait for ms_prop
+
+  const updatedSigners = existing.signers.includes(signer)
+    ? existing.signers
+    : [...existing.signers, signer];
+
+  await db.multisigProposal.update({
+    where: { id: proposalId },
+    data: { signatureCount, signers: updatedSigners },
+  });
+}

--- a/indexer/src/reconciliation.test.ts
+++ b/indexer/src/reconciliation.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for the indexer ↔ contract reconciliation job.
+ *
+ * Verifies that a deliberately introduced indexing discrepancy is detected
+ * and reported via the drift result (and Prometheus counters).
+ */
+
+import {
+  reconcileAttestations,
+  OnChainAttestation,
+  scheduleReconciliationJob,
+} from "./reconciliation";
+import { register } from "prom-client";
+
+function makeIndexedRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "att-1",
+    issuer: "GISSUER",
+    subject: "GSUBJECT",
+    claimType: "KYC_PASSED",
+    timestamp: BigInt(1_700_000_000),
+    expiration: null,
+    isRevoked: false,
+    revocationReason: null,
+    metadata: null,
+    imported: false,
+    bridged: false,
+    sourceChain: null,
+    sourceTx: null,
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+    updatedAt: new Date("2024-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+function makeOnChain(
+  overrides: Partial<OnChainAttestation> = {},
+): OnChainAttestation {
+  return {
+    id: "att-1",
+    issuer: "GISSUER",
+    subject: "GSUBJECT",
+    claim_type: "KYC_PASSED",
+    timestamp: 1_700_000_000,
+    expiration: null,
+    revoked: false,
+    metadata: null,
+    ...overrides,
+  };
+}
+
+function makeMockDb(rows: ReturnType<typeof makeIndexedRow>[]) {
+  return {
+    attestation: {
+      findMany: jest.fn().mockResolvedValue(rows),
+    },
+  };
+}
+
+describe("reconcileAttestations", () => {
+  beforeEach(() => {
+    register.resetMetrics();
+  });
+
+  it("reports no drift when indexed and on-chain state match", async () => {
+    const db = makeMockDb([makeIndexedRow()]);
+    const fetchOnChain = jest.fn().mockResolvedValue(makeOnChain());
+
+    const result = await reconcileAttestations(db as never, fetchOnChain, {
+      sampleSize: 10,
+    });
+
+    expect(result.checked).toBe(1);
+    expect(result.drifts).toHaveLength(0);
+    expect(result.missingOnChain).toBe(0);
+    expect(fetchOnChain).toHaveBeenCalledWith("att-1");
+  });
+
+  it("detects and reports a deliberately introduced claimType discrepancy", async () => {
+    // Indexed row has the wrong claim type — simulates an indexing bug.
+    const db = makeMockDb([
+      makeIndexedRow({ claimType: "WRONG_CLAIM" }),
+    ]);
+    const fetchOnChain = jest.fn().mockResolvedValue(
+      makeOnChain({ claim_type: "KYC_PASSED" }),
+    );
+
+    const result = await reconcileAttestations(db as never, fetchOnChain, {
+      sampleSize: 10,
+    });
+
+    expect(result.checked).toBe(1);
+    expect(result.drifts).toHaveLength(1);
+    expect(result.drifts[0].attestationId).toBe("att-1");
+    expect(result.drifts[0].fields).toContain("claimType");
+    expect(result.drifts[0].indexed.claimType).toBe("WRONG_CLAIM");
+    expect(result.drifts[0].onChain.claimType).toBe("KYC_PASSED");
+  });
+
+  it("detects isRevoked drift against on-chain revoked flag", async () => {
+    const db = makeMockDb([makeIndexedRow({ isRevoked: false })]);
+    const fetchOnChain = jest
+      .fn()
+      .mockResolvedValue(makeOnChain({ revoked: true }));
+
+    const result = await reconcileAttestations(db as never, fetchOnChain);
+
+    expect(result.drifts).toHaveLength(1);
+    expect(result.drifts[0].fields).toContain("isRevoked");
+  });
+
+  it("reports missing_on_chain when the contract has no row for an indexed id", async () => {
+    const db = makeMockDb([makeIndexedRow()]);
+    const fetchOnChain = jest.fn().mockResolvedValue(null);
+
+    const result = await reconcileAttestations(db as never, fetchOnChain);
+
+    expect(result.missingOnChain).toBe(1);
+    expect(result.drifts[0].fields).toEqual(["missing_on_chain"]);
+  });
+
+  it("samples only the requested attestation IDs when provided", async () => {
+    const db = makeMockDb([makeIndexedRow({ id: "att-only" })]);
+    const fetchOnChain = jest.fn().mockResolvedValue(
+      makeOnChain({ id: "att-only" }),
+    );
+
+    await reconcileAttestations(db as never, fetchOnChain, {
+      attestationIds: ["att-only"],
+    });
+
+    expect(db.attestation.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ["att-only"] } },
+    });
+  });
+});
+
+describe("scheduleReconciliationJob", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("runs on the configured schedule", async () => {
+    const db = makeMockDb([]);
+    const timer = scheduleReconciliationJob(db as never, {
+      intervalMinutes: 1,
+      sampleSize: 5,
+      contractId: "CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      rpcUrl: "http://localhost:8000/soroban/rpc",
+      runImmediately: false,
+    });
+
+    expect(timer).toBeDefined();
+
+    // Advance one interval — the scheduled callback should fire.
+    jest.advanceTimersByTime(60_000);
+    // Allow any pending promise microtasks from the interval callback.
+    await Promise.resolve();
+
+    clearInterval(timer);
+    expect(db.attestation.findMany).toHaveBeenCalled();
+  });
+});

--- a/indexer/src/reconciliation.ts
+++ b/indexer/src/reconciliation.ts
@@ -1,0 +1,318 @@
+/**
+ * Scheduled reconciliation: sample indexed attestations and diff them against
+ * live contract state fetched via Soroban RPC. Emits Prometheus metrics (and
+ * logs) when drift is detected so silent indexing bugs surface quickly.
+ */
+
+import { PrismaClient } from "@prisma/client";
+import {
+  Contract,
+  TransactionBuilder,
+  BASE_FEE,
+  Networks,
+  nativeToScVal,
+  rpc as SorobanRpc,
+  scValToNative,
+} from "@stellar/stellar-sdk";
+import { Counter, Gauge } from "prom-client";
+
+/** Indexed attestation fields used for reconciliation comparisons. */
+type IndexedAttestation = {
+  id: string;
+  issuer: string;
+  subject: string;
+  claimType: string;
+  timestamp: bigint;
+  expiration: bigint | null;
+  isRevoked: boolean;
+  metadata: string | null;
+  updatedAt?: Date;
+};
+
+/** Attestations compared during reconciliation runs */
+export const reconciliationCheckedTotal = new Counter({
+  name: "trustlink_reconciliation_checked_total",
+  help: "Total attestations compared against live contract state",
+});
+
+/** Indexed rows that diverged from on-chain state */
+export const reconciliationDriftTotal = new Counter({
+  name: "trustlink_reconciliation_drift_total",
+  help: "Total attestations where indexed state differs from on-chain state",
+  labelNames: ["field"],
+});
+
+/** Unix timestamp of the last completed reconciliation run */
+export const reconciliationLastRunTimestamp = new Gauge({
+  name: "trustlink_reconciliation_last_run_timestamp",
+  help: "Unix timestamp of the last completed reconciliation run",
+});
+
+export type OnChainAttestation = {
+  id: string;
+  issuer: string;
+  subject: string;
+  claim_type: string;
+  timestamp: bigint | number | string;
+  expiration: bigint | number | string | null;
+  revoked: boolean;
+  metadata: string | null;
+  source_chain?: string | null;
+  source_tx?: string | null;
+};
+
+export type DriftReport = {
+  attestationId: string;
+  fields: string[];
+  indexed: Record<string, unknown>;
+  onChain: Record<string, unknown>;
+};
+
+export type ReconciliationResult = {
+  checked: number;
+  missingOnChain: number;
+  drifts: DriftReport[];
+};
+
+export type ReconciliationOptions = {
+  sampleSize?: number;
+  /** When set, only these IDs are checked (used by tests). */
+  attestationIds?: string[];
+};
+
+const COMPARE_FIELDS: Array<{
+  indexed: keyof IndexedAttestation;
+  onChain: keyof OnChainAttestation;
+  normalize?: (v: unknown) => string;
+}> = [
+  { indexed: "issuer", onChain: "issuer", normalize: String },
+  { indexed: "subject", onChain: "subject", normalize: String },
+  { indexed: "claimType", onChain: "claim_type", normalize: String },
+  {
+    indexed: "timestamp",
+    onChain: "timestamp",
+    normalize: (v) => String(v),
+  },
+  {
+    indexed: "expiration",
+    onChain: "expiration",
+    normalize: (v) => (v == null ? "" : String(v)),
+  },
+  {
+    indexed: "isRevoked",
+    onChain: "revoked",
+    normalize: (v) => String(Boolean(v)),
+  },
+  {
+    indexed: "metadata",
+    onChain: "metadata",
+    normalize: (v) => (v == null ? "" : String(v)),
+  },
+];
+
+/**
+ * Compare a sample of indexed attestations against live on-chain state.
+ */
+export async function reconcileAttestations(
+  db: PrismaClient,
+  fetchOnChain: (id: string) => Promise<OnChainAttestation | null>,
+  options: ReconciliationOptions = {},
+): Promise<ReconciliationResult> {
+  const sampleSize = options.sampleSize ?? 50;
+
+  let rows: IndexedAttestation[];
+  if (options.attestationIds?.length) {
+    rows = await db.attestation.findMany({
+      where: { id: { in: options.attestationIds } },
+    });
+  } else {
+    // Prefer recent rows so drift in active traffic is caught first.
+    rows = await db.attestation.findMany({
+      take: sampleSize,
+      orderBy: { updatedAt: "desc" },
+    });
+  }
+
+  const drifts: DriftReport[] = [];
+  let missingOnChain = 0;
+
+  for (const row of rows) {
+    reconciliationCheckedTotal.inc();
+    const onChain = await fetchOnChain(row.id);
+
+    if (!onChain) {
+      missingOnChain += 1;
+      reconciliationDriftTotal.inc({ field: "missing_on_chain" });
+      drifts.push({
+        attestationId: row.id,
+        fields: ["missing_on_chain"],
+        indexed: summarizeIndexed(row),
+        onChain: {},
+      });
+      console.error(
+        `[RECONCILE] drift: attestation ${row.id} present in indexer but missing on-chain`,
+      );
+      continue;
+    }
+
+    const mismatched: string[] = [];
+    for (const field of COMPARE_FIELDS) {
+      const norm = field.normalize ?? ((v: unknown) => String(v));
+      const left = norm(row[field.indexed]);
+      const right = norm(onChain[field.onChain]);
+      if (left !== right) {
+        mismatched.push(String(field.indexed));
+        reconciliationDriftTotal.inc({ field: String(field.indexed) });
+      }
+    }
+
+    if (mismatched.length > 0) {
+      const report: DriftReport = {
+        attestationId: row.id,
+        fields: mismatched,
+        indexed: summarizeIndexed(row),
+        onChain: {
+          id: onChain.id,
+          issuer: onChain.issuer,
+          subject: onChain.subject,
+          claimType: onChain.claim_type,
+          timestamp: String(onChain.timestamp),
+          expiration:
+            onChain.expiration != null ? String(onChain.expiration) : null,
+          isRevoked: onChain.revoked,
+          metadata: onChain.metadata,
+        },
+      };
+      drifts.push(report);
+      console.error(
+        `[RECONCILE] drift on ${row.id}: fields=${mismatched.join(",")} indexed=${JSON.stringify(report.indexed)} onChain=${JSON.stringify(report.onChain)}`,
+      );
+    }
+  }
+
+  reconciliationLastRunTimestamp.set(Math.floor(Date.now() / 1000));
+
+  if (drifts.length > 0) {
+    console.error(
+      `[RECONCILE] ALERT: ${drifts.length} attestation(s) drifted out of ${rows.length} checked`,
+    );
+  } else {
+    console.log(
+      `[RECONCILE] ok: checked=${rows.length} missingOnChain=${missingOnChain}`,
+    );
+  }
+
+  return { checked: rows.length, missingOnChain, drifts };
+}
+
+function summarizeIndexed(row: IndexedAttestation): Record<string, unknown> {
+  return {
+    id: row.id,
+    issuer: row.issuer,
+    subject: row.subject,
+    claimType: row.claimType,
+    timestamp: String(row.timestamp),
+    expiration: row.expiration != null ? String(row.expiration) : null,
+    isRevoked: row.isRevoked,
+    metadata: row.metadata,
+  };
+}
+
+/**
+ * Fetch a single attestation from the live TrustLink contract via RPC simulate.
+ */
+export function createRpcAttestationFetcher(
+  contractId: string,
+  rpcUrl: string,
+  networkPassphrase: string = Networks.TESTNET,
+): (id: string) => Promise<OnChainAttestation | null> {
+  const rpc = new SorobanRpc.Server(rpcUrl, { allowHttp: true });
+  const dummySource =
+    "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+  return async (attestationId: string): Promise<OnChainAttestation | null> => {
+    try {
+      const contract = new Contract(contractId);
+      const account = await rpc.getAccount(dummySource).catch(
+        () =>
+          ({
+            accountId: () => dummySource,
+            sequenceNumber: () => "0",
+            incrementSequenceNumber: () => {},
+          }) as never,
+      );
+
+      const tx = new TransactionBuilder(account as never, {
+        fee: BASE_FEE,
+        networkPassphrase,
+      })
+        .addOperation(
+          contract.call(
+            "get_attestation",
+            nativeToScVal(attestationId, { type: "string" }),
+          ),
+        )
+        .setTimeout(30)
+        .build();
+
+      const result = await rpc.simulateTransaction(tx);
+      if (SorobanRpc.Api.isSimulationError(result)) {
+        return null;
+      }
+      const success = result as SorobanRpc.Api.SimulateTransactionSuccessResponse;
+      if (!success.result?.retval) return null;
+
+      const native = scValToNative(success.result.retval) as OnChainAttestation;
+      return {
+        ...native,
+        issuer: String(native.issuer),
+        subject: String(native.subject),
+      };
+    } catch (err) {
+      console.warn(`[RECONCILE] RPC fetch failed for ${attestationId}:`, err);
+      return null;
+    }
+  };
+}
+
+export type ScheduleReconciliationConfig = {
+  intervalMinutes?: number;
+  sampleSize?: number;
+  contractId: string;
+  rpcUrl: string;
+  networkPassphrase?: string;
+  /** Skip the immediate startup run (useful in tests). */
+  runImmediately?: boolean;
+};
+
+/**
+ * Schedule periodic reconciliation. Default: every 60 minutes, sample 50 rows.
+ */
+export function scheduleReconciliationJob(
+  db: PrismaClient,
+  config: ScheduleReconciliationConfig,
+): ReturnType<typeof setInterval> {
+  const intervalMinutes = config.intervalMinutes ?? 60;
+  const sampleSize = config.sampleSize ?? 50;
+  const fetchOnChain = createRpcAttestationFetcher(
+    config.contractId,
+    config.rpcUrl,
+    config.networkPassphrase,
+  );
+
+  const run = () =>
+    reconcileAttestations(db, fetchOnChain, { sampleSize }).catch((err) => {
+      console.error("[RECONCILE] Scheduled run failed:", err);
+    });
+
+  if (config.runImmediately !== false) {
+    run();
+  }
+
+  const intervalMs = intervalMinutes * 60 * 1000;
+  console.log(
+    `[RECONCILE] Scheduled reconciliation every ${intervalMinutes}m (sampleSize=${sampleSize})`,
+  );
+
+  return setInterval(run, intervalMs);
+}

--- a/sdk/typescript/e2e/contract-indexer-consistency.e2e.test.ts
+++ b/sdk/typescript/e2e/contract-indexer-consistency.e2e.test.ts
@@ -1,0 +1,340 @@
+/**
+ * End-to-end consistency test: contract state vs indexer GraphQL for one ID.
+ *
+ * Creates a happy-path attestation on a local Soroban network, waits for the
+ * indexer to ingest the corresponding event, then queries:
+ *   1. the contract directly (`get_attestation`)
+ *   2. the indexer's GraphQL API for the same attestation ID
+ * and asserts field-for-field equality on the shared identity fields.
+ *
+ * Prerequisites (same as trustlink.e2e.test.ts / attestation-request-flow):
+ *   - Local Stellar Quickstart running
+ *   - Contract deployed (scripts/setup_local.sh)
+ *   - Indexer running against the same CONTRACT_ID + Postgres
+ *
+ * Run:
+ *   npm run test:e2e -- contract-indexer-consistency.e2e.test.ts
+ *
+ * Env:
+ *   CONTRACT_ID / .local.contract-id
+ *   INDEXER_GRAPHQL_URL (default http://localhost:4000/graphql)
+ *   RPC_URL, NETWORK_PASSPHRASE, ADMIN_SECRET, ISSUER_SECRET (optional)
+ */
+
+import {
+  Keypair,
+  TransactionBuilder,
+  BASE_FEE,
+  Networks,
+  rpc as SorobanRpc,
+  Contract,
+  Address,
+  nativeToScVal,
+} from "@stellar/stellar-sdk";
+import { readFileSync, existsSync } from "fs";
+import { resolve } from "path";
+
+// ── Configuration ───────────────────────────────────────────────────────────
+
+const RPC_URL = process.env.RPC_URL ?? "http://localhost:8000/soroban/rpc";
+const NETWORK_PASSPHRASE =
+  process.env.NETWORK_PASSPHRASE ?? Networks.STANDALONE;
+const INDEXER_GRAPHQL_URL =
+  process.env.INDEXER_GRAPHQL_URL ?? "http://localhost:4000/graphql";
+const INDEXER_POLL_ATTEMPTS = Number(process.env.INDEXER_POLL_ATTEMPTS ?? 45);
+const INDEXER_POLL_MS = Number(process.env.INDEXER_POLL_MS ?? 2000);
+
+function resolveContractId(): string {
+  if (process.env.CONTRACT_ID) return process.env.CONTRACT_ID;
+  const idFile = resolve(__dirname, "../../../../.local.contract-id");
+  if (existsSync(idFile)) return readFileSync(idFile, "utf8").trim();
+  throw new Error(
+    "CONTRACT_ID env var not set and .local.contract-id not found. Run setup_local.sh.",
+  );
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const server = new SorobanRpc.Server(RPC_URL, { allowHttp: true });
+
+async function fundAccount(keypair: Keypair): Promise<void> {
+  const friendbotUrl = `http://localhost:8000/friendbot?addr=${keypair.publicKey()}`;
+  const res = await fetch(friendbotUrl);
+  if (!res.ok) throw new Error(`Friendbot failed: ${res.status}`);
+}
+
+async function invoke(
+  contractId: string,
+  method: string,
+  args: ReturnType<typeof nativeToScVal>[],
+  signer: Keypair,
+): Promise<string> {
+  const contract = new Contract(contractId);
+  const account = await server.getAccount(signer.publicKey());
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(30)
+    .build();
+
+  const simResult = await server.simulateTransaction(tx);
+  if (SorobanRpc.Api.isSimulationError(simResult)) {
+    throw new Error(`Simulation failed for ${method}: ${simResult.error}`);
+  }
+
+  const prepared = SorobanRpc.assembleTransaction(
+    tx,
+    simResult as SorobanRpc.Api.SimulateTransactionSuccessResponse,
+  ).build();
+
+  prepared.sign(signer);
+  const sendResult = await server.sendTransaction(prepared);
+  if (sendResult.status === "ERROR") {
+    throw new Error(
+      `sendTransaction failed for ${method}: ${JSON.stringify(sendResult.errorResult)}`,
+    );
+  }
+
+  const hash = sendResult.hash;
+  for (let i = 0; i < 30; i++) {
+    await new Promise((r) => setTimeout(r, 1000));
+    const status = await server.getTransaction(hash);
+    if (status.status === SorobanRpc.Api.GetTransactionStatus.SUCCESS) return hash;
+    if (status.status === SorobanRpc.Api.GetTransactionStatus.FAILED) {
+      throw new Error(`Transaction ${hash} failed for ${method}`);
+    }
+  }
+  throw new Error(`Transaction ${hash} timed out for ${method}`);
+}
+
+async function simulate<T>(
+  contractId: string,
+  method: string,
+  args: ReturnType<typeof nativeToScVal>[],
+): Promise<T> {
+  const contract = new Contract(contractId);
+  const dummySource =
+    "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+  const account = await server.getAccount(dummySource).catch(
+    () =>
+      ({
+        accountId: () => dummySource,
+        sequenceNumber: () => "0",
+        incrementSequenceNumber: () => {},
+      }) as never,
+  );
+
+  const tx = new TransactionBuilder(account as never, {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(30)
+    .build();
+
+  const result = await server.simulateTransaction(tx);
+  if (SorobanRpc.Api.isSimulationError(result)) {
+    throw new Error(`Simulation failed for ${method}: ${result.error}`);
+  }
+  const success = result as SorobanRpc.Api.SimulateTransactionSuccessResponse;
+  if (!success.result) throw new Error(`No result from ${method}`);
+
+  const { scValToNative } = await import("@stellar/stellar-sdk");
+  return scValToNative(success.result.retval) as T;
+}
+
+function addr(address: string) {
+  return Address.fromString(address).toScVal();
+}
+
+function str(value: string) {
+  return nativeToScVal(value, { type: "string" });
+}
+
+type GraphQLAttestation = {
+  id: string;
+  issuer: string;
+  subject: string;
+  claimType: string;
+  timestamp: string;
+  expiration: string | null;
+  isRevoked: boolean;
+  metadata: string | null;
+};
+
+async function queryIndexerAttestation(
+  attestationId: string,
+  subject: string,
+  claimType: string,
+): Promise<GraphQLAttestation | null> {
+  const query = `
+    query ConsistencyCheck($subject: String!, $claimType: String) {
+      attestations(subject: $subject, claimType: $claimType, first: 50) {
+        edges {
+          node {
+            id
+            issuer
+            subject
+            claimType
+            timestamp
+            expiration
+            isRevoked
+            metadata
+          }
+        }
+      }
+    }
+  `;
+
+  const res = await fetch(INDEXER_GRAPHQL_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      query,
+      variables: { subject, claimType },
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`GraphQL HTTP ${res.status}: ${await res.text()}`);
+  }
+
+  const body = (await res.json()) as {
+    data?: {
+      attestations?: { edges: Array<{ node: GraphQLAttestation }> };
+    };
+    errors?: unknown[];
+  };
+
+  if (body.errors?.length) {
+    throw new Error(`GraphQL errors: ${JSON.stringify(body.errors)}`);
+  }
+
+  const edges = body.data?.attestations?.edges ?? [];
+  return edges.map((e) => e.node).find((n) => n.id === attestationId) ?? null;
+}
+
+async function waitForIndexedAttestation(
+  attestationId: string,
+  subject: string,
+  claimType: string,
+): Promise<GraphQLAttestation> {
+  let lastError: unknown;
+  for (let i = 0; i < INDEXER_POLL_ATTEMPTS; i++) {
+    try {
+      const found = await queryIndexerAttestation(
+        attestationId,
+        subject,
+        claimType,
+      );
+      if (found) return found;
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((r) => setTimeout(r, INDEXER_POLL_MS));
+  }
+  throw new Error(
+    `Indexer did not surface attestation ${attestationId} after ${INDEXER_POLL_ATTEMPTS} polls. Last error: ${lastError}`,
+  );
+}
+
+// ── Test Suite ──────────────────────────────────────────────────────────────
+
+describe("Contract ↔ indexer consistency (shared attestation ID)", () => {
+  let contractId: string;
+  let adminKeypair: Keypair;
+  let issuerKeypair: Keypair;
+  let subjectKeypair: Keypair;
+
+  beforeAll(async () => {
+    contractId = resolveContractId();
+    adminKeypair = process.env.ADMIN_SECRET
+      ? Keypair.fromSecret(process.env.ADMIN_SECRET)
+      : Keypair.random();
+    issuerKeypair = process.env.ISSUER_SECRET
+      ? Keypair.fromSecret(process.env.ISSUER_SECRET)
+      : Keypair.random();
+    subjectKeypair = Keypair.random();
+
+    await Promise.all([
+      fundAccount(adminKeypair),
+      fundAccount(issuerKeypair),
+      fundAccount(subjectKeypair),
+    ]);
+  }, 60_000);
+
+  it("matches live contract fields for a happy-path attestation ID", async () => {
+    const claimType = "CONSISTENCY_CHECK";
+
+    // Ensure issuer is registered (idempotent enough for local e2e).
+    try {
+      await invoke(
+        contractId,
+        "register_issuer",
+        [addr(adminKeypair.publicKey()), addr(issuerKeypair.publicKey())],
+        adminKeypair,
+      );
+    } catch {
+      // Already registered from a prior run — continue.
+    }
+
+    await invoke(
+      contractId,
+      "create_attestation",
+      [
+        addr(issuerKeypair.publicKey()),
+        addr(subjectKeypair.publicKey()),
+        str(claimType),
+        nativeToScVal(null),
+        nativeToScVal(null),
+      ],
+      issuerKeypair,
+    );
+
+    const subjectAttestations: Array<{ id: string }> = await simulate(
+      contractId,
+      "get_subject_attestations",
+      [
+        addr(subjectKeypair.publicKey()),
+        nativeToScVal(0, { type: "u32" }),
+        nativeToScVal(10, { type: "u32" }),
+      ],
+    );
+    expect(subjectAttestations.length).toBeGreaterThan(0);
+    const attestationId = subjectAttestations[0].id;
+
+    const onChain: {
+      id: string;
+      issuer: string;
+      subject: string;
+      claim_type: string;
+      timestamp: number | bigint | string;
+      expiration: number | bigint | string | null;
+      revoked: boolean;
+      metadata: string | null;
+    } = await simulate(contractId, "get_attestation", [str(attestationId)]);
+
+    expect(onChain.id).toBe(attestationId);
+
+    const indexed = await waitForIndexedAttestation(
+      attestationId,
+      subjectKeypair.publicKey(),
+      claimType,
+    );
+
+    // Field-for-field equality on the shared identity / status surface.
+    expect(indexed.id).toBe(onChain.id);
+    expect(indexed.issuer).toBe(String(onChain.issuer));
+    expect(indexed.subject).toBe(String(onChain.subject));
+    expect(indexed.claimType).toBe(onChain.claim_type);
+    expect(indexed.timestamp).toBe(String(onChain.timestamp));
+    expect(indexed.isRevoked).toBe(Boolean(onChain.revoked));
+    expect(indexed.metadata ?? null).toBe(onChain.metadata ?? null);
+    expect(indexed.expiration ?? null).toBe(
+      onChain.expiration == null ? null : String(onChain.expiration),
+    );
+  }, 180_000);
+});


### PR DESCRIPTION
closes #980 
closes #983 
closes #984 
closes #992

### PR description

## Summary

Closes four audit follow-ups: contract↔indexer agreement coverage, scheduled reconciliation with drift alerts, an `ms_sign` crash fix plus regression test, and a real `GOVERNANCE.md`.

### Task 1 — Contract-vs-indexer consistency e2e
- Added `sdk/typescript/e2e/contract-indexer-consistency.e2e.test.ts`
- Happy-path: create attestation → wait for indexer → compare `get_attestation` vs GraphQL for the same ID (issuer, subject, claimType, timestamp, expiration, isRevoked, metadata)
- Documented in `docs/e2e-request-flow-guide.md` alongside the existing e2e suite
- Requires local Quickstart + deployed contract + indexer GraphQL (`INDEXER_GRAPHQL_URL`, default `http://localhost:4000/graphql`)

### Task 2 — Reconciliation job
- Added `indexer/src/reconciliation.ts`: samples recent attestations, re-fetches via RPC `get_attestation`, diffs fields, logs alerts, emits Prometheus counters/gauges
- Scheduled from `startIndexer` via `RECONCILE_INTERVAL_MINUTES` (default 60) and `RECONCILE_SAMPLE_SIZE` (default 50)
- Tests in `reconciliation.test.ts` assert a deliberate `claimType` mismatch is detected and reported; schedule callback is covered with fake timers
- Env docs: `indexer/.env.example`, `indexer/README.md`

### Task 3 — `ms_sign` undefined-variable regression
- Bug: handler referenced undefined `updatedSigners` → runtime crash
- Fix: `indexer/src/ms-sign.ts` (`handleMsSign`) builds `updatedSigners` from existing signers + event signer; wired from `handleEvent`
- Regression suite `ms-sign-handler.test.ts` parses a realistic Soroban `ms_sign` payload and drives the real handler (signer append, idempotent re-sign, missing proposal)
- Verified: **9/9** tests pass (`ms-sign-handler` + `reconciliation`)

### Task 4 — Rewrite `GOVERNANCE.md`
- Replaced leftover PR-description text with project governance: maintainer roles, day-to-day vs ADR/RFC decisions, adding/removing maintainers, scope boundaries, links to CONTRIBUTING / SECURITY / ADRs / CODEOWNERS
- No leftover “What I changed…” content

## Test plan
- [ ] `cd indexer && npx jest --testPathPattern='(ms-sign-handler|reconciliation)'`
- [ ] With Quickstart + contract + indexer up: run `contract-indexer-consistency.e2e.test.ts`
- [ ] Confirm `GOVERNANCE.md` reads as policy (no PR leftover text)
- [ ] Spot-check reconciler logs/metrics after introducing a bad indexed `claimType`