### PR TITLE
docs: add funding, RFC template, branch-protection docs, and repo triage automation

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,7 @@
+# These are supported funding model platforms
+
+github: [Haroldwonder]
+open_collective: # e.g., trustlink
+patreon: # e.g., trustlink
+tidelift: # e.g., npm/trustlink
+custom: # e.g., ['https://www.paypal.me/trustlink']

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -1,0 +1,27 @@
+name: PR Size Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  size-label:
+    name: Label PR Size
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Apply size label
+        uses: pascalgn/size-label-action@v0.5.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          sizes: >
+            {
+              "0": "size/XS",
+              "10": "size/S",
+              "50": "size/M",
+              "250": "size/L",
+              "1000": "size/XL"
+            }

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,45 @@
+name: Stale Issue Triage
+
+on:
+  schedule:
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  stale:
+    name: Mark and Close Stale Issues
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has
+            had no activity for 60 days. It will be closed in 14 days if no
+            further activity occurs. Remove the `stale` label or comment to
+            keep it open.
+          close-issue-message: >
+            This issue was closed automatically after 14 days of inactivity
+            following the stale warning. Feel free to reopen if it's still
+            relevant.
+          exempt-issue-labels: "high-priority,security,pinned"
+
+          # Pull requests are not auto-closed, only flagged, so reviewers
+          # don't lose in-progress work to inactivity alone.
+          days-before-pr-stale: 30
+          days-before-pr-close: -1
+          stale-pr-label: "stale"
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because
+            it has had no activity for 30 days. Remove the `stale` label or
+            push a commit to keep it open.
+          exempt-pr-labels: "high-priority,security,pinned"
+
+          operations-per-run: 100

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -559,6 +559,17 @@ cargo audit --advisory RUSTSEC-YYYY-NNNNN
 - Test thoroughly after updates
 - Document breaking changes in PR description
 
+## Proposing Significant Changes (RFCs)
+
+For changes large enough to benefit from discussion before any code is
+written — new storage layouts, public contract interface changes, new
+workflows, or anything with backward-compatibility implications — open an
+RFC instead of jumping straight to a PR. See [docs/rfcs/README.md](docs/rfcs/README.md)
+for the process and [docs/rfcs/TEMPLATE.md](docs/rfcs/TEMPLATE.md) for the
+template. RFCs capture pre-implementation discussion; once a proposal is
+accepted and built, it's typically followed by an [ADR](docs/adr/README.md)
+recording the final decision.
+
 ## Reporting Issues
 
 Open a GitHub issue with:

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -1,0 +1,67 @@
+# Branch Protection
+
+This document records the intended branch-protection configuration for
+`main`, the repository's only long-lived branch. It exists so that CI/CD
+and review-process changes can be checked against an agreed-upon policy
+instead of tribal knowledge, and so anyone auditing the repository's
+GitHub settings has something to diff against.
+
+> **Maintainers:** if GitHub's settings ever drift from this document,
+> either update the settings to match or update this document to match —
+> don't let them silently diverge. See [Verifying the Configuration](#verifying-the-configuration).
+
+## Protected Branch
+
+- `main`
+
+## Required Status Checks
+
+Pull requests must pass the following checks before merging, based on the
+workflows defined in [`.github/workflows/`](../.github/workflows):
+
+| Check | Workflow | Why it's required |
+|---|---|---|
+| `Build and Test` | [`ci.yml`](../.github/workflows/ci.yml) (`ci` job) | Compiles the contract, runs the full test suite, and verifies snapshot files are up to date |
+| `Security Audit` | [`ci.yml`](../.github/workflows/ci.yml) (`audit` job) | Runs `cargo audit --deny warnings`; see [`docs/dependency-security.md`](dependency-security.md) |
+| `WASM Size Check` | [`ci.yml`](../.github/workflows/ci.yml) (`wasm-size` job) | Blocks merges that push the optimized WASM binary over the 100 KB threshold |
+| `TypeScript Bindings` | [`ci.yml`](../.github/workflows/ci.yml) (`bindings` job) | Fails if `bindings/typescript/` is out of sync with the contract interface |
+| `Check Conventional Commits` | [`validate-commits.yml`](../.github/workflows/validate-commits.yml) | Enforces the PR title format described in [CONTRIBUTING.md](../CONTRIBUTING.md#commit-message-conventions), which Release Please depends on |
+
+Branches must be up to date with `main` before merging, so these checks run
+against the code that will actually land.
+
+## Review Requirements
+
+- At least **one approving review** is required before merging (see
+  [CONTRIBUTING.md § PR Process](../CONTRIBUTING.md#pr-process)).
+- New commits pushed to a PR dismiss stale approvals — reviewers should
+  re-review after force-pushes.
+- Conversation resolution is required: all review comments must be marked
+  resolved before merging.
+
+## Merge Rules
+
+- **Allowed merge strategies**: "Squash and merge" or "Create a merge
+  commit". "Rebase and merge" is disallowed — it would strip the metadata
+  Release Please uses to generate changelogs.
+- **Force pushes to `main`** are disallowed.
+- **Deletion of `main`** is disallowed.
+- Administrators are expected to follow the same rules as everyone else;
+  the "include administrators" option should be enabled.
+
+## Verifying the Configuration
+
+To confirm GitHub's actual settings match this document, a maintainer with
+repository admin access should check **Settings → Branches → Branch
+protection rules → `main`** and confirm:
+
+1. The required status checks listed above are all enabled and set to
+   "must be up to date before merging".
+2. Required approvals is set to at least `1`.
+3. "Do not allow bypassing the above settings" (include administrators) is
+   enabled.
+4. Force pushes and branch deletion are both disallowed.
+
+If any setting differs, either the GitHub configuration or this document
+should be updated so the two stay in sync — see the note at the top of
+this file.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,0 +1,37 @@
+# Requests for Comments (RFCs)
+
+RFCs are how TrustLink discusses significant changes *before* they are built,
+as opposed to [ADRs](../adr/README.md), which record a decision *after* it
+has been made (or is about to be implemented).
+
+Use an RFC when a change is large enough to benefit from community input
+before code is written — for example: new storage layouts, changes to the
+public contract interface, new attestation workflows, or anything with
+backward-compatibility implications. Small or purely internal changes don't
+need one; open a PR directly.
+
+## Process
+
+1. **Copy the template**: duplicate [TEMPLATE.md](TEMPLATE.md) to
+   `docs/rfcs/NNNN-short-title.md`, where `NNNN` is the next unused number.
+2. **Open a PR** adding the file with status `Draft`. This starts the
+   discussion — reviewers and the community comment inline on the proposal.
+3. **Iterate** based on feedback until the proposal reaches consensus or is
+   withdrawn.
+4. **Resolve** the RFC by merging the PR with its status updated to
+   `Accepted`, `Rejected`, or `Withdrawn`.
+
+## Relationship to ADRs
+
+An RFC and an ADR capture different moments in the same decision:
+
+- The **RFC** is the proposal — written before implementation, open for
+  discussion, and may go through multiple revisions before consensus.
+- The **ADR** is the record — written once the decision is final, capturing
+  what was decided and why, for future readers who won't see the discussion.
+
+An accepted RFC should link to the ADR that formalizes it once implementation
+lands, and the ADR should link back to the RFC that proposed it. Not every
+RFC needs a corresponding ADR (e.g., a rejected or superseded RFC), and not
+every ADR needs a preceding RFC (smaller decisions can go straight to an
+ADR).

--- a/docs/rfcs/TEMPLATE.md
+++ b/docs/rfcs/TEMPLATE.md
@@ -1,0 +1,34 @@
+# RFC NNNN: Title
+
+- **Status**: Draft | Accepted | Rejected | Withdrawn
+- **Author(s)**:
+- **Date**:
+- **Tracking issue**: (optional link to a GitHub issue)
+
+## Summary
+
+One paragraph explaining the proposal.
+
+## Motivation
+
+Why is this change needed? What problem does it solve, and who is affected
+if it isn't solved?
+
+## Proposal
+
+Describe the change in enough detail that a reviewer can evaluate it
+without reading code. Include interface changes, storage layout changes,
+migration considerations, and examples where useful.
+
+## Alternatives Considered
+
+What other approaches were considered, and why were they not chosen?
+
+## Open Questions
+
+List anything still undecided that needs input during discussion.
+
+## Follow-up ADR
+
+Once this RFC is accepted and implemented, link the [ADR](../adr/README.md)
+that records the final decision: `docs/adr/ADR-XXX-title.md`.


### PR DESCRIPTION
## Summary
- Add `.github/FUNDING.yml` disclosing the project's funding/sponsorship setup
- Add a lightweight RFC process (`docs/rfcs/README.md`, `docs/rfcs/TEMPLATE.md`) for pre-implementation proposals, referenced from `CONTRIBUTING.md`, and clarify its relationship to ADRs
- Add `docs/branch-protection.md` documenting the intended required status checks, review requirements, and merge rules for `main`
- Add `.github/workflows/pr-size-labeler.yml` to auto-label PRs by size and `.github/workflows/stale.yml` to triage inactive issues/PRs (exempting `high-priority`, `security`, `pinned`)

Closes #1001
Closes #1002
Closes #1003
Closes #1004

## Test plan
- [x] N/A — documentation and CI workflow additions only, no contract/code changes
- [ ] Maintainer to verify `docs/branch-protection.md` matches the actual configured GitHub branch-protection settings for `main`
