### PR TITLE
Fix bindings resilience, CODEOWNERS coverage, and docs (#957, #994, #995, #996)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,40 @@
 # TypeScript and React SDKs — owned by the SDK team
 /sdk/ @Haroldwonder/sdk-team
 
+# Generated contract bindings — owned by the SDK team
+/bindings/ @Haroldwonder/sdk-team
+
+# Off-chain indexer service — owned by the indexer team
+/indexer/ @Haroldwonder/indexer-team
+
+# Infrastructure-as-code — owned by the devops team
+/infra/ @Haroldwonder/devops-team
+
+# Monitoring and alerting configuration — owned by the devops team
+/monitoring/ @Haroldwonder/devops-team
+
+# CI/CD workflows — owned by the devops team
+/.github/workflows/ @Haroldwonder/devops-team
+
+# Build and dev scripts — owned by the devops team
+/scripts/ @Haroldwonder/devops-team
+
+# Fuzz targets — owned by the security team
+/fuzz/ @Haroldwonder/security-team
+
+# Contract benchmarks — owned by the contract team
+/benches/ @Haroldwonder/contract-team
+
+# Root-level integration tests and snapshots — owned by the contract team
+/tests/ @Haroldwonder/contract-team
+/test_snapshots/ @Haroldwonder/contract-team
+
+# Integration examples — owned by the devrel team
+/examples/ @Haroldwonder/devrel-team
+
+# General documentation — owned by the devrel team
+/docs/ @Haroldwonder/devrel-team
+
 # Security-related documentation — owned by the security team
 /docs/security*.md @Haroldwonder/security-team
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/Haroldwonder/TrustLink/security/advisories/new
+    about: Report a security vulnerability privately. Do NOT open a public issue — see SECURITY.md. You can also email security@trustlink.io.
+  - name: General Questions & Discussions
+    url: https://github.com/Haroldwonder/TrustLink/discussions
+    about: Ask questions or discuss ideas that aren't a bug report or feature request.

--- a/bindings/typescript/src/client.ts
+++ b/bindings/typescript/src/client.ts
@@ -48,6 +48,14 @@ import {
   TrustLinkError,
 } from "./validation";
 
+import {
+  CircuitBreaker,
+  withRetry,
+  type RetryOptions,
+  type CircuitBreakerOptions,
+  type ResilienceConfig,
+} from "./resilience";
+
 export type { Attestation, AttestationStatus, AuditEntry, ClaimTypeInfo,
   ContractConfig, ContractMetadata, Delegation, Endorsement, FeeConfig, GlobalStats,
   HealthStatus, IssuerMetadata, IssuerStats, IssuerTier, MultiSigProposal,
@@ -62,6 +70,12 @@ export interface TrustLinkClientOptions {
   rpcUrl: string;
   /** Network passphrase. Defaults to testnet. */
   networkPassphrase?: string;
+  /** Fine-grained retry configuration for transient RPC failures. */
+  retry?: RetryOptions;
+  /** Fine-grained circuit breaker configuration. */
+  circuitBreaker?: CircuitBreakerOptions;
+  /** Simplified resilience configuration (used if `retry`/`circuitBreaker` are not given). */
+  resilience?: ResilienceConfig;
 }
 
 // ─── Internal helpers ─────────────────────────────────────────────────────────
@@ -118,35 +132,53 @@ export class TrustLinkClient {
   private readonly server: rpc.Server;
   private readonly networkPassphrase: string;
   private readonly contractId: string;
+  private readonly retryOptions: RetryOptions;
+  private readonly breaker: CircuitBreaker;
 
   constructor(opts: TrustLinkClientOptions) {
     this.contractId = opts.contractId;
     this.contract = new Contract(opts.contractId);
     this.server = new rpc.Server(opts.rpcUrl, { allowHttp: opts.rpcUrl.startsWith("http://") });
     this.networkPassphrase = opts.networkPassphrase ?? Networks.TESTNET;
+
+    const res = opts.resilience ?? {};
+    this.retryOptions = opts.retry ?? {
+      maxAttempts: res.maxRetries,
+      initialDelayMs: res.backoffMs,
+    };
+    this.breaker = new CircuitBreaker(opts.circuitBreaker ?? {
+      failureThreshold: res.circuitBreakerThreshold,
+    });
+  }
+
+  /** Run an RPC call with exponential backoff retry and circuit breaker protection. */
+  private rpcRetry<T>(fn: () => Promise<T>): Promise<T> {
+    return withRetry(fn, this.retryOptions, this.breaker);
   }
 
   // ─── Low-level helpers ──────────────────────────────────────────────────────
 
   /** Simulate a read-only call and return the decoded native value. */
   private async simulate(method: string, args: xdr.ScVal[]): Promise<unknown> {
-    const op = this.contract.call(method, ...args);
-    const account = new Account("GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN", "0");
-    const tx = new TransactionBuilder(account, {
-      fee: BASE_FEE,
-      networkPassphrase: this.networkPassphrase,
-    })
-      .addOperation(op)
-      .setTimeout(30)
-      .build();
+    return this.rpcRetry(async () => {
+      const op = this.contract.call(method, ...args);
+      const account = new Account("GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN", "0");
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(op)
+        .setTimeout(30)
+        .build();
 
-    const result = await this.server.simulateTransaction(tx);
-    if (rpc.Api.isSimulationError(result)) {
-      throw new Error(parseError(result));
-    }
-    const simSuccess = result as rpc.Api.SimulateTransactionSuccessResponse;
-    if (!simSuccess.result) throw new Error("No result returned from simulation");
-    return scValToNative(simSuccess.result.retval);
+      const result = await this.server.simulateTransaction(tx);
+      if (rpc.Api.isSimulationError(result)) {
+        throw new Error(parseError(result));
+      }
+      const simSuccess = result as rpc.Api.SimulateTransactionSuccessResponse;
+      if (!simSuccess.result) throw new Error("No result returned from simulation");
+      return scValToNative(simSuccess.result.retval);
+    });
   }
 
   /**
@@ -158,7 +190,7 @@ export class TrustLinkClient {
     args: xdr.ScVal[],
     signer: Keypair,
   ): Promise<string> {
-    const account = await this.server.getAccount(signer.publicKey());
+    const account = await this.rpcRetry(() => this.server.getAccount(signer.publicKey()));
     const op = this.contract.call(method, ...args);
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
@@ -168,7 +200,7 @@ export class TrustLinkClient {
       .setTimeout(30)
       .build();
 
-    const simResult = await this.server.simulateTransaction(tx);
+    const simResult = await this.rpcRetry(() => this.server.simulateTransaction(tx));
     if (rpc.Api.isSimulationError(simResult)) {
       throw new Error(parseError(simResult));
     }
@@ -176,15 +208,17 @@ export class TrustLinkClient {
     const prepared = rpc.assembleTransaction(tx, simResult).build() as Transaction;
     prepared.sign(signer);
 
-    const sendResult = await this.server.sendTransaction(prepared);
+    // Retries only cover transport-level failures reaching the RPC node — an
+    // "ERROR" response (an on-chain rejection) is surfaced immediately, not retried.
+    const sendResult = await this.rpcRetry(() => this.server.sendTransaction(prepared));
     if (sendResult.status === "ERROR") {
       throw new Error(`Transaction failed: ${JSON.stringify(sendResult.errorResult)}`);
     }
 
-    let getResult = await this.server.getTransaction(sendResult.hash);
+    let getResult = await this.rpcRetry(() => this.server.getTransaction(sendResult.hash));
     for (let i = 0; i < 20 && getResult.status === "NOT_FOUND"; i++) {
       await new Promise((r) => setTimeout(r, 1500));
-      getResult = await this.server.getTransaction(sendResult.hash);
+      getResult = await this.rpcRetry(() => this.server.getTransaction(sendResult.hash));
     }
 
     if (getResult.status !== "SUCCESS") {

--- a/bindings/typescript/src/index.ts
+++ b/bindings/typescript/src/index.ts
@@ -21,3 +21,5 @@
 export * from "./types";
 export * from "./client";
 export * from "./validation";
+export { CircuitBreaker, withRetry } from "./resilience";
+export type { RetryOptions, CircuitBreakerOptions, ResilienceConfig } from "./resilience";

--- a/bindings/typescript/src/resilience.ts
+++ b/bindings/typescript/src/resilience.ts
@@ -1,0 +1,135 @@
+/**
+ * Resilience utilities: exponential backoff retry and circuit breaker.
+ */
+
+/** Simplified resilience config accepted by TrustLinkClient constructor. */
+export interface ResilienceConfig {
+  /** Maximum number of retry attempts (default: 3) */
+  maxRetries?: number;
+  /** Initial backoff delay in ms (default: 200) */
+  backoffMs?: number;
+  /** Failure count before opening the circuit breaker (default: 5) */
+  circuitBreakerThreshold?: number;
+}
+
+export interface RetryOptions {
+  /** Maximum number of attempts (default: 3) */
+  maxAttempts?: number;
+  /** Initial delay in ms (default: 200) */
+  initialDelayMs?: number;
+  /** Maximum delay cap in ms (default: 10_000) */
+  maxDelayMs?: number;
+  /** Jitter factor 0–1 (default: 0.2) */
+  jitter?: number;
+  /** Connection timeout in ms applied per attempt (default: 30_000) */
+  timeoutMs?: number;
+}
+
+export interface CircuitBreakerOptions {
+  /** Failures before opening the circuit (default: 5) */
+  failureThreshold?: number;
+  /** Ms to wait before trying half-open (default: 30_000) */
+  resetTimeoutMs?: number;
+}
+
+type CircuitState = "closed" | "open" | "half-open";
+
+export class CircuitBreaker {
+  private state: CircuitState = "closed";
+  private failures = 0;
+  private lastFailureTime = 0;
+
+  private readonly failureThreshold: number;
+  private readonly resetTimeoutMs: number;
+
+  constructor(opts: CircuitBreakerOptions = {}) {
+    this.failureThreshold = opts.failureThreshold ?? 5;
+    this.resetTimeoutMs = opts.resetTimeoutMs ?? 30_000;
+  }
+
+  isOpen(): boolean {
+    if (this.state === "open") {
+      if (Date.now() - this.lastFailureTime >= this.resetTimeoutMs) {
+        this.state = "half-open";
+        return false;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  recordSuccess(): void {
+    this.failures = 0;
+    this.state = "closed";
+  }
+
+  recordFailure(): void {
+    this.failures++;
+    this.lastFailureTime = Date.now();
+    if (this.failures >= this.failureThreshold) {
+      this.state = "open";
+    }
+  }
+
+  getState(): CircuitState {
+    return this.state;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`Operation timed out after ${ms}ms`)),
+      ms
+    );
+    promise.then(
+      (v) => { clearTimeout(timer); resolve(v); },
+      (e) => { clearTimeout(timer); reject(e); }
+    );
+  });
+}
+
+/**
+ * Execute `fn` with exponential backoff retry and optional circuit breaker.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  retryOpts: RetryOptions = {},
+  breaker?: CircuitBreaker
+): Promise<T> {
+  const maxAttempts = retryOpts.maxAttempts ?? 3;
+  const initialDelayMs = retryOpts.initialDelayMs ?? 200;
+  const maxDelayMs = retryOpts.maxDelayMs ?? 10_000;
+  const jitter = retryOpts.jitter ?? 0.2;
+  const timeoutMs = retryOpts.timeoutMs ?? 30_000;
+
+  if (breaker?.isOpen()) {
+    throw new Error("Circuit breaker is open — request rejected");
+  }
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const result = await withTimeout(fn(), timeoutMs);
+      breaker?.recordSuccess();
+      return result;
+    } catch (err) {
+      lastError = err;
+      breaker?.recordFailure();
+
+      if (attempt === maxAttempts) break;
+
+      const base = initialDelayMs * Math.pow(2, attempt - 1);
+      const capped = Math.min(base, maxDelayMs);
+      const jitterMs = capped * jitter * Math.random();
+      await sleep(capped + jitterMs);
+    }
+  }
+
+  throw lastError;
+}

--- a/examples/insurance/README.md
+++ b/examples/insurance/README.md
@@ -1,13 +1,14 @@
 # Insurance Policy Underwriting Example
 
-This example shows how a Soroban insurance contract uses TrustLink to verify a policyholder before issuing coverage.
+This example shows how a Soroban insurance contract uses TrustLink to verify a policyholder before issuing coverage. It models a minimal underwriting flow: an insurer may only issue a policy to a subject who holds valid `KYC_PASSED` and `AML_CLEARED` attestations, keeping identity verification out of the insurer's own storage and delegated to TrustLink.
 
 ## What It Demonstrates
 
-- A contract stores a TrustLink contract address.
-- `issue_policy` checks `has_all_claims(subject, ["KYC_PASSED", "AML_CLEARED"])` on the policyholder.
-- Policy issuance is rejected unless both identity claims are valid.
-- Unit tests cover both allowed and blocked issuance flows.
+- A contract stores a TrustLink contract address at `initialize` time.
+- `issue_policy` checks `has_all_claims(subject, ["KYC_PASSED", "AML_CLEARED"])` on the policyholder before underwriting.
+- Policy issuance is rejected (the call panics) unless **both** identity claims are valid — `has_all_claims` uses AND-logic.
+- Issued policies are numbered sequentially and stored so `get_policy_holder` can look up the holder of any policy.
+- Unit tests cover both the allowed and blocked issuance flows using a mock TrustLink contract.
 
 ## Contract Pattern
 
@@ -23,6 +24,16 @@ if !trustlink.has_all_claims(&policyholder, &required_claims) {
 }
 ```
 
+`issue_policy` requires the insurer's authorization (`insurer.require_auth()`), calls out to the configured TrustLink contract to evaluate the claims, and only then persists a new policy record keyed by an incrementing policy number.
+
+## Scenario Walkthrough
+
+1. **Deploy TrustLink** (or reuse an existing deployment) and register the issuers that will attest `KYC_PASSED` and `AML_CLEARED` for prospective policyholders.
+2. **Deploy the insurance contract** and call `initialize(admin, trustlink_contract)` once, pointing it at the TrustLink deployment.
+3. **Issue attestations** for a policyholder from the registered issuers — `KYC_PASSED` from a KYC provider, `AML_CLEARED` from an AML screening issuer.
+4. **Issue the policy**: the insurer calls `issue_policy(insurer, policyholder)`. TrustLink is queried via `has_all_claims`; if the policyholder is missing either claim (or either has expired or been revoked), the call panics and no policy is created.
+5. **Look up the policyholder** for any issued policy with `get_policy_holder(policy_id)`.
+
 ## Files
 
 - `src/lib.rs`: Insurance contract and unit tests.
@@ -34,3 +45,99 @@ if !trustlink.has_all_claims(&policyholder, &required_claims) {
 cd examples/insurance
 cargo test
 ```
+
+The test suite uses a mock `TrustLink` contract (`MockTrustLink`) to exercise both branches:
+
+| Scenario | Test |
+|---|---|
+| Policyholder has both `KYC_PASSED` and `AML_CLEARED` → policy issued | `issue_policy_allowed_for_policyholders_with_all_claims` |
+| Policyholder is missing at least one claim → issuance rejected | `issue_policy_rejected_when_policyholder_missing_a_claim` |
+
+## Deployment
+
+### Prerequisites
+
+```bash
+cargo install --locked stellar-cli --features opt
+rustup target add wasm32-unknown-unknown
+```
+
+### 1. Build
+
+```bash
+cd examples/insurance
+cargo build --target wasm32-unknown-unknown --release
+```
+
+### 2. Deploy TrustLink (if you need your own instance)
+
+```bash
+export ADMIN_SECRET=SXXX...
+cd ../..
+make deploy NETWORK=testnet
+export TRUSTLINK_ID=C...
+```
+
+### 3. Register the KYC and AML issuers
+
+```bash
+stellar contract invoke --id $TRUSTLINK_ID --source $ADMIN_SECRET --network testnet \
+  -- register_issuer --admin <ADMIN_ADDRESS> --issuer <KYC_ISSUER_ADDRESS>
+
+stellar contract invoke --id $TRUSTLINK_ID --source $ADMIN_SECRET --network testnet \
+  -- register_issuer --admin <ADMIN_ADDRESS> --issuer <AML_ISSUER_ADDRESS>
+```
+
+### 4. Issue the required claims for a policyholder
+
+```bash
+stellar contract invoke --id $TRUSTLINK_ID --source <KYC_ISSUER_SECRET> --network testnet \
+  -- create_attestation \
+  --issuer <KYC_ISSUER_ADDRESS> \
+  --subject <POLICYHOLDER_ADDRESS> \
+  --claim_type KYC_PASSED \
+  --expiration null \
+  --metadata null
+
+stellar contract invoke --id $TRUSTLINK_ID --source <AML_ISSUER_SECRET> --network testnet \
+  -- create_attestation \
+  --issuer <AML_ISSUER_ADDRESS> \
+  --subject <POLICYHOLDER_ADDRESS> \
+  --claim_type AML_CLEARED \
+  --expiration null \
+  --metadata null
+```
+
+### 5. Deploy and initialize the insurance contract
+
+```bash
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/insurance_example.wasm \
+  --source $ADMIN_SECRET \
+  --network testnet
+export INSURANCE_ID=C...
+
+stellar contract invoke --id $INSURANCE_ID --source $ADMIN_SECRET --network testnet \
+  -- initialize \
+  --admin <ADMIN_ADDRESS> \
+  --trustlink_contract $TRUSTLINK_ID
+```
+
+### 6. Issue a policy
+
+```bash
+stellar contract invoke --id $INSURANCE_ID --source <INSURER_SECRET> --network testnet \
+  -- issue_policy \
+  --insurer <INSURER_ADDRESS> \
+  --policyholder <POLICYHOLDER_ADDRESS>
+
+stellar contract invoke --id $INSURANCE_ID --network testnet \
+  -- get_policy_holder --policy_id 1
+```
+
+## Production Notes
+
+- Set a meaningful `expiration` on `KYC_PASSED` and `AML_CLEARED` attestations rather than leaving them permanent — most underwriting programs require periodic re-verification.
+- Use `has_valid_claim_from_issuer` instead of `has_all_claims` if only specific accredited KYC/AML providers should be trusted for underwriting decisions.
+- Subscribe to `Revoked` events from TrustLink in an off-chain indexer so previously-issued policies can be flagged for review if a policyholder's claims are later revoked.
+- Keep sensitive underwriting data (health details, financial history) off-chain; TrustLink attestations here only carry a boolean claim of KYC/AML status, not the underlying documentation.


### PR DESCRIPTION
## Summary

- **#957** — `bindings/typescript` had no retry/backoff or circuit breaker, unlike `sdk/typescript`. Ported `resilience.ts` (retry-with-backoff + `CircuitBreaker`) into `bindings/typescript`, wired it into `simulate()` and each RPC call inside `invoke()` (`getAccount`, `simulateTransaction`, `sendTransaction`, `getTransaction`). An on-chain "ERROR" status is still surfaced immediately rather than retried — only transport-level failures reaching the RPC node are retried.
- **#994** — `.github/CODEOWNERS` only covered `src/`, `sdk/`, and two docs files. Added entries for `bindings/`, `indexer/`, `infra/`, `monitoring/`, `.github/workflows/`, `scripts/`, `fuzz/`, `benches/`, `tests/`, `test_snapshots/`, `examples/`, and a general `docs/` fallback (the existing specific `docs/security*.md` / `docs/compliance.md` rules still win, per "last matching rule wins").
- **#995** — `examples/insurance/README.md` was ~36 lines. Expanded it to match sibling example READMEs: scenario walkthrough, contract pattern, test table, full deployment steps, and production notes.
- **#996** — `.github/ISSUE_TEMPLATE/` had no `config.yml`. Added one with `blank_issues_enabled: false` and contact links for security vulnerability reporting and general questions/discussions.

Closes #957
Closes #994
Closes #995
Closes #996

## Test plan

- [ ] CI (typecheck/build) on `bindings/typescript`
- [ ] Manual review of CODEOWNERS routing
- [ ] Manual review of rendered `examples/insurance/README.md`
- [ ] Verify issue-creation chooser shows the new contact links

(Per task instructions, no new automated tests were added in this PR.)