### PR TITLE
docs: add issue templates, translations, SLA, and contributor guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,43 @@
+name: "📚 Documentation"
+description: Report a typo, unclear section, or missing content in the docs
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for issues with documentation — typos, unclear wording, outdated instructions, or missing content.
+  - type: input
+    id: location
+    attributes:
+      label: Where is the issue?
+      description: File path or URL (e.g. `docs/quickstart.md`, `README.md#usage`)
+    validations:
+      required: true
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type of issue
+      options:
+        - Typo / grammar
+        - Unclear or confusing explanation
+        - Outdated or incorrect information
+        - Missing content
+        - Broken link
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What's wrong, and what would you expect to see instead?
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix (optional)
+      description: If you already have wording or content in mind, share it here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,37 @@
+name: "❓ Question / Support"
+description: Ask a question or get help using TrustLink
+title: "[Question]: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for usage questions or support requests. For bugs, please use the Bug Report template instead.
+  - type: textarea
+    id: question
+    attributes:
+      label: What's your question?
+      description: Be as specific as possible.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What are you trying to accomplish? Include relevant code, config, or contract addresses.
+    validations:
+      required: false
+  - type: input
+    id: area
+    attributes:
+      label: Area
+      description: Which part of TrustLink does this relate to? (e.g. contract, TypeScript SDK, Python SDK, indexer, examples, docs)
+    validations:
+      required: false
+  - type: textarea
+    id: attempts
+    attributes:
+      label: What have you already tried?
+      description: Docs read, approaches attempted, etc.
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,10 @@ pre-commit run cargo-fmt     # check one hook by id
 
 Before diving in, read [docs/stellar-concepts.md](docs/stellar-concepts.md) for a beginner-friendly explanation of ledger timestamps, storage TTL, `require_auth`, and the WASM deployment model — concepts that come up throughout the codebase.
 
+## Not sure where to start?
+
+See [docs/good-first-issues.md](docs/good-first-issues.md) for concrete starter tasks across the contract, SDKs, indexer, examples, and docs.
+
 ## Prerequisites
 
 | Tool          | Version                            | Install                                    |
@@ -413,6 +417,19 @@ cargo audit --advisory RUSTSEC-YYYY-NNNNN
 - Review changelogs before major version updates
 - Test thoroughly after updates
 - Document breaking changes in PR description
+
+## Maintainer Response-Time SLA
+
+To set clear expectations for contributors, maintainers aim to respond within the following timeframes. "Respond" means an initial triage comment, label, or reaction — not necessarily a full resolution.
+
+| Item | First response |
+|------|-----------------|
+| New issue (bug, feature, question, docs) | Within 5 business days |
+| New pull request | Within 5 business days |
+| Follow-up comment on an open issue/PR | Within 5 business days |
+| Security report (see [Reporting Security Issues](README.md#reporting-security-issues)) | Follows the dedicated security disclosure process, not this table |
+
+These are targets, not guarantees — response times may be longer around releases or during maintainer availability gaps. If you haven't heard back after the window above, a polite ping on the issue/PR is welcome.
 
 ## Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -975,6 +975,10 @@ New to TrustLink or Soroban? Watch the [TrustLink Video Tutorial](https://www.yo
 
 A companion written guide with all commands and code snippets is available at [docs/video-tutorial-guide.md](docs/video-tutorial-guide.md).
 
+## Quickstart & Glossary
+
+New to TrustLink? [docs/quickstart.md](docs/quickstart.md) gets you from clone to a verified claim in a few minutes, and [docs/glossary.md](docs/glossary.md) covers the key terms used throughout these docs. Both are also available in [Español](docs/i18n/es/quickstart.md) ([glosario](docs/i18n/es/glossary.md)) — see [docs/i18n/](docs/i18n/) for the translation directory convention.
+
 ## Integration Guide
 
 For a step-by-step walkthrough covering Rust cross-contract patterns, JavaScript/TypeScript usage, error handling, and testnet testing, see [docs/integration-guide.md](docs/integration-guide.md).

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,22 @@
+# Glossary
+
+Key terms used throughout the TrustLink documentation and codebase.
+
+| Term | Definition |
+|---|---|
+| **Attestation** | An on-chain record created by an issuer that a subject holds a specific claim (e.g. "KYC_PASSED"). |
+| **Claim** | A named assertion about a subject, such as `KYC_PASSED` or `ACCREDITED_INVESTOR`. Claim types are registered before use. |
+| **Issuer** | An address authorized by the admin to create attestations. Issuers can be added or removed by the admin. |
+| **Subject** | The address that an attestation is issued about (e.g. the user being KYC-verified). |
+| **Admin** | The address with authority to configure the contract: registering issuers, setting fees, managing bridge contracts, and transferring admin rights. |
+| **Bridge Contract** | An external contract registered to import attestations that originated on another chain. |
+| **Revocation** | Marking an existing attestation as no longer valid. TrustLink keeps an immutable history — revoked attestations are not deleted, only flagged. |
+| **Expiration** | An optional `valid_to` timestamp after which an attestation is no longer considered valid. |
+| **TTL (Time To Live)** | The Soroban ledger mechanism controlling how long persistent storage entries remain live before requiring an extension. See [docs/stellar-concepts.md](stellar-concepts.md). |
+| **`require_auth`** | The Soroban SDK call that verifies the calling address has authorized the current invocation. |
+| **Multi-Sig Attestation** | An attestation that requires signatures/approval from multiple issuers before becoming valid. |
+| **Indexer** | The off-chain service (`indexer/`) that reads contract events and stores them in a queryable database. |
+| **Soroban** | Stellar's smart contract platform, which TrustLink's contract is built on. |
+| **WASM** | WebAssembly — the compiled binary format Soroban contracts run as. |
+
+Translations of this glossary: [Español](i18n/es/glossary.md)

--- a/docs/good-first-issues.md
+++ b/docs/good-first-issues.md
@@ -1,0 +1,46 @@
+# Good First Issues
+
+TrustLink spans a Rust smart contract, two SDKs (TypeScript and Python), an off-chain indexer, several example apps, and a large set of documentation. This guide gives new contributors a concrete starting point in each subsystem, without having to first understand the whole codebase.
+
+Browse all currently open starter tasks with the [`good first issue`](https://github.com/Haroldwonder/TrustLink/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) label.
+
+## Contract (Rust / Soroban)
+
+The core on-chain logic lives at the repo root (`src/`, built with `cargo build`/`cargo test`).
+
+- Start with [docs/stellar-concepts.md](stellar-concepts.md) if you're new to Soroban.
+- Good starter tasks: adding a new read-only query function, improving error messages, adding unit tests for an existing code path, or fixing a Clippy warning.
+- Setup: see [CONTRIBUTING.md](../CONTRIBUTING.md#prerequisites) for Rust/wasm32 toolchain install.
+
+## SDKs (TypeScript & Python)
+
+- TypeScript bindings: `bindings/typescript/`
+- Python bindings: `bindings/python/`
+- Good starter tasks: improving type coverage, adding usage examples to SDK README files, adding a convenience wrapper method, or fixing a bug in request/response parsing.
+- See [docs/bindings-generation.md](bindings-generation.md) for how bindings are generated from the contract WASM.
+
+## Indexer
+
+The off-chain indexer lives in `indexer/` (Prisma + TypeScript).
+
+- Good starter tasks: adding a new indexed field, writing a migration, improving indexer logging, or adding a query helper.
+- See [docs/monitoring.md](monitoring.md) for how the indexer relates to event streaming.
+
+## Examples
+
+`examples/` contains standalone sample integrations: `react-app`, `python-verification`, `kyc-token`, `issuer-cli`, `anchor-integration`, `governance`.
+
+- Good starter tasks: fixing a broken example, adding comments/README clarifications, updating an example to use a newer SDK method, or adding a small new example for an uncovered use case.
+
+## Documentation
+
+`docs/` holds all project documentation.
+
+- Good starter tasks: fixing typos or broken links, clarifying a confusing section, adding a missing explanation, or translating a doc (see [docs/i18n/](i18n/)).
+- The [Documentation issue template](../.github/ISSUE_TEMPLATE/documentation.yml) is a good way to report gaps you find while reading.
+
+## After you pick a task
+
+1. Comment on the issue to claim it.
+2. Follow the [Local Setup](../CONTRIBUTING.md#local-setup) and [PR Process](../CONTRIBUTING.md#pr-process) sections of `CONTRIBUTING.md`.
+3. Open a PR referencing the issue (`Closes #123`).

--- a/docs/i18n/README.md
+++ b/docs/i18n/README.md
@@ -1,0 +1,18 @@
+# Translated Documentation
+
+Translations of TrustLink docs live under `docs/i18n/<lang>/`, where `<lang>` is a two-letter [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) code (e.g. `es` for Spanish).
+
+Each translated file should:
+
+- Mirror the filename of the English source it translates (e.g. `docs/quickstart.md` → `docs/i18n/es/quickstart.md`).
+- Link back to the English original near the top (`*[Read this in English](../../quickstart.md)*`).
+- Be linked from the English original's "Translations" line.
+
+## Available translations
+
+| Document | Languages |
+|---|---|
+| [Quickstart](../quickstart.md) | [Español](es/quickstart.md) |
+| [Glossary](../glossary.md) | [Español](es/glossary.md) |
+
+To add a new language, create `docs/i18n/<lang>/` and translate the files you want covered — a full set isn't required to start.

--- a/docs/i18n/es/glossary.md
+++ b/docs/i18n/es/glossary.md
@@ -1,0 +1,22 @@
+# Glosario
+
+Términos clave usados en la documentación y el código de TrustLink.
+
+*[Read this in English](../../glossary.md)*
+
+| Término | Definición |
+|---|---|
+| **Attestation (Atestación)** | Un registro on-chain creado por un issuer que certifica que un subject posee un claim específico (p. ej. "KYC_PASSED"). |
+| **Claim** | Una afirmación con nombre sobre un subject, como `KYC_PASSED` o `ACCREDITED_INVESTOR`. Los tipos de claim se registran antes de usarse. |
+| **Issuer (Emisor)** | Una dirección autorizada por el admin para crear atestaciones. El admin puede añadir o eliminar issuers. |
+| **Subject (Sujeto)** | La dirección sobre la que se emite una atestación (p. ej. el usuario que se está verificando con KYC). |
+| **Admin (Administrador)** | La dirección con autoridad para configurar el contrato: registrar issuers, establecer comisiones, gestionar contratos puente y transferir derechos de administrador. |
+| **Bridge Contract (Contrato puente)** | Un contrato externo registrado para importar atestaciones originadas en otra cadena. |
+| **Revocation (Revocación)** | Marcar una atestación existente como no válida. TrustLink mantiene un historial inmutable — las atestaciones revocadas no se eliminan, solo se marcan. |
+| **Expiration (Expiración)** | Una marca de tiempo `valid_to` opcional después de la cual una atestación deja de considerarse válida. |
+| **TTL (Time To Live)** | El mecanismo del ledger de Soroban que controla cuánto tiempo permanecen activas las entradas de almacenamiento persistente antes de requerir una extensión. Ver [docs/stellar-concepts.md](../../stellar-concepts.md). |
+| **`require_auth`** | La llamada del SDK de Soroban que verifica que la dirección que llama ha autorizado la invocación actual. |
+| **Multi-Sig Attestation (Atestación multifirma)** | Una atestación que requiere firmas/aprobación de varios issuers antes de ser válida. |
+| **Indexer (Indexador)** | El servicio off-chain (`indexer/`) que lee los eventos del contrato y los almacena en una base de datos consultable. |
+| **Soroban** | La plataforma de contratos inteligentes de Stellar sobre la que está construido el contrato de TrustLink. |
+| **WASM** | WebAssembly — el formato binario compilado en el que se ejecutan los contratos de Soroban. |

--- a/docs/i18n/es/quickstart.md
+++ b/docs/i18n/es/quickstart.md
@@ -1,0 +1,57 @@
+# Guía de inicio rápido
+
+Pon en marcha un contrato TrustLink y verifica claims en pocos minutos.
+
+*[Read this in English](../../quickstart.md)*
+
+## 1. Requisitos previos
+
+| Herramienta | Instalación |
+|---|---|
+| Rust (stable) | https://rustup.rs |
+| Target wasm32 | `rustup target add wasm32-unknown-unknown` |
+| Soroban CLI | `cargo install --locked soroban-cli` |
+
+## 2. Usa el despliegue en testnet
+
+Ya existe una instancia de TrustLink desplegada en Stellar Testnet, así que puedes empezar a integrar sin desplegar la tuya propia:
+
+```
+Contract ID: CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCN8
+Network Passphrase: Test SDF Network ; September 2015
+RPC URL: https://soroban-testnet.stellar.org
+```
+
+## 3. O ejecuta tu propia instancia local
+
+```bash
+# Clona el repositorio
+git clone https://github.com/Haroldwonder/TrustLink.git
+cd TrustLink
+
+# Inicia un nodo local de Stellar Quickstart
+docker compose up -d
+
+# Compila, despliega e inicializa localmente
+make local-deploy
+```
+
+El ID del contrato desplegado se escribe en `.local.contract-id`.
+
+## 4. Verifica un claim (llamada cross-contract en Rust)
+
+```rust
+let trustlink = trustlink::Client::new(&env, &trustlink_id);
+let claim = String::from_str(&env, "KYC_PASSED");
+
+if !trustlink.has_valid_claim(&subject, &claim) {
+    return Err(Error::KYCRequired);
+}
+```
+
+## 5. Siguientes pasos
+
+- Patrones completos de integración en Rust y TypeScript: [docs/integration-guide.md](../../integration-guide.md)
+- Términos clave usados en toda la documentación: [docs/glossary.md](glossary.md)
+- Modelo de seguridad y jerarquía de confianza: [docs/security.md](../../security.md)
+- ¿No conoces conceptos de Soroban como TTL o `require_auth`? Consulta [docs/stellar-concepts.md](../../stellar-concepts.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,57 @@
+# Quickstart
+
+Get a TrustLink contract deployed and verifying claims in a few minutes.
+
+## 1. Prerequisites
+
+| Tool | Install |
+|---|---|
+| Rust (stable) | https://rustup.rs |
+| wasm32 target | `rustup target add wasm32-unknown-unknown` |
+| Soroban CLI | `cargo install --locked soroban-cli` |
+
+## 2. Use the testnet deployment
+
+A TrustLink instance is already deployed on Stellar Testnet, so you can start integrating without deploying your own:
+
+```
+Contract ID: CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCN8
+Network Passphrase: Test SDF Network ; September 2015
+RPC URL: https://soroban-testnet.stellar.org
+```
+
+## 3. Or run your own local instance
+
+```bash
+# Clone
+git clone https://github.com/Haroldwonder/TrustLink.git
+cd TrustLink
+
+# Start a local Stellar Quickstart node
+docker compose up -d
+
+# Build, deploy, and initialize locally
+make local-deploy
+```
+
+The deployed contract ID is written to `.local.contract-id`.
+
+## 4. Verify a claim (Rust cross-contract call)
+
+```rust
+let trustlink = trustlink::Client::new(&env, &trustlink_id);
+let claim = String::from_str(&env, "KYC_PASSED");
+
+if !trustlink.has_valid_claim(&subject, &claim) {
+    return Err(Error::KYCRequired);
+}
+```
+
+## 5. Next steps
+
+- Full Rust and TypeScript integration patterns: [docs/integration-guide.md](integration-guide.md)
+- Key terms used throughout the docs: [docs/glossary.md](glossary.md)
+- Security model and trust hierarchy: [docs/security.md](security.md)
+- Unfamiliar with Soroban concepts like TTL or `require_auth`? See [docs/stellar-concepts.md](stellar-concepts.md)
+
+Translations of this guide: [Español](i18n/es/quickstart.md)


### PR DESCRIPTION
## Summary
- Add Question/Support and Documentation issue templates (`.github/ISSUE_TEMPLATE/`)
- Add `docs/quickstart.md` and `docs/glossary.md`, with Spanish translations under `docs/i18n/es/` and a translation directory convention documented in `docs/i18n/README.md`, linked from the README
- Document a maintainer response-time SLA for new issues/PRs in `CONTRIBUTING.md`
- Add `docs/good-first-issues.md` contributor onboarding guide, referenced from `CONTRIBUTING.md`

Closes #997
Closes #998
Closes #999
Closes #1000

## Test plan
Docs-only change; tests skipped per request.
- [x] Reviewed rendered Markdown/YAML for correctness
- [x] Verified relative links resolve to existing files