### PR TITLE
docs: add ISSUE_TEMPLATE/config.yml with template chooser and contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 TrustLink Community Discussions
+    url: https://github.com/Haroldwonder/TrustLink/discussions
+    about: Ask questions, share ideas, and discuss with the community
+  - name: 📖 TrustLink Documentation
+    url: https://github.com/Haroldwonder/TrustLink#readme
+    about: Read the documentation before opening an issue
+  - name: 🔒 Report a Security Vulnerability
+    url: https://github.com/Haroldwonder/TrustLink/security/advisories/new
+    about: Please report security vulnerabilities privately


### PR DESCRIPTION
## Description
Adds `.github/ISSUE_TEMPLATE/config.yml` to provide a template chooser with helpful contact links.

Closes #996

## Changes
- Added `config.yml` with `blank_issues_enabled: true`
- Added 3 contact links: Community Discussions, Documentation, and Security Advisories
- Follows GitHub's issue template chooser specification

## Testing
- Valid YAML syntax confirmed
- All URLs point to valid TrustLink resources
